### PR TITLE
Use Extended length APDUs only on compatible adapters and devices

### DIFF
--- a/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcSmartCardConnection.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcSmartCardConnection.java
@@ -52,6 +52,11 @@ public class NfcSmartCardConnection implements SmartCardConnection {
     }
 
     @Override
+    public boolean isExtendedLengthApduSupported() {
+        return card.isExtendedLengthApduSupported();
+    }
+
+    @Override
     public byte[] sendAndReceive(byte[] apdu) throws IOException {
         Logger.d("sent: " + StringUtils.bytesToHex(apdu));
         byte[] received = card.transceive(apdu);

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnection.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnection.java
@@ -97,6 +97,15 @@ public class UsbSmartCardConnection extends UsbYubiKeyConnection implements Smar
         return Transport.USB;
     }
 
+    /**
+     * This connection generally supports Extended length APDUs. This can be limited by firmware
+     * version of connected YubiKey.
+     */
+    @Override
+    public boolean isExtendedLengthApduSupported() {
+        return true;
+    }
+
     @Override
     public byte[] sendAndReceive(byte[] apdu) throws IOException {
         return transceive(REQUEST_MESSAGE_TYPE, apdu);

--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/SmartCardConnection.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/SmartCardConnection.java
@@ -40,4 +40,13 @@ public interface SmartCardConnection extends YubiKeyConnection {
      * @return the physical transport used for the connection.
      */
     Transport getTransport();
+
+    /**
+     * Standard APDUs have a 1-byte length field, allowing a maximum of 255 payload bytes,
+     * which results in a maximum APDU length of 261 bytes. Extended length APDUs have a 3-byte length field,
+     * allowing 65535 payload bytes.
+     *
+     * @return true if this connection object supports Extended length APDUs.
+     */
+    boolean isExtendedLengthApduSupported();
 }

--- a/piv/src/main/java/com/yubico/yubikit/piv/PivSession.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/PivSession.java
@@ -199,7 +199,9 @@ public class PivSession extends ApplicationSession<PivSession> {
         protocol.select(AID);
         version = Version.fromBytes(protocol.sendAndReceive(new Apdu(0, INS_GET_VERSION, 0, 0, null)));
         protocol.enableWorkarounds(version);
-        if (version.isAtLeast(4, 0, 0)) {
+
+        // use extended length APDUs on compatible connections and devices
+        if (connection.isExtendedLengthApduSupported() && version.isAtLeast(4, 0, 0)) {
             protocol.setApduFormat(ApduFormat.EXTENDED);
         }
     }


### PR DESCRIPTION
This PR fixes a bug where the SDK used Extended length APDUs on incompatible NFC adapters. 

[Android documentation](https://developer.android.com/reference/android/nfc/tech/IsoDep#isExtendedLengthApduSupported()) says following about Extended length APDUs:

> Standard APDUs have a 1-byte length field, allowing a maximum of 255 payload bytes, which results in a maximum APDU length of 261 bytes.
> 
> Extended length APDUs have a 3-byte length field, allowing 65535 payload bytes.
> 
> Some NFC adapters, like the one used in the Nexus S and the Galaxy Nexus do not support extended length APDUs. They are expected to be well-supported in the future though. Use this method to check for extended length APDU support.

The issue is easily reproduced on a "compatible" device (without Extended APDUs support) by generating an EC key with the AndroidDemo app. During the key generation, an APDU with size greater than the max Standard length APDU size is sent over the connection and following exception is thrown by the Android framework:

```
E/yubikit: Error:
    java.io.IOException: Transceive length exceeds supported maximum
        at android.nfc.TransceiveResult.getResponseOrThrow(TransceiveResult.java:50)
        at android.nfc.tech.BasicTagTechnology.transceive(BasicTagTechnology.java:151)
        at android.nfc.tech.IsoDep.transceive(IsoDep.java:172)
```

To avoid sending Extended length APDUs over incompatible connections, the code uses [`IsoDep.isExtendedLengthApduSupported`](https://developer.android.com/reference/android/nfc/tech/IsoDep#isExtendedLengthApduSupported()) to get the proper capability of the NFC adapter.

Note: We always mark USB connections to YubiKey as capable of Extended Length APDUs - the SmartCardProtocol checks the firmware version of connected YubiKey to decide the support - only FW >= 4.0.0 will use Extended length APDUs.