### PR TITLE
Is NFC device a Yubico key?

### DIFF
--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/management/ManagementFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/management/ManagementFragment.kt
@@ -69,6 +69,12 @@ class ManagementFragment : YubiKeyFragment<ManagementSession, ManagementViewMode
         binding.applicationTable.visibility = View.GONE
         binding.save.visibility = View.GONE
 
+        viewModel.errorInfo.observe(viewLifecycleOwner) { errorString ->
+            errorString?.let {
+                binding.info.text = "Error:\n$it"
+            }
+        }
+
         viewModel.deviceInfo.observe(viewLifecycleOwner) {
             if (it != null) {
                 val info = it.deviceInfo

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/management/ManagementViewModel.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/management/ManagementViewModel.kt
@@ -32,6 +32,7 @@ import com.yubico.yubikit.core.util.StringUtils
 import com.yubico.yubikit.management.DeviceInfo
 import com.yubico.yubikit.management.ManagementSession
 import com.yubico.yubikit.support.DeviceUtil
+import com.yubico.yubikit.support.UnknownKeyException
 import java.io.IOException
 
 data class ConnectedDeviceInfo(
@@ -43,6 +44,9 @@ data class ConnectedDeviceInfo(
 class ManagementViewModel : YubiKeyViewModel<ManagementSession>() {
     private val _deviceInfo = MutableLiveData<ConnectedDeviceInfo?>()
     val deviceInfo: LiveData<ConnectedDeviceInfo?> = _deviceInfo
+
+    private val _errorInfo = MutableLiveData<String?>()
+    val errorInfo: LiveData<String?> = _errorInfo
 
     private fun readDeviceInfo(device: YubiKeyDevice) {
 
@@ -57,6 +61,8 @@ class ManagementViewModel : YubiKeyViewModel<ManagementSession>() {
                 _deviceInfo.postValue(
                     ConnectedDeviceInfo(DeviceUtil.readInfo(it, usbPid), usbPid?.type, atr)
                 )
+            } catch (unknownKeyException: UnknownKeyException) {
+                _errorInfo.postValue("This device is not a YubiKey neither a Security Key by Yubico")
             } catch (e: Exception) {
                 Logger.d("Caught ${e.message} when reading device info")
                 throw e

--- a/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
@@ -25,6 +25,9 @@ import android.nfc.tech.Ndef;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.YubiKeyConnection;
 import com.yubico.yubikit.core.YubiKeyDevice;
+import com.yubico.yubikit.core.application.ApplicationNotAvailableException;
+import com.yubico.yubikit.core.smartcard.SmartCardConnection;
+import com.yubico.yubikit.core.smartcard.SmartCardProtocol;
 import com.yubico.yubikit.core.util.Callback;
 import com.yubico.yubikit.core.util.Result;
 
@@ -139,4 +142,33 @@ public class NfcYubiKeyDevice implements YubiKeyDevice {
                 }
             });
     }
+
+    /**
+     * Probe the nfc device whether it is a Yubico hardware.
+     * @return true if this device is a YubiKey or a Security Key by Yubico.
+     */
+    public boolean isYubiKey() {
+        final byte[] managementAppId = new byte[]{(byte) 0xa0, 0x00, 0x00, 0x05, 0x27, 0x47, 0x11, 0x17};
+        final byte[] yubiOtpAppId = new byte[]{(byte) 0xa0, 0x00, 0x00, 0x05, 0x27, 0x20, 0x01, 0x01};
+
+        try (SmartCardConnection connection = openConnection(SmartCardConnection.class)) {
+            SmartCardProtocol protocol = new SmartCardProtocol(connection);
+            try {
+                protocol.select(managementAppId);
+                return true;
+            } catch (ApplicationNotAvailableException managementNotAvailable) {
+                try {
+                    protocol.select(yubiOtpAppId);
+                    return true;
+                } catch (ApplicationNotAvailableException yubiOtpNotAvailable) {
+                    // ignored
+                }
+            }
+        } catch (IOException ioException) {
+            // ignored
+        }
+
+        return false;
+    }
+
 }

--- a/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
@@ -26,6 +26,7 @@ import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.YubiKeyConnection;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.core.application.ApplicationNotAvailableException;
+import com.yubico.yubikit.core.smartcard.AppId;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
 import com.yubico.yubikit.core.smartcard.SmartCardProtocol;
 import com.yubico.yubikit.core.util.Callback;
@@ -148,19 +149,16 @@ public class NfcYubiKeyDevice implements YubiKeyDevice {
      * @return true if this device is a YubiKey or a Security Key by Yubico.
      */
     public boolean isYubiKey() {
-        final byte[] managementAppId = new byte[]{(byte) 0xa0, 0x00, 0x00, 0x05, 0x27, 0x47, 0x11, 0x17};
-        final byte[] yubiOtpAppId = new byte[]{(byte) 0xa0, 0x00, 0x00, 0x05, 0x27, 0x20, 0x01, 0x01};
-
         try (SmartCardConnection connection = openConnection(SmartCardConnection.class)) {
             SmartCardProtocol protocol = new SmartCardProtocol(connection);
             try {
-                protocol.select(managementAppId);
+                protocol.select(AppId.MANAGEMENT);
                 return true;
             } catch (ApplicationNotAvailableException managementNotAvailable) {
                 try {
-                    protocol.select(yubiOtpAppId);
+                    protocol.select(AppId.OTP);
                     return true;
-                } catch (ApplicationNotAvailableException yubiOtpNotAvailable) {
+                } catch (ApplicationNotAvailableException otpNotAvailable) {
                     // ignored
                 }
             }

--- a/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
+++ b/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
@@ -288,7 +288,7 @@ public class DeviceUtil {
      *                                  {@link OtpConnection} or {@link FidoConnection}
      */
     public static DeviceInfo readInfo(YubiKeyConnection connection, @Nullable UsbPid pid)
-            throws IOException, UnknownKeyException {
+            throws IOException, IllegalArgumentException, UnknownKeyException {
 
         YubiKeyType keyType = null;
         int interfaces = 0;

--- a/support/src/main/java/com/yubico/yubikit/support/UnknownKeyException.java
+++ b/support/src/main/java/com/yubico/yubikit/support/UnknownKeyException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2022 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.support;
+
+public class UnknownKeyException extends RuntimeException {
+}


### PR DESCRIPTION
It is simple to verify that a USB device is known YubiKey by comparing the USB PID values. Because this is a bit more complicated for NFC devices, this PR adds two different methods which clients can use to verify that the NFC connection was created by YubiKey.

1. `DeviceUtil.readInfo(YubiKeyConnection connection, UsbPid)` will throw `UnknownKeyException` if the device connected through `connection` is not manufactured by Yubico. To use this method, one needs to add dependency to the `:support` module which might not be ideal.
2. `bool NfcYubiKeyDevice.isYubiKey()` will return `true` if the device is manufactured by Yubico. The disadvantage of this method is that it opens several sessions (Management and YubiOTP) on the NFC device, which might degrade the performance if used every time when a NFC connection is observed.