### PR TITLE
Handle all exceptions when opening NFC connections

### DIFF
--- a/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
@@ -138,8 +138,12 @@ public class NfcYubiKeyDevice implements YubiKeyDevice {
             executorService.submit(() -> {
                 try (T connection = openConnection(connectionType)) {
                     callback.invoke(Result.success(connection));
-                } catch (IOException e) {
-                    callback.invoke(Result.failure(e));
+                } catch (IOException ioException) {
+                    callback.invoke(Result.failure(ioException));
+                } catch (Exception exception) {
+                    callback.invoke(Result.failure(new IOException("openConnection(" +
+                            connectionType.getSimpleName() + ") exception: " + exception.getMessage())
+                    ));
                 }
             });
     }


### PR DESCRIPTION
Exceptions which happened during openConnection and were not IOExceptions were swallowed by the task and never reported as a failure Result to the callback. 

This fix makes sure that any exception will be reported in the callback as an IOException, so that the callback can handle it.