### PR TITLE
Catch SecurityException when NFC key is removed

### DIFF
--- a/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
@@ -102,7 +102,7 @@ public class NfcYubiKeyDevice implements YubiKeyDevice {
                     //noinspection BusyWait
                     Thread.sleep(250);
                 }
-            } catch (InterruptedException | IOException e) {
+            } catch (SecurityException | InterruptedException | IOException e) {
                 // Ignore
             }
             onRemoved.run();


### PR DESCRIPTION
Android 13 introduced the following change:
- when accessing a nfc tag which is no longer connected, throw a SecurityException (see [commit](https://android.googlesource.com/platform/frameworks/base/+/113f3a4a1d9171db7456aa9ae8b0a2b50545c326%5E%21/)). 

Stack trace for reference:
```
java.lang.SecurityException: Permission Denial: Tag ( ID: 27 AB A7 25 01 A7 AB ) is out of date
  at android.nfc.Tag.getTagService(Tag.java:381)
  at android.nfc.tech.BasicTagTechnology.isConnected(BasicTagTechnology.java:63)
  at android.nfc.tech.IsoDep.isConnected(IsoDep.java:40)
  at com.yubico.yubikit.android.transport.nfc.NfcYubiKeyDevice.lambda$remove$0$com-yubico-yubikit-android-transport-nfc-NfcYubiKeyDevice(NfcYubiKeyDevice.java:102)
```

I couldn't find any official documentation for this, but the commit. #79 has been reproduced on Android 13 device and the issue is coming from that uncaught SecurityException.

This PR adds handling of the exception in the `remove` method to be able to call the `onRemoved` runnable. It is safe to ignore this SecurityException and it has no effect on devices running Android < 13.