### PR TITLE
Pin JDK version to 11.0.16

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,9 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          distribution: "zulu"
+          java-version: "11.0.16"
       - name: Build with Gradle
         run: NO_GPG_SIGN=true ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,8 +12,9 @@ jobs:
       - name: set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
-          java-version: "11.0.16"
+          distribution: 'zulu'
+          java-version: '11.0.16'
+
       - name: Build with Gradle
         run: NO_GPG_SIGN=true ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -33,6 +33,12 @@ jobs:
       with:
         languages: ${{ matrix.language }}
 
+    - name: Setup Java
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: '11.0.16'
+
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
 


### PR DESCRIPTION
Using JDK 11 in our setup-java automatically installs the latest JDK, which is currently 11.0.17 (see https://www.java.com/en/releases/).
 
This version has an issue with javadoc builds, described here: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8222091

Using this version to build yubikit-android fails our CI builds, this PR pins the JDK to the latest version without the issue - 11.0.16.