### PR TITLE
Unpin JDK version

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,8 +12,8 @@ jobs:
       - name: set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
-          java-version: '11.0.16'
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Build with Gradle
         run: NO_GPG_SIGN=true ./gradlew --stacktrace check test build javadocJar publishToMavenLocal


### PR DESCRIPTION
Because of an issue in Java 11.0.17 (https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8222091) the version of JDK we used in our GitHub action was pinned to 11.0.16. This PR reverts this pinning, as the issue was fixed in 11.0.18. 

This PR also switches to use Eclipse Adoptium OpenJDK for building yubikit on GitHub.