### PR TITLE
Provide extensible approach to configure NFC and USB discovery

### DIFF
--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/BaseYubikeyFragment.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/BaseYubikeyFragment.kt
@@ -74,7 +74,7 @@ abstract class BaseYubikeyFragment(private val logTag: String) : Fragment() {
 
         getViewModel().sessionUsb.observe(viewLifecycleOwner, Observer {
             hideAllSnackBars()
-            onUsbSession(it != null && getViewModel().hasPermission(it))
+            onUsbSession(getViewModel().hasConnection)
         })
 
         getViewModel().sessionNfc.observe(viewLifecycleOwner, Observer {
@@ -86,11 +86,10 @@ abstract class BaseYubikeyFragment(private val logTag: String) : Fragment() {
 
     override fun onStart() {
         super.onStart()
-        val currentUsbSession = getViewModel().sessionUsb.value
-        if (currentUsbSession!= null && getViewModel().hasPermission(currentUsbSession)) {
+        if (getViewModel().hasConnection) {
             onUsbSession(true)
         } else {
-            showSnackBar(SnackBarType.PERMISSIONS, currentUsbSession != null)
+            showSnackBar(SnackBarType.PERMISSIONS, getViewModel().sessionUsb.value != null)
         }
     }
 

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/YubikeyViewModel.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/YubikeyViewModel.kt
@@ -80,7 +80,6 @@ open class YubikeyViewModel(private val yubikitManager: YubiKitManager) : ViewMo
 
             if (!hasPermission) {
                 _error.value = NoPermissionsException(session.usbDevice)
-
             }
         }
 
@@ -90,6 +89,10 @@ open class YubikeyViewModel(private val yubikitManager: YubiKitManager) : ViewMo
             if (session ==_sessionUsb.value) {
                 _sessionUsb.value = if(sessions.isEmpty()) null else sessions.keys.last()
             }
+        }
+
+        override fun onRequestPermissionsResult(session: UsbSession, isGranted: Boolean) {
+            onSessionReceived(session, isGranted)
         }
     }
 

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/YubikeyViewModel.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/YubikeyViewModel.kt
@@ -24,12 +24,15 @@ import com.yubico.yubikit.YubiKitManager
 import com.yubico.yubikit.demo.fido.arch.ErrorLiveEvent
 import com.yubico.yubikit.demo.fido.arch.SingleLiveEvent
 import com.yubico.yubikit.demo.raw.UsbDeviceNotFoundException
+import com.yubico.yubikit.demo.settings.Ramps
 import com.yubico.yubikit.exceptions.NfcDisabledException
 import com.yubico.yubikit.exceptions.NfcNotFoundException
 import com.yubico.yubikit.exceptions.NoPermissionsException
 import com.yubico.yubikit.transport.YubiKeySession
+import com.yubico.yubikit.transport.nfc.NfcConfiguration
 import com.yubico.yubikit.transport.nfc.NfcSession
 import com.yubico.yubikit.transport.nfc.NfcSessionListener
+import com.yubico.yubikit.transport.usb.UsbConfiguration
 import com.yubico.yubikit.transport.usb.UsbSession
 import com.yubico.yubikit.transport.usb.UsbSessionListener
 import com.yubico.yubikit.utils.ILogger
@@ -47,24 +50,23 @@ open class YubikeyViewModel(private val yubikitManager: YubiKitManager) : ViewMo
      * Keeps active iso7816 session/connection that will be used to send/receive bytes on button click
      */
     private val _sessionUsb = SingleLiveEvent<UsbSession>()
-    val sessionUsb : LiveData<UsbSession> = _sessionUsb
+    val sessionUsb: LiveData<UsbSession> = _sessionUsb
 
     private val _sessionNfc = SingleLiveEvent<NfcSession>()
-    val sessionNfc : LiveData<NfcSession> = _sessionNfc
+    val sessionNfc: LiveData<NfcSession> = _sessionNfc
 
     private val _error = ErrorLiveEvent(TAG)
     protected fun postError(e: Throwable) {
         _error.postValue(e)
     }
 
-    val error : LiveData<Throwable> = _error
+    val error: LiveData<Throwable> = _error
 
     /**
      * Listeners for yubikey discovery (over USB and NFC)
      */
     private val usbListener = object: UsbSessionListener {
         override fun onSessionReceived(session: UsbSession, hasPermission: Boolean) {
-            val hadPermissions = sessions[session] != false
             sessions[session] = hasPermission
 
             if (hasPermission) {
@@ -101,7 +103,7 @@ open class YubikeyViewModel(private val yubikitManager: YubiKitManager) : ViewMo
      * Start usb discovery as soon as we create model
      */
     init {
-        yubikitManager.startUsbDiscovery(true, usbListener)
+        yubikitManager.startUsbDiscovery(UsbConfiguration(), usbListener)
 
         Logger.getInstance().setLogger(object : ILogger {
             override fun logDebug(message: String?) {
@@ -127,7 +129,11 @@ open class YubikeyViewModel(private val yubikitManager: YubiKitManager) : ViewMo
      */
     fun startNfcDiscovery(activity: Activity) {
         try {
-            yubikitManager.startNfcDiscovery(false, activity, nfcListener)
+            yubikitManager.startNfcDiscovery(
+                    NfcConfiguration()
+                        .setSkipNdefCheck(true)
+                        .setDisableNfcDiscoverySound(Ramps.OATH_NFC_SOUND.getValue(activity) == false),
+                    activity, nfcListener)
         } catch (e: NfcDisabledException) {
             _error.value = e
         } catch (e: NfcNotFoundException) {
@@ -143,11 +149,16 @@ open class YubikeyViewModel(private val yubikitManager: YubiKitManager) : ViewMo
     }
 
     /**
-     * Check if user granted permissions to connect to device
+     * Checks if there is usb connection and user granted permissions to connect to device
      */
-    fun hasPermission(session: UsbSession) : Boolean {
-        return sessions[session] == true
-    }
+    val hasConnection: Boolean
+        get() {
+            sessionUsb.value?.run {
+                return sessions[this] == true
+            } ?: run {
+                return false
+            }
+        }
 
 
     /**
@@ -156,9 +167,10 @@ open class YubikeyViewModel(private val yubikitManager: YubiKitManager) : ViewMo
     fun executeDemoCommands(session: UsbSession? = _sessionUsb.value) {
         when {
             // if user didn't accept permissions let's prompt him again
-            sessions[session] == false -> yubikitManager.startUsbDiscovery(true, usbListener)
+            sessions[session] == false -> yubikitManager.startUsbDiscovery(UsbConfiguration(), usbListener)
             session != null -> session.executeDemoCommands()
-            else -> _error.value = UsbDeviceNotFoundException("The key is not plugged in")
+            else -> _error.value =
+                    UsbDeviceNotFoundException("The key is not plugged in")
         }
     }
 

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/oath/CredentialListAdapter.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/oath/CredentialListAdapter.kt
@@ -33,6 +33,7 @@ import com.yubico.yubikit.oath.Credential
 import com.yubico.yubikit.oath.OathType
 import kotlinx.android.synthetic.main.oath_item_authenticator_list.view.*
 import java.util.*
+import kotlin.math.abs
 
 private const val MILLS_IN_SECOND = 1000.toLong()
 class CredentialListAdapter(
@@ -122,7 +123,7 @@ class CredentialListAdapter(
             var intCode = Integer.parseInt(code.value)
             return StringBuilder().apply {
                 for (i in 0..4) {
-                    append(STEAM_CHARS[intCode % STEAM_CHARS.length])
+                    append(STEAM_CHARS[abs(intCode % STEAM_CHARS.length)])
                     intCode /= STEAM_CHARS.length
                 }
 

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/settings/Ramps.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/settings/Ramps.kt
@@ -25,6 +25,7 @@ class Ramps {
         val USE_CUSTOM_TABS = Ramps.Ramp("customtabs", true)
         val OATH_USE_TOUCH = Ramps.Ramp("use_touch", false)
         val OATH_TRUNCATE = Ramps.Ramp("truncate_totp", true)
+        val OATH_NFC_SOUND = Ramps.Ramp("nfc_sound", true)
         val PIV_NUM_RETRIES = Ramps.Ramp("pin_retries", 10)
         val PIV_USE_DEFAULT_MGMT = Ramps.Ramp("mgmt_key", true)
     }

--- a/YubikitDemo/src/main/res/xml/settings.xml
+++ b/YubikitDemo/src/main/res/xml/settings.xml
@@ -50,6 +50,12 @@
             android:title="Truncate TOTP"
             android:summary="When it's off generated result won't be truncated to digits number and full Integer value will be provided. Used when creating new oath credentials from QR code. May be used for authenticators that accept TOTP in non-standard form" />
 
+        <SwitchPreferenceCompat
+            android:key="nfc_sound"
+            app:defaultValue="true"
+            android:title="Tag discovery sound"
+            android:summary="When it's off tag reading will to be silent - no sound and vibration"/>
+
         <EditTextPreference
             android:inputType="numberDecimal"
             android:digits="0123456789"

--- a/fido/build.gradle
+++ b/fido/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.compileSdkVersion
+    testOptions.unitTests.includeAndroidResources = true
 
     defaultConfig {
         minSdkVersion project.minFidoSdkVersion
@@ -29,8 +30,8 @@ dependencies {
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation "org.robolectric:robolectric:4.2"
     testImplementation "org.mockito:mockito-core:2.11.0"
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
 apply from: rootProject.file('release.gradle')

--- a/fido/src/test/java/com/yubico/yubikit/utils/PackageUtilsTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/utils/PackageUtilsTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowPackageManager;
 
 import java.util.List;
@@ -35,6 +36,7 @@ public class PackageUtilsTest {
 
     }
     @Test
+    @Config(sdk = 27)
     public void getCertSHA256() {
         shadowPackageManager.installPackage(
                 newPackageInfo(TEST_PACKAGE_NAME, new Signature("00000000"), new Signature("FFFFFFFF")));

--- a/fidodemo/src/test/java/com/yubico/yubikit/demo/fido/Fido2ViewModelTest.kt
+++ b/fidodemo/src/test/java/com/yubico/yubikit/demo/fido/Fido2ViewModelTest.kt
@@ -32,7 +32,7 @@ import org.mockito.*
 
 @RunWith(AndroidJUnit4::class)
 //@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
+//@Config(manifest = Config.NONE)
 class Fido2ViewModelTest {
 
     private val fidoApi = Fido2ClientApi(ApplicationProvider.getApplicationContext<Context>())

--- a/oath/build.gradle
+++ b/oath/build.gradle
@@ -39,8 +39,8 @@ dependencies {
     testImplementation 'androidx.test.ext:junit:1.1.1'
     testImplementation "org.robolectric:robolectric:4.2"
 
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
 apply from: rootProject.file('release.gradle')

--- a/oath/src/main/java/com/yubico/yubikit/oath/Code.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/Code.java
@@ -44,7 +44,7 @@ public class Code {
      * @param validFrom timestamp that was used to generate code
      * @param validUntil timestamp when one-time password becomes invalid/expired
      */
-    Code(@NonNull String value, long validFrom, long validUntil) {
+    public Code(@NonNull String value, long validFrom, long validUntil) {
         this.value = value;
         this.validFrom = validFrom;
         this.validUntil = validUntil;

--- a/oath/src/main/java/com/yubico/yubikit/oath/Credential.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/Credential.java
@@ -19,6 +19,8 @@ import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Pair;
 
+import androidx.annotation.Nullable;
+
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Base32;
 import org.apache.commons.codec.binary.Hex;
@@ -36,7 +38,7 @@ public class Credential implements Serializable {
      */
     public final String name;
     private final int period;
-    private final String issuer;
+    private final @Nullable String issuer;
     private final OathType oathType;
 
     /**
@@ -202,7 +204,7 @@ public class Credential implements Serializable {
             issuer = nameAndIssuer.second;
         } else {
             name = data;
-            issuer = "";
+            issuer = null;
         }
 
         if (codeValue != null && codeValue.length > 0) {
@@ -245,7 +247,7 @@ public class Credential implements Serializable {
             longName += String.format(Locale.ROOT,"%d/", period);
         }
 
-        if (!TextUtils.isEmpty(issuer)) {
+        if (issuer != null) {
             longName += String.format(Locale.ROOT,"%s:", issuer);
         }
         longName += name;

--- a/oath/src/main/java/com/yubico/yubikit/oath/Credential.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/Credential.java
@@ -88,6 +88,11 @@ public class Credential implements Serializable {
     private static final String NOT_TRUNCATED_CODE_PREFIX = "full_";
 
     /**
+     * Default period for all TOTP codes
+     */
+    public static final int DEFAULT_PERIOD = 30;
+
+    /**
      * Parse credential properties from uri
      * @param uri Uri that received from QR reader or manually from server that requires TOTP/HOTP
      * Format example: otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example
@@ -135,7 +140,7 @@ public class Credential implements Serializable {
             throw new ParseUriException("Digits must be in range 6-8");
         }
 
-        Integer period = parseInt(uri.getQueryParameter("period"), 30);
+        Integer period = parseInt(uri.getQueryParameter("period"), DEFAULT_PERIOD);
         if (period == null) {
             throw new ParseUriException("Invalid value for period");
         }
@@ -191,11 +196,15 @@ public class Credential implements Serializable {
 
         if (data.contains("/")) {
             String[] parts = data.split("/",  2);
-            data = parts[1];
-            Integer periodInt = parseInt(parts[0], 30);
-            period = periodInt != null ? periodInt : 30;
+            Integer periodInt = parseInt(parts[0], DEFAULT_PERIOD);
+            if (periodInt != null) {
+                data = parts[1];
+                period = periodInt;
+            } else {
+                period = DEFAULT_PERIOD;
+            }
         } else {
-            period = 30;
+            period = DEFAULT_PERIOD;
         }
 
         if (data.contains(":")) {
@@ -243,7 +252,7 @@ public class Credential implements Serializable {
      */
     public String getId() {
         String longName = "";
-        if (oathType == OathType.TOTP && period != 30) {
+        if (oathType == OathType.TOTP && period != DEFAULT_PERIOD) {
             longName += String.format(Locale.ROOT,"%d/", period);
         }
 

--- a/oath/src/main/java/com/yubico/yubikit/oath/OathApplication.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/OathApplication.java
@@ -101,7 +101,7 @@ public class OathApplication  extends Iso7816Application {
     /**
      * Version, ID and a challenge if authentication is configured
      */
-    private OathApplicationInfo applicationInfo;
+    private final OathApplicationInfo applicationInfo;
 
 
     /**
@@ -116,15 +116,15 @@ public class OathApplication  extends Iso7816Application {
         try {
             applicationInfo = new OathApplicationInfo(sendAndReceive(new Apdu(0, INS_SELECT, 0x04, 0, AID)));
         } catch (ApduCodeException e) {
+            close();
             if (e.getStatusCode() == APPLICATION_NOT_FOUND_ERROR) {
                 throw new ApplicationNotFound("OATH application is disabled on this device");
             } else {
                 throw e;
             }
-        } finally {
-            if (applicationInfo == null) {
-                close();
-            }
+        } catch (IOException e){
+            close();
+            throw e;
         }
     }
 

--- a/oath/src/main/java/com/yubico/yubikit/oath/OathApplicationInfo.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/OathApplicationInfo.java
@@ -82,9 +82,10 @@ public class OathApplicationInfo {
 
     /**
      * @return device id hash string
+     * @param deviceId pass device id received from YubiKit when selected OATH applet
      * @throws NoSuchAlgorithmException if SHA256 is not found
      */
-    public String getDeviceIdString() throws NoSuchAlgorithmException {
+    public static String getDeviceIdString(byte[] deviceId) throws NoSuchAlgorithmException {
         MessageDigest messageDigest = null;
         messageDigest = MessageDigest.getInstance("SHA256");
         messageDigest.update(deviceId);

--- a/oath/src/test/java/com/yubico/yubikit/oath/CredentialDataTest.java
+++ b/oath/src/test/java/com/yubico/yubikit/oath/CredentialDataTest.java
@@ -24,6 +24,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.nio.charset.StandardCharsets;
+
 @RunWith(AndroidJUnit4.class)
 public class CredentialDataTest {
 
@@ -50,6 +52,36 @@ public class CredentialDataTest {
         Assert.assertEquals(usingSeparator.getIssuer(), "Issuer");
         Credential usingBoth = Credential.parseUri(Uri.parse("otpauth://totp/IssuerA:account?secret=abba&issuer=IssuerB"));
         Assert.assertEquals(usingBoth.getIssuer(), "IssuerA");
+    }
+
+    @Test
+    public void testParseData() throws ParseUriException {
+        int tagName = 0x71;
+        final String issuer = "issuer";
+        String accountId = "20/issuer:account";
+        Credential credential = new Credential(accountId.getBytes(StandardCharsets.UTF_8), tagName, null, 0);
+        Assert.assertEquals(issuer, credential.getIssuer());
+        Assert.assertEquals(20, credential.getPeriod());
+
+        String accountWithSlash = "this/account";
+        credential = new Credential(accountWithSlash.getBytes(StandardCharsets.UTF_8), tagName, null, 0);
+        Assert.assertNull(credential.getIssuer());
+        Assert.assertEquals(accountWithSlash, credential.name);
+
+        String accountWithSlashAndIssuer = "issuer:this/account";
+        credential = new Credential(accountWithSlashAndIssuer.getBytes(StandardCharsets.UTF_8), tagName, null, 0);
+        Assert.assertEquals(issuer, credential.getIssuer());
+        Assert.assertEquals(accountWithSlash, credential.name);
+
+        String issuerAndAccountWithSlash = "this/issuer:this/account";
+        credential = new Credential(issuerAndAccountWithSlash.getBytes(StandardCharsets.UTF_8), tagName, null, 0);
+        Assert.assertEquals("this/issuer", credential.getIssuer());
+        Assert.assertEquals(accountWithSlash, credential.name);
+
+        String accountWithSlashAndColon = "issuer:this:account";
+        credential = new Credential(accountWithSlashAndColon.getBytes(StandardCharsets.UTF_8), tagName, null, 0);
+        Assert.assertEquals(issuer, credential.getIssuer());
+        Assert.assertEquals("this:account", credential.name);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/otp/src/main/java/com/yubico/yubikit/otp/OtpActivity.java
+++ b/otp/src/main/java/com/yubico/yubikit/otp/OtpActivity.java
@@ -91,6 +91,11 @@ public class OtpActivity extends AppCompatActivity {
                     }
                 }
             }
+
+            @Override
+            public void onRequestPermissionsResult(@NonNull UsbSession session, boolean isGranted) {
+                // We don't need permissions to handle YubiOTP
+            }
         });
     }
 

--- a/otp/src/main/java/com/yubico/yubikit/otp/OtpActivity.java
+++ b/otp/src/main/java/com/yubico/yubikit/otp/OtpActivity.java
@@ -33,9 +33,11 @@ import com.google.android.material.snackbar.Snackbar;
 import com.yubico.yubikit.YubiKitManager;
 import com.yubico.yubikit.exceptions.NfcDisabledException;
 import com.yubico.yubikit.exceptions.NfcNotFoundException;
+import com.yubico.yubikit.transport.nfc.NfcConfiguration;
 import com.yubico.yubikit.transport.nfc.NfcDeviceManager;
 import com.yubico.yubikit.transport.nfc.NfcSession;
 import com.yubico.yubikit.transport.nfc.NfcSessionListener;
+import com.yubico.yubikit.transport.usb.UsbConfiguration;
 import com.yubico.yubikit.transport.usb.UsbSession;
 import com.yubico.yubikit.transport.usb.UsbSessionListener;
 
@@ -71,7 +73,7 @@ public class OtpActivity extends AppCompatActivity {
         }));
 
         manager = new YubiKitManager(this);
-        manager.startUsbDiscovery(false, new UsbSessionListener() {
+        manager.startUsbDiscovery(new UsbConfiguration().setHandlePermissions(false), new UsbSessionListener() {
             @Override
             public void onSessionReceived(@NonNull UsbSession session, boolean hasPermission) {
                 usbSessionCounter++;
@@ -96,7 +98,7 @@ public class OtpActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         try {
-            manager.startNfcDiscovery(true, this, new NfcSessionListener() {
+            manager.startNfcDiscovery(new NfcConfiguration(), this, new NfcSessionListener() {
                 @Override
                 public void onSessionReceived(@NonNull NfcSession session) {
                     try {

--- a/yubikit/README.md
+++ b/yubikit/README.md
@@ -46,8 +46,8 @@ yubikitVersion=1.0.0-beta04
         }
 
         @Override
-        public void onError(@NonNull UsbSession session, @NonNull Throwable error) {
-            // user didn't grant permissions to specific yubikey
+        public void onRequestPermissionsResult(@NonNull UsbSession session, Boolean isGranted) {
+            // whether user granted permissions to specific yubikey
         }
     }
 ```
@@ -62,7 +62,7 @@ for NFC session discoveries
 ```
 -3. Start discovery for key over USB or NFC. Note: discovery over NFC requires `Activity` that is in foreground (we recommend starting discovery over NFC in `onResume()`). Discovery over USB does not require Activity.
 ```java
-    yubiKitManager.startUsbDiscovery(true, new UsbListener());
+    yubiKitManager.startUsbDiscovery(UsbConfiguration(), new UsbListener());
 ```
 and/or
 ```java
@@ -70,7 +70,7 @@ and/or
     public void onResume() {
         super.onResume()
         try {
-            yubiKitManager.startNfcDiscovery(false, activity, new NfcListener);
+            yubiKitManager.startNfcDiscovery(NfcConfiguration(), activity, new NfcListener);
         } catch (NfcDisabledException e) {
             // show Snackbar message that user needs to turn on NFC for this feature
         } catch (NfcNotFoundException e) {
@@ -110,7 +110,7 @@ and/or
 ```
 Discovery over USB can be kept as long as `YubiKitManager` instance is alive (we recommend stopping discovery over USB before yubiKitManager is destroyed).
 ```java
-    yubiKitManager.stopUsbDiscovery(activity)
+    yubiKitManager.stopUsbDiscovery()
 ```
 -6. Optional. Turn on verbose logging from **YubiKit** for debugging purposes:
 ```java

--- a/yubikit/build.gradle
+++ b/yubikit/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion project.compileSdkVersion
-
+    testOptions.unitTests.includeAndroidResources = true
     defaultConfig {
         minSdkVersion project.minSdkVersion
         targetSdkVersion project.targetSdkVersion
@@ -32,8 +32,8 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.2"
     testImplementation "org.mockito:mockito-core:2.11.0"
 
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
 
 apply from: rootProject.file('release.gradle')

--- a/yubikit/src/main/java/com/yubico/yubikit/YubiKitManager.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/YubiKitManager.java
@@ -165,5 +165,17 @@ public final class YubiKitManager {
                 }
             });
         }
+
+        @Override
+        public void onRequestPermissionsResult(@NonNull final UsbSession session, final boolean isGranted) {
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    if (usbListener != null) {
+                        usbListener.onRequestPermissionsResult(session, isGranted);
+                    }
+                }
+            });
+        }
     }
 }

--- a/yubikit/src/main/java/com/yubico/yubikit/YubiKitManager.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/YubiKitManager.java
@@ -23,9 +23,11 @@ import android.os.Looper;
 
 import com.yubico.yubikit.exceptions.NfcDisabledException;
 import com.yubico.yubikit.exceptions.NfcNotFoundException;
+import com.yubico.yubikit.transport.nfc.NfcConfiguration;
 import com.yubico.yubikit.transport.nfc.NfcDeviceManager;
 import com.yubico.yubikit.transport.nfc.NfcSession;
 import com.yubico.yubikit.transport.nfc.NfcSessionListener;
+import com.yubico.yubikit.transport.usb.UsbConfiguration;
 import com.yubico.yubikit.transport.usb.UsbDeviceManager;
 import com.yubico.yubikit.transport.usb.UsbSession;
 import com.yubico.yubikit.transport.usb.UsbSessionListener;
@@ -76,15 +78,14 @@ public final class YubiKitManager {
      * Subscribe on changes that happen via USB and detect if there any Yubikeys got connected
      *
      * This registers broadcast receivers, to unsubscribe from receiver use {@link YubiKitManager#stopUsbDiscovery()}
-     * @param handlePermissions true to show dialog for permissions or nfc enabling setting,
-     *                          otherwise it will return error in callback if no permissions/setting
+     * @param usbConfiguration additional configurations on how USB discovery should be handled
      * @param listener  listener that is going to be invoked upon successful discovery of key session
      *                  or failure to detect any session (lack of permissions)
      */
-    public void startUsbDiscovery(boolean handlePermissions, @NonNull UsbSessionListener listener) {
+    public void startUsbDiscovery(final UsbConfiguration usbConfiguration, @NonNull UsbSessionListener listener) {
         usbListener = listener;
         usbDeviceManager.setListener(new UsbInternalListener());
-        usbDeviceManager.enable(handlePermissions);
+        usbDeviceManager.enable(usbConfiguration);
     }
 
     /**
@@ -92,19 +93,18 @@ public final class YubiKitManager {
      *
      * This registers broadcast receivers and blocks Ndef tags to be passed to activity,
      * to unsubscribe use {@link YubiKitManager#stopNfcDiscovery(Activity)}
-     * @param handleUnavailableNfc true to show dialog for permissions or nfc enabling setting,
-     *                          otherwise it will return error in callback if no permissions/setting
+     * @param nfcConfiguration additional configurations on how NFC discovery should be handled
      * @param listener  listener that is going to be invoked upon successful discovery of key session
      *                  or failure to detect any session (setting if off or no nfc adapter on device)
      * @param activity active (not finished) activity required for nfc foreground dispatch
      * @throws NfcDisabledException in case if NFC not activated
      * @throws NfcNotFoundException in case if NFC not available on android device
      */
-    public void startNfcDiscovery(boolean handleUnavailableNfc, @NonNull Activity activity, @NonNull NfcSessionListener listener)
+    public void startNfcDiscovery(final NfcConfiguration nfcConfiguration, @NonNull Activity activity, @NonNull NfcSessionListener listener)
             throws NfcDisabledException, NfcNotFoundException {
         nfcListener = listener;
         nfcDeviceManager.setListener(new NfcInternalListener());
-        nfcDeviceManager.enable(activity, handleUnavailableNfc);
+        nfcDeviceManager.enable(activity, nfcConfiguration);
     }
 
     /**

--- a/yubikit/src/main/java/com/yubico/yubikit/transport/nfc/NfcConfiguration.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/transport/nfc/NfcConfiguration.java
@@ -1,0 +1,65 @@
+package com.yubico.yubikit.transport.nfc;
+
+/**
+ * Additional configurations for NFC discovery
+ */
+public class NfcConfiguration {
+
+    // system sound that emitted when tag is discovered
+    private boolean disableNfcDiscoverySound = false;
+
+    // skip ndef check for discovered tag
+    private boolean skipNdefCheck = false;
+
+    // show settings dialog in case if NFC setting is not enabled
+    private boolean handleUnavailableNfc = false;
+
+
+    boolean isDisableNfcDiscoverySound() {
+        return disableNfcDiscoverySound;
+    }
+
+    boolean isSkipNdefCheck() {
+        return skipNdefCheck;
+    }
+
+    boolean isHandleUnavailableNfc() {
+        return handleUnavailableNfc;
+    }
+
+    /**
+     * Setting this flag allows the caller to prevent the
+     * platform from playing sounds when it discovers a tag.
+     * @param disableNfcDiscoverySound new value of this property
+     * @return configuration object
+     */
+    public NfcConfiguration setDisableNfcDiscoverySound(boolean disableNfcDiscoverySound) {
+        this.disableNfcDiscoverySound = disableNfcDiscoverySound;
+        return this;
+    }
+
+    /**
+     * Setting this flag allows the caller to prevent the
+     * platform from performing an NDEF check on the tags it
+     * @param skipNdefCheck new value of this property
+     * @return configuration object
+     */
+    public NfcConfiguration setSkipNdefCheck(boolean skipNdefCheck) {
+        this.skipNdefCheck = skipNdefCheck;
+        return this;
+    }
+
+    /**
+     * Set it to true to shows view with settings nfc setting if NFC is disabled,
+     * otherwise start of NFC session will return error in callback if no permissions/setting
+     * and allows user to handle disabled NFC reader (show error or snackbar or refer to settings)
+     * Default value is false
+     * @param handleUnavailableNfc new value of this property
+     * @return configuration object
+     */
+    public NfcConfiguration setHandleUnavailableNfc(boolean handleUnavailableNfc) {
+        this.handleUnavailableNfc = handleUnavailableNfc;
+        return this;
+    }
+
+}

--- a/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbConfiguration.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbConfiguration.java
@@ -1,0 +1,26 @@
+package com.yubico.yubikit.transport.usb;
+
+/**
+ * Additional configurations for USB discovery management
+ */
+public class UsbConfiguration {
+
+    // whether to prompt permissions when application needs them
+    private boolean handlePermissions = true;
+
+    boolean isHandlePermissions() {
+        return handlePermissions;
+    }
+
+    /**
+     * Set YubiKitManager to show dialog for permissions on USB connection
+     * @param handlePermissions true to show dialog for permissions
+     *                          otherwise it's delegated on user to make sure that application
+     *                          has permissions to communicate with device
+     */
+    public UsbConfiguration setHandlePermissions(boolean handlePermissions) {
+        this.handlePermissions = handlePermissions;
+        return this;
+    }
+
+}

--- a/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbConfiguration.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbConfiguration.java
@@ -8,8 +8,15 @@ public class UsbConfiguration {
     // whether to prompt permissions when application needs them
     private boolean handlePermissions = true;
 
+    // whether manager should discover only devices with Yubico as vendor
+    private boolean filterYubicoDevices = true;
+
     boolean isHandlePermissions() {
         return handlePermissions;
+    }
+
+    boolean isFilterYubicoDevices() {
+        return filterYubicoDevices;
     }
 
     /**
@@ -23,4 +30,7 @@ public class UsbConfiguration {
         return this;
     }
 
+    public void setFilterYubicoDevices(boolean filterYubicoDevices) {
+        this.filterYubicoDevices = filterYubicoDevices;
+    }
 }

--- a/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbDeviceManager.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbDeviceManager.java
@@ -24,8 +24,6 @@ import android.content.IntentFilter;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
 
-import com.yubico.yubikit.exceptions.NoPermissionsException;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -42,7 +40,7 @@ public class UsbDeviceManager {
     private final UsbManager usbManager;
     private boolean isPermissionRequired = false;
     private UsbBroadcastReceiver receiver;
-
+    private UsbConfiguration configuration = null;
 
     private transient UsbSessionListener listener = null;
 
@@ -69,6 +67,7 @@ public class UsbDeviceManager {
      */
     public void enable(final UsbConfiguration usbConfiguration) {
         disable();
+        configuration = usbConfiguration;
         isPermissionRequired = usbConfiguration.isHandlePermissions();
 
         receiver = new UsbBroadcastReceiver();
@@ -100,7 +99,7 @@ public class UsbDeviceManager {
     private List<UsbDevice> findDevices() {
         List<UsbDevice> yubikeys = new ArrayList<>();
         for (UsbDevice device : usbManager.getDeviceList().values()) {
-            if (device.getVendorId() == YUBICO_VENDOR_ID) {
+            if (!configuration.isFilterYubicoDevices() || device.getVendorId() == YUBICO_VENDOR_ID) {
                 yubikeys.add(device);
             }
         }
@@ -163,7 +162,7 @@ public class UsbDeviceManager {
                     return;
                 }
 
-                listener.onSessionReceived(new UsbSession(usbManager, device), usbManager.hasPermission(device));
+                listener.onRequestPermissionsResult(new UsbSession(usbManager, device), usbManager.hasPermission(device));
             }
         }
     }

--- a/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbDeviceManager.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbDeviceManager.java
@@ -65,11 +65,11 @@ public class UsbDeviceManager {
 
     /**
      * Registers receiver on usb connection event
-     * @param requirePermission if true also registers receiver on permissions grant from user
+     * @param usbConfiguration contains information if device manager also registers receiver on permissions grant from user
      */
-    public void enable(final boolean requirePermission) {
+    public void enable(final UsbConfiguration usbConfiguration) {
         disable();
-        isPermissionRequired = requirePermission;
+        isPermissionRequired = usbConfiguration.isHandlePermissions();
 
         receiver = new UsbBroadcastReceiver();
         IntentFilter intentFilter = new IntentFilter(UsbManager.ACTION_USB_DEVICE_ATTACHED);

--- a/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbIso7816Connection.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbIso7816Connection.java
@@ -182,7 +182,7 @@ public class UsbIso7816Connection implements Iso7816Connection {
                     // 4. parse received data and make sure it's proper format
                     messageHeader = new MessageHeader(bufferRead);
                     responseRequiresTimeExtension = (messageHeader.status & STATUS_TIME_EXTENSION) == STATUS_TIME_EXTENSION;
-                    if (messageHeader.verify(sequence - 1)) {
+                    if (messageHeader.verify((byte) (sequence - 1))) {
                         // if we received expected prefix we can save the rest of received data without verification
                         receivedExpectedPrefix = true;
                         stream.write(bufferRead, 0, bytesRead);
@@ -269,7 +269,7 @@ public class UsbIso7816Connection implements Iso7816Connection {
          * @param sequence Bulk-OUT message sequence
          * @return true if prefix has expected format
          */
-        private boolean verify(int sequence) {
+        private boolean verify(byte sequence) {
             if (this.type != RESPONSE_DATA_BLOCK) {
                 return false;
             }

--- a/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbSessionListener.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbSessionListener.java
@@ -21,4 +21,5 @@ import androidx.annotation.NonNull;
 public interface UsbSessionListener {
     void onSessionReceived(@NonNull final UsbSession session, boolean hasPermission);
     void onSessionRemoved(@NonNull final UsbSession session);
+    void onRequestPermissionsResult(@NonNull final UsbSession session, boolean isGranted);
 }

--- a/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbSessionListener.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/transport/usb/UsbSessionListener.java
@@ -19,7 +19,24 @@ package com.yubico.yubikit.transport.usb;
 import androidx.annotation.NonNull;
 
 public interface UsbSessionListener {
+    /**
+     * Invoked when detected inserted device after usb discovery started
+     * @param session usb session that associated with plugged in device
+     * @param hasPermission true if device has required permissions granted by user
+     */
     void onSessionReceived(@NonNull final UsbSession session, boolean hasPermission);
+
+    /**
+     * Invoked when detected removal/ejection of usb device after usb discovery started
+     * @param session usb session that will become inactive
+     */
     void onSessionRemoved(@NonNull final UsbSession session);
+
+    /**
+     * If discovery was started with handling permissions than user will be prompted with UI
+     * dialog to ask for necessary permissions to communicate with device
+     * @param session usb session for which user had permissions prompt
+     * @param isGranted true if user selected to grant permissions, otherwise false
+     */
     void onRequestPermissionsResult(@NonNull final UsbSession session, boolean isGranted);
 }

--- a/yubikit/src/main/java/com/yubico/yubikit/utils/ILogger.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/utils/ILogger.java
@@ -16,7 +16,21 @@
 
 package com.yubico.yubikit.utils;
 
+/**
+ * Interface that needs to be implemented in order to customize logging within SDK
+ * it's up to user whether to send logs to logcat, file or network
+ */
 public interface ILogger {
+    /**
+     * Logs message (debug level)
+     * @param message the message can to be logged
+     */
     void logDebug(String message);
+
+    /**
+     * Logs message (error level)
+     * @param message the message can to be logged
+     * @param throwable the exception that can to be logged or counted
+     */
     void logError(String message, Throwable throwable);
 }

--- a/yubikit/src/main/java/com/yubico/yubikit/utils/Logger.java
+++ b/yubikit/src/main/java/com/yubico/yubikit/utils/Logger.java
@@ -16,6 +16,11 @@
 
 package com.yubico.yubikit.utils;
 
+/**
+ * Helper singleton class allows to customize logs within SDK
+ * SDK has only 2 levels of logging: debug information and error
+ * If logger is not provided SDK won't produce any logs
+ */
 public class Logger {
     private static final Logger ourInstance = new Logger();
 

--- a/yubikit/src/test/java/com/yubico/yubikit/YubikitManagerTest.java
+++ b/yubikit/src/test/java/com/yubico/yubikit/YubikitManagerTest.java
@@ -6,9 +6,11 @@ import android.os.Handler;
 import com.yubico.yubikit.exceptions.NfcDisabledException;
 import com.yubico.yubikit.exceptions.NfcNotFoundException;
 import com.yubico.yubikit.transport.YubiKeySession;
+import com.yubico.yubikit.transport.nfc.NfcConfiguration;
 import com.yubico.yubikit.transport.nfc.NfcDeviceManager;
 import com.yubico.yubikit.transport.nfc.NfcSession;
 import com.yubico.yubikit.transport.nfc.NfcSessionListener;
+import com.yubico.yubikit.transport.usb.UsbConfiguration;
 import com.yubico.yubikit.transport.usb.UsbDeviceManager;
 import com.yubico.yubikit.transport.usb.UsbSession;
 import com.yubico.yubikit.transport.usb.UsbSessionListener;
@@ -62,8 +64,8 @@ public class YubikitManagerTest {
 
     @Test
     public void discoverSession() throws NfcDisabledException, NfcNotFoundException {
-        yubiKitManager.startNfcDiscovery(true, mockActivity, new NfcListener());
-        yubiKitManager.startUsbDiscovery(true, new UsbListener());
+        yubiKitManager.startNfcDiscovery(new NfcConfiguration(), mockActivity, new NfcListener());
+        yubiKitManager.startUsbDiscovery(new UsbConfiguration(), new UsbListener());
 
         // wait until listener will be invoked
         try {
@@ -83,10 +85,11 @@ public class YubikitManagerTest {
 
     @Test
     public void discoverUsbSession() throws NfcNotFoundException, NfcDisabledException {
-        yubiKitManager.startUsbDiscovery(true, new UsbListener());
+        UsbConfiguration configuration = new UsbConfiguration();
+        yubiKitManager.startUsbDiscovery(configuration, new UsbListener());
 
-        Mockito.verify(mockUsb).enable(true);
-        Mockito.verify(mockNfc, Mockito.never()).enable(mockActivity, true);
+        Mockito.verify(mockUsb).enable(configuration);
+        Mockito.verify(mockNfc, Mockito.never()).enable(mockActivity, new NfcConfiguration());
 
         // wait until listener will be invoked
         try {
@@ -105,9 +108,10 @@ public class YubikitManagerTest {
 
     @Test
     public void discoverNfcSession() throws NfcNotFoundException, NfcDisabledException {
-        yubiKitManager.startNfcDiscovery(true, mockActivity, new NfcListener());
-        Mockito.verify(mockUsb, Mockito.never()).enable(true);
-        Mockito.verify(mockNfc).enable(mockActivity, true);
+        NfcConfiguration configuration = new NfcConfiguration();
+        yubiKitManager.startNfcDiscovery(configuration, mockActivity, new NfcListener());
+        Mockito.verify(mockUsb, Mockito.never()).enable(new UsbConfiguration());
+        Mockito.verify(mockNfc).enable(mockActivity, configuration);
 
         // wait until listener will be invoked
         try {


### PR DESCRIPTION
Created UsbConfiguration and NfcConfiguration classes that need to be passed when start discovery of YubiKey connection.
Added ability to turn off sound for NFC tag discovery. And also Skipping NDEF check (for most of YubiKey connections we don't need NDEF tag, so skipping it's check might optimize the speed of discovery of NFC tag)
Added onRequestPermissionsResult callback for usbManager that will be invoked when permissions were granted or denied by user (addressing https://github.com/Yubico/yubikit-android/issues/8)