### PR TITLE
Fix typo in pkcs1.15 padding implementation for RSA signature

### DIFF
--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/BaseYubikeyFragment.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/BaseYubikeyFragment.kt
@@ -27,7 +27,7 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.Observer
 import androidx.lifecycle.OnLifecycleEvent
 import com.google.android.material.snackbar.Snackbar
-import com.yubico.yubikit.demo.raw.UsbDeviceNotFoundException
+import com.yubico.yubikit.demo.exceptions.UsbDeviceNotFoundException
 import com.yubico.yubikit.exceptions.NfcDisabledException
 import com.yubico.yubikit.exceptions.NfcNotFoundException
 import com.yubico.yubikit.exceptions.NoPermissionsException

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/YubikeyViewModel.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/YubikeyViewModel.kt
@@ -23,7 +23,7 @@ import androidx.lifecycle.ViewModel
 import com.yubico.yubikit.YubiKitManager
 import com.yubico.yubikit.demo.fido.arch.ErrorLiveEvent
 import com.yubico.yubikit.demo.fido.arch.SingleLiveEvent
-import com.yubico.yubikit.demo.raw.UsbDeviceNotFoundException
+import com.yubico.yubikit.demo.exceptions.UsbDeviceNotFoundException
 import com.yubico.yubikit.demo.settings.Ramps
 import com.yubico.yubikit.exceptions.NfcDisabledException
 import com.yubico.yubikit.exceptions.NfcNotFoundException

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/exceptions/InvalidCertDataException.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/exceptions/InvalidCertDataException.kt
@@ -1,0 +1,7 @@
+package com.yubico.yubikit.demo.exceptions
+
+import com.yubico.yubikit.apdu.ApduException
+
+class InvalidCertDataException(message: String, cause: Throwable?) : ApduException(message, cause) {
+    constructor(message: String) : this(message, null)
+}

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/exceptions/UsbDeviceNotFoundException.java
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/exceptions/UsbDeviceNotFoundException.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.yubico.yubikit.demo.raw;
+package com.yubico.yubikit.demo.exceptions;
 
 import com.yubico.yubikit.exceptions.YubikeyCommunicationException;
 

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/piv/PivFragment.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/piv/PivFragment.kt
@@ -124,6 +124,7 @@ class PivFragment : BaseYubikeyFragment(TAG), PasswordDialogFragment.DialogListe
                 Toast.makeText(context, throwable.message, Toast.LENGTH_LONG).show()
             }
         }
+        showProgress(false)
         activity?.invalidateOptionsMenu()
     }
 

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/piv/PivViewModel.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/piv/PivViewModel.kt
@@ -167,7 +167,9 @@ class PivViewModel(yubiKitManager: YubiKitManager, private val settings: ISettin
                             val certificate = _certificates.value?.get(slot.value)
                             if(certificate != null) {
                                 val signatureIsValid = verifySignature(data, signature, certificate)
-                                Logger.d(if (signatureIsValid) "Signature is valid. " else "Signature is not valid. ")
+                                if (!signatureIsValid) {
+                                    throw InvalidCertDataException("Verification of signature failed. Make sure your imported certificate contains the data about key pair on this slot")
+                                }
                             }
                             _operationCompleted.postValue("Signature: " + Base64.encodeToString(signature, Base64.DEFAULT))
                         }

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/piv/PivViewModel.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/piv/PivViewModel.kt
@@ -18,6 +18,7 @@ package com.yubico.yubikit.demo.piv
 
 import android.os.Build
 import android.os.Bundle
+import android.util.Base64
 import android.util.SparseArray
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -27,6 +28,7 @@ import com.yubico.yubikit.YubiKitManager
 import com.yubico.yubikit.apdu.ApduCodeException
 import com.yubico.yubikit.apdu.ApduException
 import com.yubico.yubikit.demo.YubikeyViewModel
+import com.yubico.yubikit.demo.exceptions.InvalidCertDataException
 import com.yubico.yubikit.demo.fido.arch.SingleLiveEvent
 import com.yubico.yubikit.demo.oath.AuthRequiredException
 import com.yubico.yubikit.demo.oath.PasswordDialogFragment
@@ -38,15 +40,15 @@ import com.yubico.yubikit.transport.YubiKeySession
 import com.yubico.yubikit.utils.Logger
 import com.yubico.yubikit.utils.StringUtils
 import org.apache.commons.codec.binary.Hex
