### PR TITLE
Rename default git branch to main

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '25 16 * * 0'
 

--- a/pom.gradle
+++ b/pom.gradle
@@ -1,7 +1,7 @@
 project.ext.pomData = {
     name = project.ext.pomName //"Yubico YubiKit ${project.name.capitalize()}"
     description = project.description
-    url = "https://github.com/Yubico/yubikit-android/tree/master/${project.name}"
+    url = "https://github.com/Yubico/yubikit-android/tree/main/${project.name}"
     licenses {
         license {
             name = 'The Apache License, Version 2.0'


### PR DESCRIPTION
We are going to change the default branch name for this project to `main`.
This PR changes `master` to `main` where appropriate. 