### PR TITLE
Fix KeyPairGenerator spec

### DIFF
--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
@@ -170,6 +170,7 @@ class PivCertificateFragment : Fragment() {
                         factory.initialize(
                             PivAlgorithmParameterSpec(
                                 slot,
+                                KeyType.ECCP256,
                                 PinPolicy.DEFAULT,
                                 TouchPolicy.DEFAULT,
                                 pin.toCharArray()

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivAlgorithmParameterSpec.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivAlgorithmParameterSpec.java
@@ -1,5 +1,6 @@
 package com.yubico.yubikit.piv.jca;
 
+import com.yubico.yubikit.piv.KeyType;
 import com.yubico.yubikit.piv.PinPolicy;
 import com.yubico.yubikit.piv.Slot;
 import com.yubico.yubikit.piv.TouchPolicy;
@@ -12,14 +13,16 @@ import javax.security.auth.Destroyable;
 
 public class PivAlgorithmParameterSpec implements AlgorithmParameterSpec, Destroyable {
     final Slot slot;
+    final KeyType keyType;
     final PinPolicy pinPolicy;
     final TouchPolicy touchPolicy;
     @Nullable
     final char[] pin;
     private boolean destroyed = false;
 
-    public PivAlgorithmParameterSpec(Slot slot, @Nullable PinPolicy pinPolicy, @Nullable TouchPolicy touchPolicy, @Nullable char[] pin) {
+    public PivAlgorithmParameterSpec(Slot slot, KeyType keyType, @Nullable PinPolicy pinPolicy, @Nullable TouchPolicy touchPolicy, @Nullable char[] pin) {
         this.slot = slot;
+        this.keyType = keyType;
         this.pinPolicy = pinPolicy != null ? pinPolicy : PinPolicy.DEFAULT;
         this.touchPolicy = touchPolicy != null ? touchPolicy : TouchPolicy.DEFAULT;
         this.pin = pin != null ? Arrays.copyOf(pin, pin.length) : null;

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivDeviceTests.java
@@ -249,7 +249,7 @@ public class PivDeviceTests {
         Logger.d("Generate key: " + keyType);
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(keyType.params.algorithm.name());
-        kpg.initialize(new PivAlgorithmParameterSpec(Slot.SIGNATURE, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, DEFAULT_PIN));
+        kpg.initialize(new PivAlgorithmParameterSpec(Slot.SIGNATURE, keyType, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, DEFAULT_PIN));
         KeyPair keyPair = kpg.generateKeyPair();
 
         //PublicKey publicKey = piv.generateKey(Slot.SIGNATURE, keyType, PinPolicy.DEFAULT, TouchPolicy.DEFAULT);
@@ -308,7 +308,7 @@ public class PivDeviceTests {
         piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
         Logger.d("Generate key: " + keyType);
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(keyType.params.algorithm.name());
-        kpg.initialize(new PivAlgorithmParameterSpec(Slot.KEY_MANAGEMENT, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, DEFAULT_PIN));
+        kpg.initialize(new PivAlgorithmParameterSpec(Slot.KEY_MANAGEMENT, keyType, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, DEFAULT_PIN));
         KeyPair pair = kpg.generateKeyPair();
 
         testDecrypt(pair, Cipher.getInstance("RSA/ECB/PKCS1Padding"));
@@ -391,18 +391,16 @@ public class PivDeviceTests {
         piv.verifyPin(DEFAULT_PIN);
 
         KeyPairGenerator ecGen = KeyPairGenerator.getInstance("EC");
-        ecGen.initialize(new PivAlgorithmParameterSpec(Slot.AUTHENTICATION, null, null, null));
         for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384)) {
-            ecGen.initialize(keyType.params.bitLength);
+        ecGen.initialize(new PivAlgorithmParameterSpec(Slot.AUTHENTICATION, keyType, null, null, null));
             KeyPair keyPair = ecGen.generateKeyPair();
             PivTestUtils.ecSignAndVerify(keyPair.getPrivate(), keyPair.getPublic());
             PivTestUtils.ecKeyAgreement(keyPair.getPrivate(), keyPair.getPublic());
         }
 
         KeyPairGenerator rsaGen = KeyPairGenerator.getInstance("RSA");
-        rsaGen.initialize(new PivAlgorithmParameterSpec(Slot.AUTHENTICATION, null, null, null));
         for (KeyType keyType : Arrays.asList(KeyType.RSA1024, KeyType.RSA2048)) {
-            rsaGen.initialize(keyType.params.bitLength);
+            rsaGen.initialize(new PivAlgorithmParameterSpec(Slot.AUTHENTICATION, keyType, null, null, null));
             KeyPair keyPair = rsaGen.generateKeyPair();
             PivTestUtils.rsaEncryptAndDecrypt(keyPair.getPrivate(), keyPair.getPublic());
             PivTestUtils.rsaSignAndVerify(keyPair.getPrivate(), keyPair.getPublic());

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDeviceTests.java
@@ -86,9 +86,8 @@ public class PivJcaDeviceTests {
         Security.addProvider(provider);
 
         KeyPairGenerator ecGen = KeyPairGenerator.getInstance("EC", provider);
-        ecGen.initialize(new PivAlgorithmParameterSpec(Slot.AUTHENTICATION, null, null, DEFAULT_PIN));
         for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384)) {
-            ecGen.initialize(keyType.params.bitLength);
+            ecGen.initialize(new PivAlgorithmParameterSpec(Slot.AUTHENTICATION, keyType, null, null, DEFAULT_PIN));
             KeyPair keyPair = ecGen.generateKeyPair();
             PivTestUtils.ecSignAndVerify(keyPair.getPrivate(), keyPair.getPublic());
             PivTestUtils.ecKeyAgreement(keyPair.getPrivate(), keyPair.getPublic());
@@ -96,9 +95,8 @@ public class PivJcaDeviceTests {
         }
 
         KeyPairGenerator rsaGen = KeyPairGenerator.getInstance("RSA", provider);
-        rsaGen.initialize(new PivAlgorithmParameterSpec(Slot.AUTHENTICATION, null, null, DEFAULT_PIN));
         for (KeyType keyType : Arrays.asList(KeyType.RSA1024, KeyType.RSA2048)) {
-            rsaGen.initialize(keyType.params.bitLength);
+            rsaGen.initialize(new PivAlgorithmParameterSpec(Slot.AUTHENTICATION, keyType, null, null, DEFAULT_PIN));
             KeyPair keyPair = rsaGen.generateKeyPair();
             PivTestUtils.rsaEncryptAndDecrypt(keyPair.getPrivate(), keyPair.getPublic());
             PivTestUtils.rsaSignAndVerify(keyPair.getPrivate(), keyPair.getPublic());


### PR DESCRIPTION
This adds KeyType to the PivAlgorithmParameterSpec, and forbids the use of the `initialize(keySize)` initializer.