### PR TITLE
Conditionally disable release signing 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           java-version: 11
       - name: Build with Gradle
-        run: ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
+        run: SIGN=false ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
 
       - name: Upload jars
         uses: actions/upload-artifact@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,9 @@ jobs:
         with:
           java-version: 11
       - name: Build with Gradle
-        run: SIGN=false ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
+        env:
+          SIGN: false
+        run: ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
 
       - name: Upload jars
         uses: actions/upload-artifact@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,9 +14,7 @@ jobs:
         with:
           java-version: 11
       - name: Build with Gradle
-        env:
-          SIGN: false
-        run: ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
+        run: SIGN=false ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
 
       - name: Upload jars
         uses: actions/upload-artifact@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           java-version: 11
       - name: Build with Gradle
-        run: SIGN=false ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
+        run: NO_GPG_SIGN=true ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
 
       - name: Upload jars
         uses: actions/upload-artifact@v2

--- a/android/publish.gradle
+++ b/android/publish.gradle
@@ -1,7 +1,9 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
+ext.signingDisabled = System.getenv("SIGN") == "false"
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+ext.signRelease = isReleaseVersion && !signingDisabled
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
@@ -59,7 +61,7 @@ afterEvaluate {
         }
     }
     tasks.withType(Sign) {
-        onlyIf { isReleaseVersion }
+        onlyIf { signRelease }
     }
     signing {
         useGpgCmd()

--- a/android/publish.gradle
+++ b/android/publish.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-ext.signingDisabled = System.getenv("SIGN") == "false"
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
-ext.signRelease = isReleaseVersion && !signingDisabled
 
 task javadoc(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
@@ -61,7 +59,7 @@ afterEvaluate {
         }
     }
     tasks.withType(Sign) {
-        onlyIf { signRelease }
+        onlyIf { isReleaseVersion && System.getenv("NO_GPG_SIGN") != "true" }
     }
     signing {
         useGpgCmd()

--- a/doc/publish.adoc
+++ b/doc/publish.adoc
@@ -39,3 +39,8 @@ Publishing can also be done for a single module:
   ./gradlew modulename:publish
 
 When publishing to Sonatype you will need to log in to the staging repo to close and release.
+
+When building release, gradle will by default execute signing tasks. When this is not desired, for
+example during CI builds, it is possible to disable signing with `SIGN` env variable set to `FALSE`.
+
+  SIGN=false ./gradlew publishToMaven

--- a/doc/publish.adoc
+++ b/doc/publish.adoc
@@ -41,6 +41,6 @@ Publishing can also be done for a single module:
 When publishing to Sonatype you will need to log in to the staging repo to close and release.
 
 When building release, gradle will by default execute signing tasks. When this is not desired, for
-example during CI builds, it is possible to disable signing with `SIGN` env variable set to `false`.
+example during CI builds, it is possible to disable signing with `NO_GPG_SIGN` env variable set to `true`.
 
-  SIGN=false ./gradlew publishToMaven
+  NO_GPG_SIGN=true ./gradlew publishToMaven

--- a/doc/publish.adoc
+++ b/doc/publish.adoc
@@ -41,6 +41,6 @@ Publishing can also be done for a single module:
 When publishing to Sonatype you will need to log in to the staging repo to close and release.
 
 When building release, gradle will by default execute signing tasks. When this is not desired, for
-example during CI builds, it is possible to disable signing with `SIGN` env variable set to `FALSE`.
+example during CI builds, it is possible to disable signing with `SIGN` env variable set to `false`.
 
   SIGN=false ./gradlew publishToMaven

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,7 +1,9 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
+ext.signingDisabled = System.getenv("SIGN") == "false"
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+ext.signRelease = isReleaseVersion && !signingDisabled
 
 java {
     withJavadocJar()
@@ -18,7 +20,7 @@ publishing {
         }
     }
     tasks.withType(Sign) {
-        onlyIf { isReleaseVersion }
+        onlyIf { signRelease }
     }
 
     signing {

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,9 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-ext.signingDisabled = System.getenv("SIGN") == "false"
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
-ext.signRelease = isReleaseVersion && !signingDisabled
 
 java {
     withJavadocJar()
@@ -20,7 +18,7 @@ publishing {
         }
     }
     tasks.withType(Sign) {
-        onlyIf { signRelease }
+        onlyIf { isReleaseVersion && System.getenv("NO_GPG_SIGN") != "true" }
     }
 
     signing {


### PR DESCRIPTION
When using version string for release versions (without -SNAPSHOT postfix) signing is executed automatically during `publish` and `publishToMavenLocal` gradle tasks. This makes most of the CI builds fail in release branch, because the CI nodes don't have signing configuration/possibility.

This PR adds an option to opt out from signing by using environmental variable `NO_GPG_SIGN` set to `true`.

Example:

`NO_GPG_SIGN=true ./gradlew publishToMavenLocal`

When `NO_GPG_SIGN` is not defined or is not `true`, gradle will execute signing tasks.