-import java.io.File
-import java.io.IOException
+import java.io.*
 import java.nio.charset.StandardCharsets
-import java.security.PrivateKey
+import java.security.*
+import java.security.cert.CertificateEncodingException
+import java.security.cert.CertificateException
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
-import javax.security.cert.CertificateEncodingException
-import javax.security.cert.CertificateException
-import javax.security.cert.X509Certificate
 
 private const val OPERATION_ID = "operationId"
 private const val PASSWORD = "password"
@@ -158,10 +160,16 @@ class PivViewModel(yubiKitManager: YubiKitManager, private val settings: ISettin
                         }
                         Operations.SIGN -> {
                             _operationStarted.postValue("Signing message")
-                            val signature = pivApplication.sign(request.getSerializable(SLOT_ID) as Slot,
-                                    request.getSerializable(ALGO) as Algorithm,
-                                    request.getString(DATA)!!.toByteArray(StandardCharsets.UTF_8))
-                            _operationCompleted.postValue("Received signature " + StringUtils.convertBytesToString(signature))
+                            val data = request.getString(DATA)!!.toByteArray(StandardCharsets.UTF_8)
+                            val slot = request.getSerializable(SLOT_ID) as Slot
+                            val algorithm = request.getSerializable(ALGO) as Algorithm
+                            val signature = pivApplication.sign(slot, algorithm, data)
+                            val certificate = _certificates.value?.get(slot.value)
+                            if(certificate != null) {
+                                val signatureIsValid = verifySignature(data, signature, certificate)
+                                Logger.d(if (signatureIsValid) "Signature is valid. " else "Signature is not valid. ")
+                            }
+                            _operationCompleted.postValue("Signature: " + Base64.encodeToString(signature, Base64.DEFAULT))
                         }
                         Operations.CHANGE_PIN -> {
                             _operationStarted.postValue("Changing pin")
@@ -421,9 +429,33 @@ class PivViewModel(yubiKitManager: YubiKitManager, private val settings: ISettin
         executeDemoCommands()
     }
 
+    /**
+     * Helper method to verify that signature is authentic (provided using key pair within Certificate)
+     */
+    private fun verifySignature(data: ByteArray, signature: ByteArray, certificate: X509Certificate) : Boolean {
+        try {
+            val privateSignature = Signature.getInstance(certificate.sigAlgName)
+            privateSignature.initVerify(certificate)
+            privateSignature.update(data)
+            return privateSignature.verify(signature)
+        } catch (e: NoSuchAlgorithmException) {
+            throw InvalidCertDataException("Cert algorithm " + certificate.sigAlgName + " is not valid", e)
+        } catch (e: InvalidKeyException) {
+            throw InvalidCertDataException("Cert key " + StringUtils.convertBytesToString(certificate.publicKey.encoded) + " is not valid", e)
+        } catch (e: SignatureException) {
+            throw InvalidCertDataException("Signature " + StringUtils.convertBytesToString(signature) + " is not valid", e)
+        }
+    }
+
+    /**
+     * Reads certificate from file
+     */
     private fun readCertificateFromFile(fileName: String): X509Certificate {
-        return try {
-            X509Certificate.getInstance(File(fileName).readBytes())
+        try {
+            FileInputStream(fileName).use { inStream ->
+                val cf = CertificateFactory.getInstance("X.509")
+                return cf.generateCertificate(inStream) as X509Certificate
+            }
         } catch (e: CertificateException) {
             throw IOException("Failed to read cert from file $fileName", e)
         }

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/raw/SecCertificate.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/raw/SecCertificate.kt
@@ -16,7 +16,7 @@
 
 package com.yubico.yubikit.demo.raw
 
-import com.yubico.yubikit.apdu.ApduException
+import com.yubico.yubikit.demo.exceptions.InvalidCertDataException
 import com.yubico.yubikit.utils.StringUtils
 import java.security.*
 import java.util.*
@@ -102,10 +102,6 @@ class SecCertificate(keyData: ByteArray) {
             }
             tag = data[0].toInt().and(0xff)
         }
-    }
-
-    class InvalidCertDataException(message: String, cause: Throwable?) : ApduException(message, cause) {
-        constructor(message: String) : this(message, null)
     }
 
     companion object {

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/raw/SecCertificate.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/raw/SecCertificate.kt
@@ -18,10 +18,16 @@ package com.yubico.yubikit.demo.raw
 
 import com.yubico.yubikit.demo.exceptions.InvalidCertDataException
 import com.yubico.yubikit.utils.StringUtils
-import java.security.*
-import java.util.*
-import javax.security.cert.CertificateException
-import javax.security.cert.X509Certificate
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.security.InvalidKeyException
+import java.security.NoSuchAlgorithmException
+import java.security.Signature
+import java.security.SignatureException
+import java.security.cert.CertificateException
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Locale
 
 class SecCertificate(keyData: ByteArray) {
 
@@ -58,7 +64,9 @@ class SecCertificate(keyData: ByteArray) {
 
         // 3. instantiates an X509Certificate object with provided byte array
         try {
-            certificate = X509Certificate.getInstance(mutableData)
+            val stream: InputStream = ByteArrayInputStream(mutableData)
+            val cf = CertificateFactory.getInstance("X.509")
+            certificate = cf.generateCertificate(stream) as X509Certificate
         } catch (e: CertificateException) {
             throw InvalidCertDataException("Can't parse certificate data", e)
         }

--- a/YubikitDemo/src/main/java/com/yubico/yubikit/demo/raw/YubikeySmartcardViewModel.kt
+++ b/YubikitDemo/src/main/java/com/yubico/yubikit/demo/raw/YubikeySmartcardViewModel.kt
@@ -25,6 +25,7 @@ import com.yubico.yubikit.apdu.ApduException
 
 import com.yubico.yubikit.apdu.Apdu
 import com.yubico.yubikit.demo.YubikeyViewModel
+import com.yubico.yubikit.demo.exceptions.InvalidCertDataException
 import com.yubico.yubikit.demo.fido.arch.SingleLiveEvent
 import com.yubico.yubikit.transport.Iso7816Connection
 import com.yubico.yubikit.transport.YubiKeySession
@@ -102,7 +103,7 @@ open class YubikeySmartcardViewModel(yubikitManager: YubiKitManager, private val
             val signedData = signedString.toByteArray(Charsets.UTF_8)
             val signatureIsValid = certificate.verify(signedData, signatureData)
             _log.postValue(if (signatureIsValid) "Signature is valid." else "Signature is not valid.")
-        } catch (e: SecCertificate.InvalidCertDataException) {
+        } catch (e: InvalidCertDataException) {
             postError(e)
             return
         }

--- a/piv/src/main/java/com/yubico/yubikit/piv/PivApplication.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/PivApplication.java
@@ -23,19 +23,19 @@ import com.yubico.yubikit.Iso7816Application;
 import com.yubico.yubikit.apdu.Apdu;
 import com.yubico.yubikit.apdu.ApduCodeException;
 import com.yubico.yubikit.apdu.ApduException;
-import com.yubico.yubikit.apdu.ApduUtils;
 import com.yubico.yubikit.apdu.Tlv;
 import com.yubico.yubikit.apdu.TlvUtils;
 import com.yubico.yubikit.apdu.Version;
 import com.yubico.yubikit.exceptions.ApplicationNotFound;
 import com.yubico.yubikit.exceptions.NotSupportedOperation;
-import com.yubico.yubikit.transport.Iso7816Connection;
 import com.yubico.yubikit.transport.YubiKeySession;
 import com.yubico.yubikit.utils.Logger;
 import com.yubico.yubikit.utils.StringUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
@@ -45,6 +45,10 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.spec.InvalidKeySpecException;
@@ -58,9 +62,6 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import javax.security.cert.CertificateEncodingException;
-import javax.security.cert.CertificateException;
-import javax.security.cert.X509Certificate;
 
 import static com.yubico.yubikit.piv.CryptoUtils.publicEccKey;
 import static com.yubico.yubikit.piv.CryptoUtils.publicRsaKey;
@@ -115,7 +116,7 @@ public class PivApplication extends Iso7816Application {
     private static final byte PUK_P2 = (byte)0x81;
 
     private static final List<Algorithm> SUPPORTED_ALGORITHMS = Arrays.asList(Algorithm.RSA1024, Algorithm.RSA2048, Algorithm.ECCP256, Algorithm.ECCP384);
-    private static final byte[] RSA_HASH_SHA256_PREFIX = new byte[] {0x30, 0x32, 0x30, 0x0d, 0x06, 0x09, 0x60, (byte)0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20};
+    private static final byte[] RSA_HASH_SHA256_PREFIX = new byte[] {0x30, 0x31, 0x30, 0x0d, 0x06, 0x09, 0x60, (byte)0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20};
     private static final byte TDES = 0x03;
 
 
@@ -231,7 +232,7 @@ public class PivApplication extends Iso7816Application {
 
         byte[] requestMessage;
         if (algorithm == Algorithm.RSA1024 || algorithm == Algorithm.RSA2048) {
-            requestMessage = addPkcsPadding(algorithm == Algorithm.RSA1024 ? 128 : 256, hash);
+            requestMessage = addPkcs1_15Padding(algorithm == Algorithm.RSA1024 ? 128 : 256, hash);
         } else {
             requestMessage = hash;
         }
@@ -239,7 +240,6 @@ public class PivApplication extends Iso7816Application {
         boolean lengthCondition;
         switch (algorithm) {
             case RSA1024:
-                // TODO: this case doesn't work
                 lengthCondition = requestMessage.length == 128;
                 break;
             case RSA2048:
@@ -404,7 +404,7 @@ public class PivApplication extends Iso7816Application {
         }
 
         try {
-            return X509Certificate.getInstance(certData.get(TAG_CERTIFICATE));
+            return parseCertificate(certData.get(TAG_CERTIFICATE));
         } catch (CertificateException e) {
             throw new ApduException("Failed to parse certificate", e);
         }
@@ -452,7 +452,7 @@ public class PivApplication extends Iso7816Application {
         }
         try {
             byte[] responseData = sendAndReceive(new Apdu(0, INS_ATTEST, slot.value, 0, null));
-            return X509Certificate.getInstance(responseData);
+            return parseCertificate(responseData);
         } catch (ApduCodeException e){
             if (INCORRECT_VALUES_ERROR == e.getStatusCode()) {
                 throw new NotSupportedOperation(String.format(Locale.ROOT, "Make sure that key is generated on slot %02X", slot.value));
@@ -562,7 +562,6 @@ public class PivApplication extends Iso7816Application {
                     length = 64;
                     break;
                 case 2048:
-                    // TODO: this case doesn't work
                     algorithm = Algorithm.RSA2048;
                     length = 128;
                     break;
@@ -675,7 +674,7 @@ public class PivApplication extends Iso7816Application {
      * @return padded hash message to requested length
      * @throws IOException never occurs because we do only memory stream writing
      */
-    private byte[] addPkcsPadding(int length, byte[] hash) throws IOException {
+    private byte[] addPkcs1_15Padding(int length, byte[] hash) throws IOException {
         int paddingLength = length - (RSA_HASH_SHA256_PREFIX.length + hash.length) - 3;
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
@@ -693,6 +692,12 @@ public class PivApplication extends Iso7816Application {
         stream.write(RSA_HASH_SHA256_PREFIX);
         stream.write(hash);
         return stream.toByteArray();
+    }
+
+    private X509Certificate parseCertificate(byte[] data) throws CertificateException {
+        InputStream stream = new ByteArrayInputStream(data);
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        return (X509Certificate)cf.generateCertificate(stream);
     }
 
     /**

--- a/piv/src/main/java/com/yubico/yubikit/piv/PivApplication.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/PivApplication.java
@@ -694,6 +694,12 @@ public class PivApplication extends Iso7816Application {
         return stream.toByteArray();
     }
 
+    /**
+     * Generates x509 certificate object from byte array
+     * @param data contains certificate data
+     * @return java.security.cert.X509Certificate representation of certificate
+     * @throws CertificateException
+     */
     private X509Certificate parseCertificate(byte[] data) throws CertificateException {
         InputStream stream = new ByteArrayInputStream(data);
         CertificateFactory cf = CertificateFactory.getInstance("X.509");


### PR DESCRIPTION
Added verification logic within demo when signing data to make sure that signature returned is valid/authentic.
Switched from [javax Certificate](https://developer.android.com/reference/javax/security/cert/X509Certificate) to [java Certificate](https://developer.android.com/reference/java/security/cert/X509Certificate), because it seems like the way [JDK wants to move to](https://bugs.openjdk.java.net/browse/JDK-8227395)

Addressing issue: https://github.com/Yubico/yubikit-android/issues/15