### PR TITLE
Fixes to 2.1.0-alpha.1 (1)

### DIFF
--- a/AndroidDemo/build.gradle
+++ b/AndroidDemo/build.gradle
@@ -54,13 +54,13 @@ dependencies {
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.1'
 
-    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.core:core-ktx:1.8.0'
     implementation 'androidx.fragment:fragment-ktx:1.4.1'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'com.google.android.material:material:1.6.0'
+    implementation 'com.google.android.material:material:1.6.1'
 
     // Lifecycle
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,10 @@ android {
         targetCompatibility = 1.8
     }
 
+    publishing {
+        singleVariant('release')
+    }
+
     namespace = 'com.yubico.yubikit.android'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,12 +30,12 @@ dependencies {
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.2.2'
-    compileOnly 'androidx.annotation:annotation:1.3.0'
+    compileOnly 'androidx.annotation:annotation:1.4.0'
 
     testImplementation project(':testing')
     testImplementation 'androidx.test.ext:junit:1.1.3'
     testImplementation 'org.robolectric:robolectric:4.5.1'
-    testImplementation 'org.mockito:mockito-core:3.8.0'
+    testImplementation 'org.mockito:mockito-core:3.9.0'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test:runner:1.4.0'

--- a/android/src/androidTest/java/com/yubico/yubikit/android/ExampleInstrumentedTest.java
+++ b/android/src/androidTest/java/com/yubico/yubikit/android/ExampleInstrumentedTest.java
@@ -2,7 +2,7 @@ package com.yubico.yubikit.android;
 
 import android.content.Context;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyDevice.java
@@ -114,6 +114,7 @@ public class UsbYubiKeyDevice implements YubiKeyDevice, Closeable {
 
         // Keep UsbOtpConnection open until another connection is needed, to prevent re-enumeration of the USB device.
         if (OtpConnection.class.isAssignableFrom(connectionType)) {
+            @SuppressWarnings("unchecked")
             Callback<Result<OtpConnection, IOException>> otpCallback = value -> callback.invoke((Result<T, IOException>) value);
             if (otpConnection == null) {
                 otpConnection = new CachedOtpConnection(otpCallback);

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/ConnectionManager.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/ConnectionManager.java
@@ -93,8 +93,9 @@ public class ConnectionManager {
         synchronized (handlers) {
             for (Map.Entry<Class<? extends YubiKeyConnection>, ConnectionHandler<? extends YubiKeyConnection>> entry : handlers.entrySet()) {
                 if (connectionType.isAssignableFrom(entry.getKey())) {
-                    //noinspection unchecked
-                    return (ConnectionHandler<T>) entry.getValue();
+                    @SuppressWarnings("unchecked")
+                    ConnectionHandler<T> entryValue = (ConnectionHandler<T>) entry.getValue();
+                    return entryValue;
                 }
             }
         }

--- a/android/src/test/java/com/yubico/yubikit/android/YubikitManagerTest.java
+++ b/android/src/test/java/com/yubico/yubikit/android/YubikitManagerTest.java
@@ -57,8 +57,8 @@ public class YubikitManagerTest {
 
     @Before
     public void setUp() throws NfcNotAvailable {
-        Mockito.doAnswer(new UsbListenerInvocation(usbSession)).when(mockUsb).enable(Mockito.any(), Mockito.any(Callback.class));
-        Mockito.doAnswer(new NfcListenerInvocation(nfcSession)).when(mockNfc).enable(Mockito.any(), Mockito.any(), Mockito.any(Callback.class));
+        Mockito.doAnswer(new UsbListenerInvocation(usbSession)).when(mockUsb).enable(Mockito.any(), ArgumentMatchers.<Callback<UsbYubiKeyDevice>>any());
+        Mockito.doAnswer(new NfcListenerInvocation(nfcSession)).when(mockNfc).enable(Mockito.any(), Mockito.any(), ArgumentMatchers.<Callback<NfcYubiKeyDevice>>any());
     }
 
     @Test
@@ -87,7 +87,7 @@ public class YubikitManagerTest {
         UsbConfiguration configuration = new UsbConfiguration();
         yubiKitManager.startUsbDiscovery(configuration, new UsbListener());
 
-        Mockito.verify(mockUsb).enable(Mockito.eq(configuration), Mockito.any(Callback.class));
+        Mockito.verify(mockUsb).enable(Mockito.eq(configuration), ArgumentMatchers.<Callback<UsbYubiKeyDevice>>any());
         Mockito.verify(mockNfc, Mockito.never()).enable(Mockito.any(), Mockito.any(), Mockito.any());
 
         // wait until listener will be invoked
@@ -110,7 +110,7 @@ public class YubikitManagerTest {
         NfcConfiguration configuration = new NfcConfiguration();
         yubiKitManager.startNfcDiscovery(configuration, mockActivity, new NfcListener());
 
-        Mockito.verify(mockUsb, Mockito.never()).enable(Mockito.any(), Mockito.any(Callback.class));
+        Mockito.verify(mockUsb, Mockito.never()).enable(Mockito.any(), ArgumentMatchers.<Callback<UsbYubiKeyDevice>>any());
         Mockito.verify(mockNfc).enable(Mockito.eq(mockActivity), Mockito.eq(configuration), Mockito.any());
 
         // wait until listener will be invoked

--- a/android/src/test/java/com/yubico/yubikit/android/YubikitManagerTest.java
+++ b/android/src/test/java/com/yubico/yubikit/android/YubikitManagerTest.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -42,18 +43,20 @@ import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
+
 @RunWith(AndroidJUnit4.class)
 @Config(manifest = Config.NONE)
 public class YubikitManagerTest {
-    private UsbYubiKeyManager mockUsb = Mockito.mock(UsbYubiKeyManager.class);
-    private NfcYubiKeyManager mockNfc = Mockito.mock(NfcYubiKeyManager.class);
-    private Activity mockActivity = Mockito.mock(Activity.class);
+    private final UsbYubiKeyManager mockUsb = Mockito.mock(UsbYubiKeyManager.class);
+    private final NfcYubiKeyManager mockNfc = Mockito.mock(NfcYubiKeyManager.class);
+    private final Activity mockActivity = Mockito.mock(Activity.class);
 
-    private UsbYubiKeyDevice usbSession = Mockito.mock(UsbYubiKeyDevice.class);
-    private NfcYubiKeyDevice nfcSession = Mockito.mock(NfcYubiKeyDevice.class);
+    private final UsbYubiKeyDevice usbSession = Mockito.mock(UsbYubiKeyDevice.class);
+    private final NfcYubiKeyDevice nfcSession = Mockito.mock(NfcYubiKeyDevice.class);
 
     private final CountDownLatch signal = new CountDownLatch(2);
-    private YubiKitManager yubiKitManager = new YubiKitManager(mockUsb, mockNfc);
+    private final YubiKitManager yubiKitManager = new YubiKitManager(mockUsb, mockNfc);
 
     @Before
     public void setUp() throws NfcNotAvailable {
@@ -142,13 +145,14 @@ public class YubikitManagerTest {
         }
     }
 
-    private class UsbListenerInvocation implements Answer {
-        private UsbYubiKeyDevice session;
+    private static class UsbListenerInvocation implements Answer {
+        private final UsbYubiKeyDevice session;
 
         private UsbListenerInvocation(UsbYubiKeyDevice session) {
             this.session = session;
         }
 
+        @Nullable
         @Override
         public Object answer(InvocationOnMock invocation) throws Throwable {
             Callback<? super UsbYubiKeyDevice> internalListener = invocation.getArgument(1);
@@ -162,13 +166,14 @@ public class YubikitManagerTest {
         }
     }
 
-    private class NfcListenerInvocation implements Answer {
-        private NfcYubiKeyDevice session;
+    private static class NfcListenerInvocation implements Answer {
+        private final NfcYubiKeyDevice session;
 
         private NfcListenerInvocation(NfcYubiKeyDevice session) {
             this.session = session;
         }
 
+        @Nullable
         @Override
         public Object answer(InvocationOnMock invocation) throws Throwable {
             Callback<? super NfcYubiKeyDevice> internalListener = invocation.getArgument(2);

--- a/android/src/test/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnectionTest.java
+++ b/android/src/test/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnectionTest.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Semaphore;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        kotlin_version = '1.6.21'
+        kotlin_version = '1.7.0'
     }
     repositories {
         mavenCentral()

--- a/management/src/main/java/com/yubico/yubikit/management/DeviceInfo.java
+++ b/management/src/main/java/com/yubico/yubikit/management/DeviceInfo.java
@@ -201,7 +201,14 @@ public class DeviceInfo {
                         autoEjectTimeout,
                         challengeResponseTimeout,
                         deviceFlags
-                ), serialNumber, version, formFactor, supportedCapabilities, isLocked, isFips, isSky
+                ),
+                serialNumber == 0 ? null : serialNumber,
+                version,
+                formFactor,
+                supportedCapabilities,
+                isLocked,
+                isFips,
+                isSky
         );
     }
 

--- a/oath/src/main/java/com/yubico/yubikit/oath/OathSession.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/OathSession.java
@@ -724,7 +724,7 @@ public class OathSession extends ApplicationSession<OathSession> {
             }
             messageDigest.update(salt);
             byte[] digest = messageDigest.digest();
-            return Base64.encodeBase64String(Arrays.copyOfRange(digest, 0, 16)).replaceAll("=", "");
+            return new String(Base64.encodeBase64(Arrays.copyOfRange(digest, 0, 16))).replaceAll("=", "");
         }
     }
 }

--- a/oath/src/main/java/com/yubico/yubikit/oath/OathSession.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/OathSession.java
@@ -35,6 +35,7 @@ import org.apache.commons.codec.binary.Base64;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -724,7 +725,10 @@ public class OathSession extends ApplicationSession<OathSession> {
             }
             messageDigest.update(salt);
             byte[] digest = messageDigest.digest();
-            return new String(Base64.encodeBase64(Arrays.copyOfRange(digest, 0, 16))).replaceAll("=", "");
+            return new String(
+                    Base64.encodeBase64(Arrays.copyOfRange(digest, 0, 16)),
+                    StandardCharsets.US_ASCII)
+                .replaceAll("=", "");
         }
     }
 }

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivEcSignatureSpi.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivEcSignatureSpi.java
@@ -80,11 +80,13 @@ public abstract class PivEcSignatureSpi extends SignatureSpi {
         throw new SignatureException("Not initialized");
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void engineSetParameter(String param, Object value) throws InvalidParameterException {
         throw new InvalidParameterException("ECDSA doesn't take parameters");
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Object engineGetParameter(String param) throws InvalidParameterException {
         throw new InvalidParameterException("ECDSA doesn't take parameters");

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivRsaSignatureSpi.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivRsaSignatureSpi.java
@@ -114,6 +114,7 @@ public class PivRsaSignatureSpi extends SignatureSpi {
         throw new SignatureException("Not initialized");
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected void engineSetParameter(String param, Object value) throws InvalidParameterException {
         try {
@@ -124,6 +125,7 @@ public class PivRsaSignatureSpi extends SignatureSpi {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Object engineGetParameter(String param) throws InvalidParameterException {
         if (delegate != null) {


### PR DESCRIPTION
Fixes following issues:

- [ANDSDK-82](https://yubico.atlassian.net/browse/ANDSDK-82) - DeviceInfo serial number wrongly set to 0
- [ANDSDK-84](https://yubico.atlassian.net/browse/ANDSDK-84) - No static method encodeBase64String
- [ANDSDK-101](https://yubico.atlassian.net/browse/ANDSDK-101) - bump Kotlin version
- [ANDSDK-102](https://yubico.atlassian.net/browse/ANDSDK-102) - fix gradle warning
- [ANDSDK-85](https://yubico.atlassian.net/browse/ANDSDK-85) - suppress warnings
- [ANDSDK-86](https://yubico.atlassian.net/browse/ANDSDK-86) - suppress warnings