### PR TITLE
Add ATR/ATS getter to SmartCardConnection

### DIFF
--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/management/ManagementFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/management/ManagementFragment.kt
@@ -81,7 +81,8 @@ class ManagementFragment : YubiKeyFragment<ManagementSession, ManagementViewMode
                         "SKY: ${info.isSky}\n" +
                         "Locked: ${info.isLocked}\n" +
                         "Auto eject timeout: ${info.config.autoEjectTimeout}\n" +
-                        "Challenge response timeout: ${info.config.challengeResponseTimeout}"
+                        "Challenge response timeout: ${info.config.challengeResponseTimeout}\n" +
+                        "ATR: ${it.atr}"
                 checkboxIds.forEach { (transport, capability), id ->
                     view.findViewById<CheckBox>(id).let { checkbox ->
                         if (info.getSupportedCapabilities(transport) and capability.bit != 0) {

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/management/ManagementViewModel.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/management/ManagementViewModel.kt
@@ -28,6 +28,7 @@ import com.yubico.yubikit.core.application.ApplicationNotAvailableException
 import com.yubico.yubikit.core.fido.FidoConnection
 import com.yubico.yubikit.core.otp.OtpConnection
 import com.yubico.yubikit.core.smartcard.SmartCardConnection
+import com.yubico.yubikit.core.util.StringUtils
 import com.yubico.yubikit.management.DeviceInfo
 import com.yubico.yubikit.management.ManagementSession
 import com.yubico.yubikit.support.DeviceUtil
@@ -35,7 +36,8 @@ import java.io.IOException
 
 data class ConnectedDeviceInfo(
     val deviceInfo: DeviceInfo,
-    val type: YubiKeyType?
+    val type: YubiKeyType?,
+    val atr: String
 )
 
 class ManagementViewModel : YubiKeyViewModel<ManagementSession>() {
@@ -50,8 +52,10 @@ class ManagementViewModel : YubiKeyViewModel<ManagementSession>() {
 
         val readInfo: (YubiKeyConnection) -> Unit = {
             try {
+                val atr = StringUtils.bytesToHex((it as? SmartCardConnection)?.atr ?: byteArrayOf())
+
                 _deviceInfo.postValue(
-                    ConnectedDeviceInfo(DeviceUtil.readInfo(it, usbPid), usbPid?.type)
+                    ConnectedDeviceInfo(DeviceUtil.readInfo(it, usbPid), usbPid?.type, atr)
                 )
             } catch (e: Exception) {
                 Logger.d("Caught ${e.message} when reading device info")

--- a/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcSmartCardConnection.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcSmartCardConnection.java
@@ -69,4 +69,10 @@ public class NfcSmartCardConnection implements SmartCardConnection {
         card.close();
         Logger.d("nfc connection closed");
     }
+
+    @Override
+    public byte[] getAtr() {
+        byte[] historicalBytes = card.getHistoricalBytes();
+        return historicalBytes != null ? historicalBytes.clone() : new byte[]{};
+    }
 }

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnection.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnection.java
@@ -111,6 +111,11 @@ public class UsbSmartCardConnection extends UsbYubiKeyConnection implements Smar
         return transceive(REQUEST_MESSAGE_TYPE, apdu);
     }
 
+    @Override
+    public byte[] getAtr() {
+        return atr.clone();
+    }
+
     /**
      * Does the data exchange between phone and connected usb device with bulk messages
      * All bulk messages begin with a 10-bytes header, followed by message-specific data.

--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/SmartCardConnection.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/SmartCardConnection.java
@@ -49,4 +49,11 @@ public interface SmartCardConnection extends YubiKeyConnection {
      * @return true if this connection object supports Extended length APDUs.
      */
     boolean isExtendedLengthApduSupported();
+
+    /**
+     * Retrieve Answer to reset (or answer to select for NFC)
+     *
+     * @return data block returned for reset command
+     */
+    byte[] getAtr();
 }


### PR DESCRIPTION
Adds `public byte[] getAtr()` method to the SmartCardConnection interface for getting [Answer to Reset](https://en.wikipedia.org/wiki/Answer_to_reset). Implements the functionality for USB and NFC smart card connections.

Updates AndroidDemo application with example usage.
