### PR TITLE
[AndroidDemo] use ActivityResultLauncher<Unit>.launch extension

### DIFF
--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/yubiotp/YubiOtpFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/yubiotp/YubiOtpFragment.kt
@@ -23,6 +23,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.launch
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.yubico.yubikit.android.app.MainViewModel
@@ -102,7 +103,7 @@ class YubiOtpFragment : Fragment() {
 
         binding.btnRequestOtp.setOnClickListener {
             activityViewModel.setYubiKeyListenerEnabled(false)
-            requestOtp.launch(null)
+            requestOtp.launch()
         }
     }
 }


### PR DESCRIPTION
`launch(null)` passes null to non-null input parameter of `OtpContract` causing `java.lang.NullPointerException: Parameter specified as non-null is null`.

To fix this we use kotlin extension for `launch` for `ActivityResultLauncher<Unit>` and don't need to pass any input parameter.

See change-log for [androidx.activity 1.2.0-alpha05](https://developer.android.com/jetpack/androidx/releases/activity#1.2.0-alpha05)

> Kotlin extensions for launch have been added to the androidx.activity.result package for ActivityResultLauncher<Void> and ActivityResultLauncher<Unit> that remove the need to pass in null or Unit, respectively, mirroring that behavior from the previously invoke() extensions. ([aosp/1304674](https://android-review.googlesource.com/1304674), [aosp/1304675](https://android-review.googlesource.com/1304675))