### PR TITLE
PIV JCA fixes

### DIFF
--- a/AndroidDemo/build.gradle
+++ b/AndroidDemo/build.gradle
@@ -5,10 +5,12 @@ android {
     compileSdkVersion 32
 
     defaultConfig {
-        minSdkVersion 24
+        minSdkVersion 19
         targetSdkVersion 32
         versionName version
         versionCode 1
+
+        multiDexEnabled true
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
@@ -275,7 +275,6 @@ class PivCertificateFragment : Fragment() {
 
         binding.delete.isEnabled = visible
         binding.sign.isEnabled = visible
-        binding.webview.isEnabled = visible
     }
 
     companion object {

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
@@ -33,6 +33,7 @@ import com.yubico.yubikit.piv.KeyType
 import com.yubico.yubikit.piv.PinPolicy
 import com.yubico.yubikit.piv.Slot
 import com.yubico.yubikit.piv.TouchPolicy
+import com.yubico.yubikit.piv.jca.PivAlgorithmParameterSpec
 import com.yubico.yubikit.piv.jca.PivPrivateKey
 import com.yubico.yubikit.piv.jca.PivProvider
 import kotlinx.coroutines.Dispatchers
@@ -48,8 +49,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.OutputStream
 import java.math.BigInteger
-import java.security.KeyFactory
-import java.security.Signature
+import java.security.*
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.security.spec.PKCS8EncodedKeySpec
@@ -165,14 +165,17 @@ class PivCertificateFragment : Fragment() {
                     pivViewModel.pendingAction.value = {
                         authenticate(pivViewModel.mgmtKeyType, pivViewModel.mgmtKey)
 
-                        // Generate a key
-                        val publicKey = generateKey(
-                            slot,
-                            KeyType.ECCP256,
-                            PinPolicy.DEFAULT,
-                            TouchPolicy.DEFAULT
+                        val provider = PivProvider(this)
+                        val factory = KeyPairGenerator.getInstance("EC", provider)
+                        factory.initialize(
+                            PivAlgorithmParameterSpec(
+                                slot,
+                                PinPolicy.DEFAULT,
+                                TouchPolicy.DEFAULT,
+                                pin.toCharArray()
+                            )
                         )
-                        val privateKey = PivPrivateKey.from(publicKey, slot, pin.toCharArray())
+                        val keyPair = factory.generateKeyPair()
 
                         // Generate a certificate
                         val name = X500Name("CN=Generated Example")
@@ -182,10 +185,8 @@ class PivCertificateFragment : Fragment() {
                             Date(),
                             Date(),
                             name,
-                            SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(publicKey.encoded))
+                            SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(keyPair.public.encoded))
                         )
-
-                        val provider = PivProvider(this)
                         val certBytes = serverCertGen.build(object : ContentSigner {
                             val messageBuffer = ByteArrayOutputStream()
                             override fun getAlgorithmIdentifier(): AlgorithmIdentifier =
@@ -194,7 +195,7 @@ class PivCertificateFragment : Fragment() {
                             override fun getOutputStream(): OutputStream = messageBuffer
                             override fun getSignature(): ByteArray {
                                 return Signature.getInstance("SHA256withECDSA", provider).apply {
-                                    initSign(privateKey)
+                                    initSign(keyPair.private)
                                     update(messageBuffer.toByteArray())
                                 }.sign()
                                 //return sign(slot, KeyType.ECCP256, messageBuffer.toByteArray(), Signature.getInstance("SHA256withECDSA"))
@@ -234,19 +235,20 @@ class PivCertificateFragment : Fragment() {
             lifecycleScope.launch(Dispatchers.Main) {
                 getSecret(requireContext(), R.string.enter_pin)?.let { pin ->
                     pivViewModel.pendingAction.value = {
-                        val publicKey = pivViewModel.certificates.value!!.get(slot.value).publicKey
-                        val keyType = KeyType.fromKey(publicKey)
+                        val provider = PivProvider(this)
 
-                        val algorithm = when (keyType.params.algorithm) {
+                        val keyStore = KeyStore.getInstance("YKPiv", provider)
+                        keyStore.load(null)
+                        val publicKey = keyStore.getCertificate(slot.value.toString(16)).publicKey
+                        val privateKey = keyStore.getKey(slot.value.toString(16), pin.toCharArray()) as PrivateKey
+                        val algorithm = when (KeyType.fromKey(publicKey).params.algorithm) {
                             KeyType.Algorithm.RSA -> "SHA256withRSA"
                             KeyType.Algorithm.EC -> "SHA256withECDSA"
                         }
 
-                        val provider = PivProvider(this)
-
                         // Create signature
                         val signature = Signature.getInstance(algorithm, provider).apply {
-                            initSign(PivPrivateKey.from(publicKey, slot, pin.toCharArray()))
+                            initSign(privateKey)
                             update(messageBytes)
                         }.sign()
 

--- a/AndroidDemo/src/main/res/layout/fragment_piv_certifiate.xml
+++ b/AndroidDemo/src/main/res/layout/fragment_piv_certifiate.xml
@@ -127,11 +127,5 @@
             android:layout_height="wrap_content"
             android:text="@string/piv_sign" />
 
-        <Button
-            android:id="@+id/webview"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/piv_webview" />
-
     </LinearLayout>
 </ScrollView>

--- a/piv/src/main/java/com/yubico/yubikit/piv/Slot.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/Slot.java
@@ -58,6 +58,14 @@ public enum Slot {
     }
 
     /**
+     * Gets the String alias for the slot, which is a HEX representation of the slot value.
+     * @return the slot alias
+     */
+    public String getStringAlias() {
+        return Integer.toString(value, 16);
+    }
+
+    /**
      * Returns the PIV slot corresponding to the given ID.
      */
     public static Slot fromValue(int value) {
@@ -67,5 +75,16 @@ public enum Slot {
             }
         }
         throw new IllegalArgumentException("Not a valid Slot :" + value);
+    }
+
+    /**
+     * Returns the PIV slot corresponding to the given String alias.
+     *
+     * The alias should be the HEX representation of the slot value.
+     * @param alias a slot value as HEX string
+     * @return a Slot
+     */
+    public static Slot fromStringAlias(String alias) {
+        return fromValue(Integer.parseInt(alias, 16));
     }
 }

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivKeyStoreSpi.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivKeyStoreSpi.java
@@ -2,12 +2,13 @@ package com.yubico.yubikit.piv.jca;
 
 import com.yubico.yubikit.core.application.BadResponseException;
 import com.yubico.yubikit.core.smartcard.ApduException;
+import com.yubico.yubikit.core.smartcard.SW;
 import com.yubico.yubikit.core.util.Callback;
 import com.yubico.yubikit.core.util.Result;
-import com.yubico.yubikit.piv.KeyType;
 import com.yubico.yubikit.piv.PinPolicy;
 import com.yubico.yubikit.piv.PivSession;
 import com.yubico.yubikit.piv.Slot;
+import com.yubico.yubikit.piv.SlotMetadata;
 import com.yubico.yubikit.piv.TouchPolicy;
 
 import java.io.InputStream;
@@ -19,12 +20,12 @@ import java.security.KeyStoreException;
 import java.security.KeyStoreSpi;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.UnrecoverableEntryException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.Enumeration;
-import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
@@ -37,53 +38,45 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
         this.provider = provider;
     }
 
-    private KeyType putKey(Slot slot, PrivateKey key, PinPolicy pinPolicy, TouchPolicy touchPolicy) throws Exception {
-        BlockingQueue<Result<KeyType, Exception>> queue = new ArrayBlockingQueue<>(1);
-        provider.invoke(result -> queue.add(Result.of(() -> result.getValue().putKey(slot, key, pinPolicy, touchPolicy))));
-        return queue.take().getValue();
-    }
-
-    private void putCertificate(Slot slot, X509Certificate certificate) throws Exception {
+    private void putEntry(Slot slot, @Nullable PrivateKey key, PinPolicy pinPolicy, TouchPolicy touchPolicy, @Nullable X509Certificate certificate) throws Exception {
         BlockingQueue<Result<Boolean, Exception>> queue = new ArrayBlockingQueue<>(1);
         provider.invoke(result -> queue.add(Result.of(() -> {
-            result.getValue().putCertificate(slot, certificate);
-            return true;
-        })));
-        queue.take().getValue();
-    }
-
-    private X509Certificate getCertificate(Slot slot) throws Exception {
-        BlockingQueue<Result<X509Certificate, Exception>> queue = new ArrayBlockingQueue<>(1);
-        provider.invoke(result -> queue.add(Result.of(() -> result.getValue().getCertificate(slot))));
-        return queue.take().getValue();
-    }
-
-    private void deleteCertificate(Slot slot) throws Exception {
-        BlockingQueue<Result<Boolean, Exception>> queue = new ArrayBlockingQueue<>(1);
-        provider.invoke(result -> queue.add(Result.of(() -> {
-            result.getValue().deleteCertificate(slot);
+            PivSession piv = result.getValue();
+            if (key != null) {
+                piv.putKey(slot, key, pinPolicy, touchPolicy);
+            }
+            if (certificate != null) {
+                piv.putCertificate(slot, certificate);
+            }
             return true;
         })));
         queue.take().getValue();
     }
 
     @Override
+    @Nullable
     public Key engineGetKey(String alias, char[] password) throws UnrecoverableKeyException {
         Slot slot = Slot.fromStringAlias(alias);
         try {
-            BlockingQueue<Result<PublicKey, Exception>> queue = new ArrayBlockingQueue<>(1);
+            BlockingQueue<Result<PivPrivateKey, Exception>> queue = new ArrayBlockingQueue<>(1);
             provider.invoke(result -> queue.add(Result.of(() -> {
                 PivSession session = result.getValue();
                 if (session.supports(PivSession.FEATURE_METADATA)) {
-                    return session.getSlotMetadata(slot).getPublicKey();
+                    SlotMetadata data = session.getSlotMetadata(slot);
+                    return PivPrivateKey.from(data.getPublicKey(), slot, data.getPinPolicy(), data.getTouchPolicy(), password);
                 } else {
-                    return session.getCertificate(slot).getPublicKey();
+                    PublicKey publicKey = session.getCertificate(slot).getPublicKey();
+                    return PivPrivateKey.from(publicKey, slot, null, null, password);
                 }
             })));
-            PublicKey publicKey = queue.take().getValue();
-            return PivPrivateKey.from(publicKey, slot, password);
+            return queue.take().getValue();
         } catch (BadResponseException e) {
             throw new UnrecoverableKeyException("No way to infer KeyType, make sure the matching certificate is stored");
+        } catch (ApduException e) {
+            if (e.getSw() == SW.FILE_NOT_FOUND) {
+                return null;
+            }
+            throw new RuntimeException(e);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -95,10 +88,61 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
     }
 
     @Override
+    @Nullable
     public Certificate engineGetCertificate(String alias) {
         Slot slot = Slot.fromStringAlias(alias);
+        BlockingQueue<Result<X509Certificate, Exception>> queue = new ArrayBlockingQueue<>(1);
+        provider.invoke(result -> queue.add(Result.of(() -> result.getValue().getCertificate(slot))));
+
         try {
-            return getCertificate(slot);
+            return queue.take().getValue();
+        } catch (BadResponseException e) {
+            // Malformed certificate?
+            return null;
+        } catch (ApduException e) {
+            if (e.getSw() == SW.FILE_NOT_FOUND) {
+                // Empty slot
+                return null;
+            }
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    @Nullable
+    public KeyStore.Entry engineGetEntry(String alias, KeyStore.ProtectionParameter protParam) throws
+            UnrecoverableEntryException {
+        Slot slot = Slot.fromStringAlias(alias);
+        try {
+            BlockingQueue<Result<KeyStore.Entry, Exception>> queue = new ArrayBlockingQueue<>(1);
+            provider.invoke(result -> queue.add(Result.of(() -> {
+                PivSession session = result.getValue();
+                Certificate certificate = session.getCertificate(slot);
+                char[] pin = null;
+                if (protParam instanceof KeyStore.PasswordProtection) {
+                    pin = ((KeyStore.PasswordProtection) protParam).getPassword();
+                }
+                PrivateKey key;
+                if (session.supports(PivSession.FEATURE_METADATA)) {
+                    SlotMetadata data = session.getSlotMetadata(slot);
+                    key = PivPrivateKey.from(data.getPublicKey(), slot, data.getPinPolicy(), data.getTouchPolicy(), pin);
+                } else {
+                    PublicKey publicKey = certificate.getPublicKey();
+                    key = PivPrivateKey.from(publicKey, slot, null, null, pin);
+                }
+                return new KeyStore.PrivateKeyEntry(key, new Certificate[]{certificate});
+            })));
+            return queue.take().getValue();
+        } catch (BadResponseException e) {
+            throw new UnrecoverableEntryException("Make sure the matching certificate is stored");
+        } catch (ApduException e) {
+            if (e.getSw() == SW.FILE_NOT_FOUND) {
+                // Empty slot
+                return null;
+            }
+            throw new RuntimeException(e);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -111,7 +155,8 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
     }
 
     @Override
-    public void engineSetEntry(String alias, KeyStore.Entry entry, @Nullable KeyStore.ProtectionParameter protParam) throws KeyStoreException {
+    public void engineSetEntry(String alias, KeyStore.Entry
+            entry, @Nullable KeyStore.ProtectionParameter protParam) throws KeyStoreException {
         Slot slot = Slot.fromStringAlias(alias);
 
         PrivateKey privateKey = null;
@@ -134,9 +179,9 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
             }
         }
 
+        PinPolicy pinPolicy = PinPolicy.DEFAULT;
+        TouchPolicy touchPolicy = TouchPolicy.DEFAULT;
         if (privateKey != null) {
-            PinPolicy pinPolicy = PinPolicy.DEFAULT;
-            TouchPolicy touchPolicy = TouchPolicy.DEFAULT;
             if (protParam != null) {
                 if (protParam instanceof PivKeyStoreKeyParameters) {
                     pinPolicy = ((PivKeyStoreKeyParameters) protParam).pinPolicy;
@@ -145,25 +190,18 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
                     throw new KeyStoreException("protParam must be an instance of PivKeyStoreKeyParameters");
                 }
             }
-            try {
-                putKey(slot, ((KeyStore.PrivateKeyEntry) entry).getPrivateKey(), pinPolicy, touchPolicy);
-            } catch (Exception e) {
-                throw new KeyStoreException(e);
-            }
         }
 
-        if (certificate != null) {
-            try {
-                putCertificate(slot, (X509Certificate) certificate);
-            } catch (Exception e) {
-                throw new KeyStoreException(e);
-            }
+        try {
+            putEntry(slot, privateKey, pinPolicy, touchPolicy, (X509Certificate) certificate);
+        } catch (Exception e) {
+            throw new KeyStoreException(e);
         }
     }
 
     @Override
-    public void engineSetKeyEntry(String alias, Key key, @Nullable char[] password, Certificate[] chain) throws KeyStoreException {
-        Objects.requireNonNull(provider);
+    public void engineSetKeyEntry(String alias, Key key,
+                                  @Nullable char[] password, Certificate[] chain) throws KeyStoreException {
         Slot slot = Slot.fromStringAlias(alias);
 
         if (password != null) {
@@ -175,8 +213,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
         }
         if (chain[0] instanceof X509Certificate) {
             try {
-                putKey(slot, (PrivateKey) key, PinPolicy.DEFAULT, TouchPolicy.DEFAULT);
-                putCertificate(slot, (X509Certificate) chain[0]);
+                putEntry(slot, (PrivateKey) key, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, (X509Certificate) chain[0]);
             } catch (Exception e) {
                 throw new KeyStoreException(e);
             }
@@ -186,16 +223,18 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
     }
 
     @Override
-    public void engineSetKeyEntry(String alias, byte[] key, Certificate[] chain) throws KeyStoreException {
+    public void engineSetKeyEntry(String alias, byte[] key, Certificate[] chain) throws
+            KeyStoreException {
         throw new KeyStoreException("Use setKeyEntry with a PrivateKey instance instead of byte[]");
     }
 
     @Override
-    public void engineSetCertificateEntry(String alias, Certificate cert) throws KeyStoreException {
+    public void engineSetCertificateEntry(String alias, Certificate cert) throws
+            KeyStoreException {
         Slot slot = Slot.fromStringAlias(alias);
         if (cert instanceof X509Certificate) {
             try {
-                putCertificate(slot, (X509Certificate) cert);
+                putEntry(slot, null, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, (X509Certificate) cert);
             } catch (Exception e) {
                 throw new KeyStoreException(e);
             }
@@ -206,10 +245,16 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
 
     @Override
     public void engineDeleteEntry(String alias) throws KeyStoreException {
-        Objects.requireNonNull(provider);
         Slot slot = Slot.fromStringAlias(alias);
+
+        BlockingQueue<Result<Boolean, Exception>> queue = new ArrayBlockingQueue<>(1);
+        provider.invoke(result -> queue.add(Result.of(() -> {
+            result.getValue().deleteCertificate(slot);
+            return true;
+        })));
+
         try {
-            deleteCertificate(slot);
+            queue.take().getValue();
         } catch (Exception e) {
             throw new KeyStoreException(e);
         }
@@ -242,33 +287,16 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
 
     @Override
     public boolean engineIsCertificateEntry(String alias) {
-        Objects.requireNonNull(provider);
-        Slot slot = Slot.fromStringAlias(alias);
-        try {
-            getCertificate(slot);
-            return true;
-        } catch (BadResponseException e) {
-            return false;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        return engineGetCertificate(alias) != null;
     }
 
     @Override
     @Nullable
     public String engineGetCertificateAlias(Certificate cert) {
-        Objects.requireNonNull(provider);
         for (Slot slot : Slot.values()) {
-            X509Certificate entry;
-            try {
-                entry = getCertificate(slot);
-            } catch (ApduException | BadResponseException e) {
-                continue;
-            } catch (Exception e) {
-                return null;
-            }
-            if (entry.equals(cert)) {
-                return slot.getStringAlias();
+            String alias = slot.getStringAlias();
+            if (cert.equals(engineGetCertificate(alias))) {
+                return alias;
             }
         }
         return null;

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivKeyStoreSpi.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivKeyStoreSpi.java
@@ -69,7 +69,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
 
     @Override
     public Key engineGetKey(String alias, char[] password) throws UnrecoverableKeyException {
-        Slot slot = parseAlias(alias);
+        Slot slot = Slot.fromStringAlias(alias);
         try {
             BlockingQueue<Result<PublicKey, Exception>> queue = new ArrayBlockingQueue<>(1);
             provider.invoke(result -> queue.add(Result.of(() -> {
@@ -96,7 +96,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
 
     @Override
     public Certificate engineGetCertificate(String alias) {
-        Slot slot = parseAlias(alias);
+        Slot slot = Slot.fromStringAlias(alias);
         try {
             return getCertificate(slot);
         } catch (Exception e) {
@@ -112,7 +112,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
 
     @Override
     public void engineSetEntry(String alias, KeyStore.Entry entry, @Nullable KeyStore.ProtectionParameter protParam) throws KeyStoreException {
-        Slot slot = parseAlias(alias);
+        Slot slot = Slot.fromStringAlias(alias);
 
         PrivateKey privateKey = null;
         Certificate certificate;
@@ -164,7 +164,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
     @Override
     public void engineSetKeyEntry(String alias, Key key, @Nullable char[] password, Certificate[] chain) throws KeyStoreException {
         Objects.requireNonNull(provider);
-        Slot slot = parseAlias(alias);
+        Slot slot = Slot.fromStringAlias(alias);
 
         if (password != null) {
             throw new KeyStoreException("Password can not be set");
@@ -192,7 +192,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
 
     @Override
     public void engineSetCertificateEntry(String alias, Certificate cert) throws KeyStoreException {
-        Slot slot = parseAlias(alias);
+        Slot slot = Slot.fromStringAlias(alias);
         if (cert instanceof X509Certificate) {
             try {
                 putCertificate(slot, (X509Certificate) cert);
@@ -207,7 +207,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
     @Override
     public void engineDeleteEntry(String alias) throws KeyStoreException {
         Objects.requireNonNull(provider);
-        Slot slot = parseAlias(alias);
+        Slot slot = Slot.fromStringAlias(alias);
         try {
             deleteCertificate(slot);
         } catch (Exception e) {
@@ -223,7 +223,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
     @Override
     public boolean engineContainsAlias(String alias) {
         try {
-            parseAlias(alias);
+            Slot.fromStringAlias(alias);
             return true;
         } catch (IllegalArgumentException e) {
             return false;
@@ -243,7 +243,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
     @Override
     public boolean engineIsCertificateEntry(String alias) {
         Objects.requireNonNull(provider);
-        Slot slot = parseAlias(alias);
+        Slot slot = Slot.fromStringAlias(alias);
         try {
             getCertificate(slot);
             return true;
@@ -268,7 +268,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
                 return null;
             }
             if (entry.equals(cert)) {
-                return Integer.toString(slot.value, 16);
+                return slot.getStringAlias();
             }
         }
         return null;
@@ -288,14 +288,6 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
     public void engineLoad(@Nullable KeyStore.LoadStoreParameter param) {
         if (param != null) {
             throw new InvalidParameterException("KeyStore must be loaded with null");
-        }
-    }
-
-    static Slot parseAlias(String alias) {
-        try {
-            return Slot.fromValue(Integer.parseInt(alias, 16));
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException(e);
         }
     }
 }

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivPrivateKey.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivPrivateKey.java
@@ -27,7 +27,7 @@ public abstract class PivPrivateKey implements PrivateKey {
     protected final char[] pin;
     private boolean destroyed = false;
 
-    public static PivPrivateKey from(PublicKey publicKey, Slot slot, @Nullable char[] pin) {
+    static PivPrivateKey from(PublicKey publicKey, Slot slot, @Nullable char[] pin) {
         KeyType keyType = KeyType.fromKey(publicKey);
         if (keyType.params.algorithm == KeyType.Algorithm.RSA) {
             return new PivPrivateKey.RsaKey(slot, keyType, ((RSAPublicKey) publicKey).getModulus(), pin);

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivDeviceTests.java
@@ -43,12 +43,16 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Security;
 import java.security.Signature;
 import java.security.SignatureException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.MGF1ParameterSpec;
@@ -220,7 +224,11 @@ public class PivDeviceTests {
         //byte[] signature = piv.sign(slot, keyType, message, sig);
         try {
             Signature sig = Signature.getInstance(signatureAlgorithm);
-            sig.initSign(PivPrivateKey.from(publicKey, slot, DEFAULT_PIN));
+
+            KeyStore keyStore = KeyStore.getInstance("YKPiv");
+            keyStore.load(null);
+            PrivateKey privateKey = (PrivateKey) keyStore.getKey(Integer.toString(slot.value, 16), DEFAULT_PIN);
+            sig.initSign(privateKey);
             sig.update(message);
             byte[] signature = sig.sign();
 
@@ -229,7 +237,7 @@ public class PivDeviceTests {
             sig.initVerify(publicKey);
             sig.update(message);
             Assert.assertTrue("Verify signature", sig.verify(signature));
-        } catch (InvalidKeyException | SignatureException e) {
+        } catch (InvalidKeyException | SignatureException | KeyStoreException | CertificateException | UnrecoverableKeyException e) {
             throw new RuntimeException(e);
         }
     }
@@ -239,36 +247,41 @@ public class PivDeviceTests {
         Security.addProvider(new PivProvider(piv));
         piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
         Logger.d("Generate key: " + keyType);
-        PublicKey publicKey = piv.generateKey(Slot.SIGNATURE, keyType, PinPolicy.DEFAULT, TouchPolicy.DEFAULT);
-        PrivateKey privateKey = PivPrivateKey.from(publicKey, Slot.SIGNATURE, DEFAULT_PIN);
+
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(keyType.params.algorithm.name());
+        kpg.initialize(new PivAlgorithmParameterSpec(Slot.SIGNATURE, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, DEFAULT_PIN));
+        KeyPair keyPair = kpg.generateKeyPair();
+
+        //PublicKey publicKey = piv.generateKey(Slot.SIGNATURE, keyType, PinPolicy.DEFAULT, TouchPolicy.DEFAULT);
+        //PrivateKey privateKey = PivPrivateKey.from(publicKey, Slot.SIGNATURE, DEFAULT_PIN);
 
         switch (keyType.params.algorithm) {
             case EC:
-                testSign(privateKey, publicKey, "SHA1withECDSA", null);
-                testSign(privateKey, publicKey, "SHA256withECDSA", null);
-                testSign(privateKey, publicKey, "NONEwithECDSA", null);
-                testSign(privateKey, publicKey, "SHA3-256withECDSA", null);
+                testSign(keyPair, "SHA1withECDSA", null);
+                testSign(keyPair, "SHA256withECDSA", null);
+                testSign(keyPair, "NONEwithECDSA", null);
+                testSign(keyPair, "SHA3-256withECDSA", null);
                 break;
             case RSA:
-                testSign(privateKey, publicKey, "SHA1withRSA", null);
-                testSign(privateKey, publicKey, "SHA256withRSA", null);
-                testSign(privateKey, publicKey, "RSASSA-PSS", new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 8, 1));
+                testSign(keyPair, "SHA1withRSA", null);
+                testSign(keyPair, "SHA256withRSA", null);
+                testSign(keyPair, "RSASSA-PSS", new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 8, 1));
 
                 // Test with custom parameter. We use a 0-length salt and ensure signatures are the same
                 PSSParameterSpec param = new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 0, 1);
-                byte[] sig1 = testSign(privateKey, publicKey, "RSASSA-PSS", param);
-                byte[] sig2 = testSign(privateKey, publicKey, "RSASSA-PSS", param);
+                byte[] sig1 = testSign(keyPair, "RSASSA-PSS", param);
+                byte[] sig2 = testSign(keyPair, "RSASSA-PSS", param);
                 Assert.assertArrayEquals("PSS parameters not used, signatures are not identical!", sig1, sig2);
                 break;
         }
     }
 
-    public static byte[] testSign(PrivateKey privateKey, PublicKey publicKey, String signatureAlgorithm, AlgorithmParameterSpec param) throws NoSuchAlgorithmException, IOException, ApduException, InvalidPinException, BadResponseException, InvalidAlgorithmParameterException, InvalidKeyException, SignatureException {
+    public static byte[] testSign(KeyPair keyPair, String signatureAlgorithm, AlgorithmParameterSpec param) throws NoSuchAlgorithmException, IOException, ApduException, InvalidPinException, BadResponseException, InvalidAlgorithmParameterException, InvalidKeyException, SignatureException {
         byte[] message = "Hello world!".getBytes(StandardCharsets.UTF_8);
 
         Logger.d("Create signature using " + signatureAlgorithm);
         Signature signer = Signature.getInstance(signatureAlgorithm);
-        signer.initSign(privateKey);
+        signer.initSign(keyPair.getPrivate());
         if (param != null) signer.setParameter(param);
         signer.update(message);
         byte[] signature = signer.sign();
@@ -276,7 +289,7 @@ public class PivDeviceTests {
         //byte[] signature = piv.sign(Slot.SIGNATURE, KeyType.fromKey(publicKey), message, signatureAlgorithm);
         try {
             Signature verifier = Signature.getInstance(signatureAlgorithm);
-            verifier.initVerify(publicKey);
+            verifier.initVerify(keyPair.getPublic());
             if (param != null) verifier.setParameter(param);
             verifier.update(message);
             Assert.assertTrue("Verify signature", verifier.verify(signature));
@@ -287,32 +300,33 @@ public class PivDeviceTests {
         }
     }
 
-    public static void testDecrypt(PivSession piv, KeyType keyType) throws BadResponseException, IOException, ApduException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, InvalidPinException {
+    public static void testDecrypt(PivSession piv, KeyType keyType) throws BadResponseException, IOException, ApduException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, InvalidPinException, InvalidAlgorithmParameterException {
         if (keyType.params.algorithm != KeyType.Algorithm.RSA) {
             throw new IllegalArgumentException("Unsupported");
         }
 
         piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
         Logger.d("Generate key: " + keyType);
-        PublicKey publicKey = piv.generateKey(Slot.KEY_MANAGEMENT, keyType, PinPolicy.DEFAULT, TouchPolicy.DEFAULT);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(keyType.params.algorithm.name());
+        kpg.initialize(new PivAlgorithmParameterSpec(Slot.KEY_MANAGEMENT, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, DEFAULT_PIN));
+        KeyPair pair = kpg.generateKeyPair();
 
-        testDecrypt(piv, publicKey, Cipher.getInstance("RSA/ECB/PKCS1Padding"));
-        testDecrypt(piv, publicKey, Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding"));
-        testDecrypt(piv, publicKey, Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding"));
+        testDecrypt(pair, Cipher.getInstance("RSA/ECB/PKCS1Padding"));
+        testDecrypt(pair, Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding"));
+        testDecrypt(pair, Cipher.getInstance("RSA/ECB/OAEPWithSHA-256AndMGF1Padding"));
     }
 
-    public static void testDecrypt(PivSession piv, PublicKey publicKey, Cipher cipher) throws BadResponseException, IOException, ApduException, NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, InvalidPinException {
+    public static void testDecrypt(KeyPair keyPair, Cipher cipher) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException, InvalidPinException {
         byte[] message = "Hello world!".getBytes(StandardCharsets.UTF_8);
 
-        piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
         Logger.d("Using cipher " + cipher.getAlgorithm());
 
-        cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+        cipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublic());
         byte[] ct = cipher.doFinal(message);
         Logger.d("Cipher text " + ct.length + ": " + StringUtils.bytesToHex(ct));
 
         Cipher decryptCipher = Cipher.getInstance(cipher.getAlgorithm());
-        decryptCipher.init(Cipher.DECRYPT_MODE, PivPrivateKey.from(publicKey, Slot.KEY_MANAGEMENT, DEFAULT_PIN));
+        decryptCipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
         byte[] pt = decryptCipher.doFinal(ct);
 
         Assert.assertArrayEquals(message, pt);


### PR DESCRIPTION
This PR adds several fixes for PIV JCA:
* Remove the usage of CompletableFuture (requires Android API 24).
* Replaces PivPrivatekey.from with more standard JCA APIs (using KeyStore and KeyPairGenerator).
* Adds Slot.fromStringAlias and .toStringAlias().
* Adds metadata getters to PivPrivateKey, as well as allowing to set/change the PIN used by the key after creation.
* Removes some unused parts of the demo app.