### PR TITLE
Review naming of hardware keys

### DIFF
--- a/support/build.gradle
+++ b/support/build.gradle
@@ -4,9 +4,11 @@ dependencies {
     api project(':management')
     api project(':yubiotp')
 
+
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.jetbrains:annotations:15.0'
     testImplementation project(':testing')
 }
 

--- a/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
+++ b/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
@@ -510,6 +510,10 @@ public class DeviceUtil {
                 namePartsList.add("FIPS");
             }
 
+            if (info.isSky() && info.getSerialNumber() != null) {
+                namePartsList.add("- Enterprise Edition");
+            }
+
             StringBuilder builder = new StringBuilder();
             for (int partCount = 0; partCount < namePartsList.size(); partCount++)
             {

--- a/support/src/test/java/com/yubico/yubikit/support/DeviceUtilTest.java
+++ b/support/src/test/java/com/yubico/yubikit/support/DeviceUtilTest.java
@@ -52,5 +52,7 @@ public class DeviceUtilTest {
         Assert.assertEquals("Security Key C NFC", DeviceUtil.getName(infoSky(FormFactor.USB_C_KEYCHAIN), keyType));
         Assert.assertEquals("Security Key NFC - Enterprise Edition", DeviceUtil.getName(infoSkyEnterprise(FormFactor.USB_A_KEYCHAIN), keyType));
         Assert.assertEquals("Security Key C NFC - Enterprise Edition", DeviceUtil.getName(infoSkyEnterprise(FormFactor.USB_C_KEYCHAIN), keyType));
+        Assert.assertEquals("Security Key NFC Bio - Enterprise Edition", DeviceUtil.getName(infoSkyEnterprise(FormFactor.USB_A_BIO), keyType));
+        Assert.assertEquals("Security Key C NFC Bio - Enterprise Edition", DeviceUtil.getName(infoSkyEnterprise(FormFactor.USB_C_BIO), keyType));
     }
 }

--- a/support/src/test/java/com/yubico/yubikit/support/DeviceUtilTest.java
+++ b/support/src/test/java/com/yubico/yubikit/support/DeviceUtilTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.support;
+
+import static com.yubico.yubikit.support.Util.info;
+import static com.yubico.yubikit.support.Util.infoNfc;
+import static com.yubico.yubikit.support.Util.infoSky;
+import static com.yubico.yubikit.support.Util.infoSkyEnterprise;
+
+import com.yubico.yubikit.core.YubiKeyType;
+import com.yubico.yubikit.management.FormFactor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DeviceUtilTest {
+
+    YubiKeyType keyType = YubiKeyType.YK4;
+
+    @Test
+    public void getYubiKeyName() {
+        Assert.assertEquals("YubiKey 5A", DeviceUtil.getName(info(FormFactor.USB_A_KEYCHAIN), keyType));
+        Assert.assertEquals("YubiKey 5 NFC", DeviceUtil.getName(infoNfc(FormFactor.USB_A_KEYCHAIN), keyType));
+        Assert.assertEquals("YubiKey 5 Nano", DeviceUtil.getName(info(FormFactor.USB_A_NANO), keyType));
+        Assert.assertEquals("YubiKey 5C", DeviceUtil.getName(info(FormFactor.USB_C_KEYCHAIN), keyType));
+        Assert.assertEquals("YubiKey 5C NFC", DeviceUtil.getName(infoNfc(FormFactor.USB_C_KEYCHAIN), keyType));
+        Assert.assertEquals("YubiKey 5C Nano", DeviceUtil.getName(info(FormFactor.USB_C_NANO), keyType));
+        Assert.assertEquals("YubiKey 5Ci", DeviceUtil.getName(info(FormFactor.USB_C_LIGHTNING), keyType));
+        Assert.assertEquals("YubiKey Bio", DeviceUtil.getName(info(FormFactor.USB_A_BIO), keyType));
+        Assert.assertEquals("YubiKey C Bio", DeviceUtil.getName(info(FormFactor.USB_C_BIO), keyType));
+        Assert.assertEquals("YubiKey 5", DeviceUtil.getName(info(FormFactor.UNKNOWN), keyType));
+        Assert.assertEquals("YubiKey 5 NFC", DeviceUtil.getName(infoNfc(FormFactor.UNKNOWN), keyType));
+    }
+
+    @Test
+    public void getSecurityKeyName() {
+        Assert.assertEquals("Security Key NFC", DeviceUtil.getName(infoSky(FormFactor.USB_A_KEYCHAIN), keyType));
+        Assert.assertEquals("Security Key C NFC", DeviceUtil.getName(infoSky(FormFactor.USB_C_KEYCHAIN), keyType));
+        Assert.assertEquals("Security Key NFC - Enterprise Edition", DeviceUtil.getName(infoSkyEnterprise(FormFactor.USB_A_KEYCHAIN), keyType));
+        Assert.assertEquals("Security Key C NFC - Enterprise Edition", DeviceUtil.getName(infoSkyEnterprise(FormFactor.USB_C_KEYCHAIN), keyType));
+    }
+}

--- a/support/src/test/java/com/yubico/yubikit/support/Util.java
+++ b/support/src/test/java/com/yubico/yubikit/support/Util.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2022 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.support;
+
+import com.yubico.yubikit.core.Transport;
+import com.yubico.yubikit.core.Version;
+import com.yubico.yubikit.management.DeviceConfig;
+import com.yubico.yubikit.management.DeviceInfo;
+import com.yubico.yubikit.management.FormFactor;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Util {
+    static class InfoBuilder {
+
+        private final FormFactor formFactor;
+        private boolean isNfc = false;
+        private boolean isSky = false;
+        private @Nullable Integer serialNumber = null;
+
+        public InfoBuilder(FormFactor formFactor) {
+            this.formFactor = formFactor;
+        }
+
+        InfoBuilder withNfc() {
+            this.isNfc = true;
+            return this;
+        }
+
+        InfoBuilder isSky() {
+            this.isSky = true;
+            return this;
+        }
+
+        InfoBuilder withSerialNumber() {
+            this.serialNumber = 123;
+            return this;
+        }
+
+        public DeviceInfo build() {
+            Map<Transport, Integer> supportedCapabilities = new HashMap<Transport, Integer>() {
+                {
+                    put(Transport.USB, 0xFF);
+                    if (isNfc) {
+                        put(Transport.NFC, 0xFF);
+                    }
+                }
+            };
+            return new DeviceInfo(new DeviceConfig.Builder().build(),
+                    serialNumber,
+                    new Version(5, 3, 0),
+                    formFactor,
+                    supportedCapabilities,
+                    false, false, isSky);
+        }
+    }
+
+    static DeviceInfo info(FormFactor formFactor) {
+        return new InfoBuilder(formFactor).build();
+    }
+
+    static DeviceInfo infoNfc(FormFactor formFactor) {
+        return new InfoBuilder(formFactor).withNfc().build();
+    }
+
+    static DeviceInfo infoSky(FormFactor formFactor) {
+        return new InfoBuilder(formFactor).isSky().withNfc().build();
+    }
+
+    static DeviceInfo infoSkyEnterprise(FormFactor formFactor) {
+        return new InfoBuilder(formFactor).isSky().withNfc().withSerialNumber().build();
+    }
+}


### PR DESCRIPTION
Updates `DeviceUtil.getName()` to recognize known Yubico hardware keys.