### PR TITLE
Allow to parse OTP tag value from different objects

### DIFF
--- a/otp/src/main/AndroidManifest.xml
+++ b/otp/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.yubico.yubikit.otp" >
+
+    <uses-permission android:name="android.permission.NFC" />
     <application>
         <activity android:name=".OtpActivity"
             android:label="@string/yubikit_otp_activity_title"

--- a/otp/src/test/java/com/yubico/yubikit/otp/OtpParserTest.java
+++ b/otp/src/test/java/com/yubico/yubikit/otp/OtpParserTest.java
@@ -52,7 +52,7 @@ public class OtpParserTest {
     public void parseInvalidFormatPayload() {
         NdefRecord record = new NdefRecord((short) 1, new byte[]{0x55},  null, createNdefData(NEO_PREFIX, new byte[0]));
         String code = OtpParser.parseNdefRecord(record);
-        Assert.assertEquals(code, "");
+        Assert.assertEquals("", code);
 
         record = new NdefRecord((short) 1, new byte[]{0x55},  null, null);
         code = OtpParser.parseNdefRecord(record);

--- a/yubikit/README.md
+++ b/yubikit/README.md
@@ -36,7 +36,7 @@ yubikitVersion=1.0.0-beta04
 ```java
     private class UsbListener implements UsbSessionListener {
         @Override
-        public void onSessionReceived(@NonNull UsbSession session) {
+        public void onSessionReceived(@NonNull UsbSession session, Boolean hasPermissions) {
             // yubikey was plugged in
         }
 


### PR DESCRIPTION
OTP module can parse NDEF tag value from URL, NdefMessage or Tag.