### PR TITLE
[AndroidDemo] Update management screen properly for unknown devices.

### DIFF
--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/management/ManagementViewModel.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/management/ManagementViewModel.kt
@@ -63,7 +63,10 @@ class ManagementViewModel : YubiKeyViewModel<ManagementSession>() {
                 )
             } catch (unknownKeyException: UnknownKeyException) {
                 _errorInfo.postValue("This device is not a YubiKey neither a Security Key by Yubico")
+                _deviceInfo.postValue(null)
             } catch (e: Exception) {
+                _errorInfo.postValue("Caught ${e.message} when reading device info")
+                _deviceInfo.postValue(null)
                 Logger.d("Caught ${e.message} when reading device info")
                 throw e
             }


### PR DESCRIPTION
When an unknown device is used with the Demo App, the views could still show information from previously connected keys, such as enabled capabilities checkboxes. This is fixed by cleaning the livedata in exceptional conditions.  