### PR TITLE
Close connection in case if application was not selected

### DIFF
--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/BaseYubikeyFragment.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/BaseYubikeyFragment.kt
@@ -73,13 +73,8 @@ abstract class BaseYubikeyFragment(private val logTag: String) : Fragment() {
         })
 
         getViewModel().sessionUsb.observe(viewLifecycleOwner, Observer {
-            hasConnection = it != null && getViewModel().hasPermission(it)
-            if (hasConnection) {
-                onUsbSession(true)
-            } else {
-                hideAllSnackBars()
-                onUsbSession(false)
-            }
+            hideAllSnackBars()
+            onUsbSession(it != null && getViewModel().hasPermission(it))
         })
 
         getViewModel().sessionNfc.observe(viewLifecycleOwner, Observer {

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/YubikeyViewModel.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/YubikeyViewModel.kt
@@ -76,10 +76,7 @@ open class YubikeyViewModel(private val yubikitManager: YubiKitManager) : ViewMo
                 _sessionUsb.value = session
             }
 
-            // if user has granted permissions we should execute command as button was clicked already
-            if (!hadPermissions && hasPermission) {
-                session.executeDemoCommands()
-            } else if (!hasPermission) {
+            if (!hasPermission) {
                 _error.value = NoPermissionsException(session.usbDevice)
 
             }

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/mgmt/ManagementFragment.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/mgmt/ManagementFragment.kt
@@ -28,6 +28,7 @@ import android.widget.Toast
 import androidx.lifecycle.*
 import com.yubico.yubikit.YubiKitManager
 import com.yubico.yubikit.apdu.ApduCodeException
+import com.yubico.yubikit.apdu.Version
 import com.yubico.yubikit.demo.BaseYubikeyFragment
 import com.yubico.yubikit.demo.R
 import com.yubico.yubikit.demo.YubikeyViewModel
@@ -76,6 +77,10 @@ class ManagementFragment : BaseYubikeyFragment(TAG) {
             }
         })
 
+        viewModel.version.observe(viewLifecycleOwner) {
+            showFirmwareVersion(it)
+        }
+
         viewModel.updated.observe(viewLifecycleOwner, Observer {
             if (it == true) {
                 val config = viewModel.deviceConfiguration.value
@@ -119,6 +124,7 @@ class ManagementFragment : BaseYubikeyFragment(TAG) {
     override fun onStart() {
         super.onStart()
         showInterfaceTable(viewModel.deviceConfiguration.value)
+        showFirmwareVersion(viewModel.version.value)
     }
 
     /**
@@ -148,6 +154,13 @@ class ManagementFragment : BaseYubikeyFragment(TAG) {
                 updateConfig(config)
                 viewModel.saveConfig(config)
             }
+        }
+    }
+
+    private fun showFirmwareVersion(version: Version?) {
+        version?.run {
+            info.visibility = View.VISIBLE
+            info.text = "Firmaware: ${this}"
         }
     }
 

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/raw/YubikeySmartcardFragment.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/raw/YubikeySmartcardFragment.kt
@@ -98,9 +98,7 @@ class YubikeySmartcardFragment : BaseYubikeyFragment(TAG) {
     }
 
     override fun onUsbSession(hasPermissions: Boolean) {
-        if (hasPermissions) {
-            log.text = "discovered yubikey via usb"
-        }
+        log.text = if (hasPermissions) "discovered yubikey via usb" else ""
     }
 
     override fun onNfcSession() {

--- a/management/src/main/java/com/yubico/yubikit/configurator/YubiKeyConfigurationApplication.java
+++ b/management/src/main/java/com/yubico/yubikit/configurator/YubiKeyConfigurationApplication.java
@@ -93,6 +93,10 @@ public class YubiKeyConfigurationApplication implements Closeable {
                 } else {
                     throw e;
                 }
+            } finally {
+                if (status == null) {
+                    close();
+                }
             }
         }
     }

--- a/management/src/main/java/com/yubico/yubikit/management/ManagementApplication.java
+++ b/management/src/main/java/com/yubico/yubikit/management/ManagementApplication.java
@@ -97,6 +97,10 @@ public class ManagementApplication extends Iso7816Application {
             } else {
                 throw e;
             }
+        } finally {
+            if (version == null) {
+                close();
+            }
         }
     }
 

--- a/oath/src/main/java/com/yubico/yubikit/oath/OathApplication.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/OathApplication.java
@@ -121,6 +121,10 @@ public class OathApplication  extends Iso7816Application {
             } else {
                 throw e;
             }
+        } finally {
+            if (applicationInfo == null) {
+                close();
+            }
         }
     }
 

--- a/piv/src/main/java/com/yubico/yubikit/piv/PivApplication.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/PivApplication.java
@@ -134,17 +134,21 @@ public class PivApplication extends Iso7816Application {
 
         try {
             sendAndReceive(new Apdu(0, INS_SELECT, 0x04, 0, AID));
+
+            byte[] versionResponse = sendAndReceive(new Apdu(0, INS_GET_VERSION, 0, 0, null));
+            // get firmware version
+            version = Version.parse(versionResponse);
         } catch (ApduCodeException e) {
             if (e.getStatusCode() == APPLICATION_NOT_FOUND_ERROR) {
                 throw new ApplicationNotFound("PIV application is disabled on this device");
             } else {
                 throw e;
             }
+        } finally {
+            if (version == null) {
+                close();
+            }
         }
-        byte[] versionResponse = sendAndReceive(new Apdu(0, INS_GET_VERSION, 0, 0, null));
-
-        // get firmware version
-        version = Version.parse(versionResponse);
     }
 
     /**


### PR DESCRIPTION
Since we create connection and selecting YubiKey applet in constructor of application (to avoid user calling extra select() method). We need to close connection if selection failed. So that user can reuse connection for another applet.
Also small improvements on demo: 
- show firmware version of the key in YubiKey Settings (managements applet) for NEO keys.
- hide snackbars if detected usb communication unless we get error that permissions are required
- clean up raw communication log when YubiKey was ejected