### PR TITLE
Add core.internal.Logger

### DIFF
--- a/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcSmartCardConnection.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcSmartCardConnection.java
@@ -19,7 +19,7 @@ package com.yubico.yubikit.android.transport.nfc;
 import android.nfc.Tag;
 import android.nfc.tech.IsoDep;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
 import com.yubico.yubikit.core.util.StringUtils;

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbDeviceManager.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbDeviceManager.java
@@ -24,7 +24,7 @@ import android.content.IntentFilter;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 
 import org.slf4j.LoggerFactory;
 

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyDevice.java
@@ -22,7 +22,7 @@ import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
 
 import com.yubico.yubikit.android.transport.usb.connection.ConnectionManager;
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyConnection;

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyManager.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyManager.java
@@ -25,7 +25,7 @@ import com.yubico.yubikit.android.transport.usb.connection.OtpConnectionHandler;
 import com.yubico.yubikit.android.transport.usb.connection.SmartCardConnectionHandler;
 import com.yubico.yubikit.android.transport.usb.connection.UsbOtpConnection;
 import com.yubico.yubikit.android.transport.usb.connection.UsbSmartCardConnection;
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.util.Callback;
 
 import org.slf4j.LoggerFactory;

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnection.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnection.java
@@ -20,7 +20,7 @@ import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbEndpoint;
 import android.hardware.usb.UsbInterface;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
 import com.yubico.yubikit.core.util.StringUtils;

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbYubiKeyConnection.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbYubiKeyConnection.java
@@ -19,7 +19,7 @@ package com.yubico.yubikit.android.transport.usb.connection;
 import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbInterface;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.YubiKeyConnection;
 
 import org.slf4j.LoggerFactory;

--- a/android/src/main/java/com/yubico/yubikit/android/ui/YubiKeyPromptActivity.java
+++ b/android/src/main/java/com/yubico/yubikit/android/ui/YubiKeyPromptActivity.java
@@ -32,7 +32,7 @@ import com.yubico.yubikit.android.transport.nfc.NfcConfiguration;
 import com.yubico.yubikit.android.transport.nfc.NfcNotAvailable;
 import com.yubico.yubikit.android.transport.nfc.NfcYubiKeyManager;
 import com.yubico.yubikit.android.transport.usb.UsbConfiguration;
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.core.application.CommandState;
 

--- a/android/src/main/java/com/yubico/yubikit/android/ui/YubiKeyPromptConnectionAction.java
+++ b/android/src/main/java/com/yubico/yubikit/android/ui/YubiKeyPromptConnectionAction.java
@@ -21,7 +21,7 @@ import android.os.Bundle;
 
 import androidx.annotation.WorkerThread;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.YubiKeyConnection;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.core.application.CommandState;

--- a/core/src/main/java/com/yubico/yubikit/core/Logger.java
+++ b/core/src/main/java/com/yubico/yubikit/core/Logger.java
@@ -16,11 +16,6 @@
 
 package com.yubico.yubikit.core;
 
-
-import org.slf4j.event.Level;
-import org.slf4j.helpers.FormattingTuple;
-import org.slf4j.helpers.MessageFormatter;
-
 import javax.annotation.Nullable;
 
 /**
@@ -35,132 +30,6 @@ import javax.annotation.Nullable;
  */
 @Deprecated
 public abstract class Logger {
-
-    public static final class Internal {
-        private static void log(Level level, org.slf4j.Logger logger, String message) {
-            if (instance != null) {
-                if (Level.ERROR == level) {
-                    instance.logError(message, new Exception("Throwable missing in logger.error"));
-                } else {
-                    instance.logDebug(message);
-                }
-            } else {
-                switch (level) {
-                    case TRACE:
-                        logger.trace(message);
-                        break;
-                    case DEBUG:
-                        logger.debug(message);
-                        break;
-                    case INFO:
-                        logger.info(message);
-                        break;
-                    case WARN:
-                        logger.warn(message);
-                        break;
-                    case ERROR:
-                        logger.error(message);
-                        break;
-                }
-            }
-        }
-
-        private static void log(Level level, org.slf4j.Logger logger, String format, Object arg) {
-            if (instance != null) {
-                logToInstance(level, MessageFormatter.format(format, arg));
-            } else {
-                switch (level) {
-                    case TRACE:
-                        logger.trace(format, arg);
-                        break;
-                    case DEBUG:
-                        logger.debug(format, arg);
-                        break;
-                    case INFO:
-                        logger.info(format, arg);
-                        break;
-                    case WARN:
-                        logger.warn(format, arg);
-                        break;
-                    case ERROR:
-                        logger.error(format, arg);
-                        break;
-                }
-            }
-        }
-
-        private static void log(Level level, org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
-            if (instance != null) {
-                logToInstance(level, MessageFormatter.format(format, arg1, arg2));
-            } else {
-                switch (level) {
-                    case TRACE:
-                        logger.trace(format, arg1, arg2);
-                        break;
-                    case DEBUG:
-                        logger.debug(format, arg1, arg2);
-                        break;
-                    case INFO:
-                        logger.info(format, arg1, arg2);
-                        break;
-                    case WARN:
-                        logger.warn(format, arg1, arg2);
-                        break;
-                    case ERROR:
-                        logger.error(format, arg1, arg2);
-                        break;
-                }
-            }
-        }
-
-        private static void log(Level level, org.slf4j.Logger logger, String format, Object... args) {
-            if (instance != null) {
-                logToInstance(level, MessageFormatter.arrayFormat(format, args));
-            } else {
-                switch (level) {
-                    case TRACE:
-                        logger.trace(format, args);
-                        break;
-                    case DEBUG:
-                        logger.debug(format, args);
-                        break;
-                    case INFO:
-                        logger.info(format, args);
-                        break;
-                    case WARN:
-                        logger.warn(format, args);
-                        break;
-                    case ERROR:
-                        logger.error(format, args);
-                        break;
-                }
-            }
-        }
-
-        private static void logToInstance(Level level, FormattingTuple formattingTuple) {
-            if (instance != null) {
-
-                Throwable throwable = formattingTuple.getThrowable();
-                String message = formattingTuple.getMessage();
-
-                if (Level.ERROR == level) {
-                    if (throwable != null) {
-                        instance.logError(message, throwable);
-                    } else {
-                        instance.logError(message, new Throwable("Throwable missing in logger.error"));
-                    }
-                } else {
-                    if (throwable != null) {
-                        instance.logDebug(message + " Throwable: " + throwable.getMessage());
-                    } else {
-                        instance.logDebug(message);
-                    }
-                }
-            }
-        }
-
-
-    }
 
     /**
      * Specifies how debug messages are logged.
@@ -194,6 +63,7 @@ public abstract class Logger {
      */
     public static void setLogger(@Nullable Logger logger) {
         instance = logger;
+        com.yubico.yubikit.core.internal.Logger.setLogger(instance);
     }
 
     /**
@@ -212,85 +82,5 @@ public abstract class Logger {
         if (instance != null) {
             instance.logError(message, throwable);
         }
-    }
-
-    public static void trace(org.slf4j.Logger logger, String message) {
-        Internal.log(Level.TRACE, logger, message);
-    }
-
-    public static void trace(org.slf4j.Logger logger, String format, Object arg) {
-        Internal.log(Level.TRACE, logger, format, arg);
-    }
-
-    public static void trace(org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
-        Internal.log(Level.TRACE, logger, format, arg1, arg2);
-    }
-
-    public static void trace(org.slf4j.Logger logger, String format, Object... args) {
-        Internal.log(Level.TRACE, logger, format, args);
-    }
-
-    public static void debug(org.slf4j.Logger logger, String message) {
-        Internal.log(Level.DEBUG, logger, message);
-    }
-
-    public static void debug(org.slf4j.Logger logger, String format, Object arg) {
-        Internal.log(Level.DEBUG, logger, format, arg);
-    }
-
-    public static void debug(org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
-        Internal.log(Level.DEBUG, logger, format, arg1, arg2);
-    }
-
-    public static void debug(org.slf4j.Logger logger, String format, Object... args) {
-        Internal.log(Level.DEBUG, logger, format, args);
-    }
-
-    public static void info(org.slf4j.Logger logger, String message) {
-        Internal.log(Level.INFO, logger, message);
-    }
-
-    public static void info(org.slf4j.Logger logger, String format, Object arg) {
-        Internal.log(Level.INFO, logger, format, arg);
-    }
-
-    public static void info(org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
-        Internal.log(Level.INFO, logger, format, arg1, arg2);
-    }
-
-    public static void info(org.slf4j.Logger logger, String format, Object... args) {
-        Internal.log(Level.INFO, logger, format, args);
-    }
-
-    public static void warn(org.slf4j.Logger logger, String message) {
-        Internal.log(Level.WARN, logger, message);
-    }
-
-    public static void warn(org.slf4j.Logger logger, String format, Object arg) {
-        Internal.log(Level.WARN, logger, format, arg);
-    }
-
-    public static void warn(org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
-        Internal.log(Level.WARN, logger, format, arg1, arg2);
-    }
-
-    public static void warn(org.slf4j.Logger logger, String format, Object... args) {
-        Internal.log(Level.WARN, logger, format, args);
-    }
-
-    public static void error(org.slf4j.Logger logger, String message) {
-        Internal.log(Level.ERROR, logger, message);
-    }
-
-    public static void error(org.slf4j.Logger logger, String format, Object arg) {
-        Internal.log(Level.ERROR, logger, format, arg);
-    }
-
-    public static void error(org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
-        Internal.log(Level.ERROR, logger, format, arg1, arg2);
-    }
-
-    public static void error(org.slf4j.Logger logger, String format, Object... args) {
-        Internal.log(Level.ERROR, logger, format, args);
     }
 }

--- a/core/src/main/java/com/yubico/yubikit/core/application/CommandState.java
+++ b/core/src/main/java/com/yubico/yubikit/core/application/CommandState.java
@@ -15,7 +15,7 @@
  */
 package com.yubico.yubikit.core.application;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 
 import org.slf4j.LoggerFactory;
 

--- a/core/src/main/java/com/yubico/yubikit/core/fido/FidoProtocol.java
+++ b/core/src/main/java/com/yubico/yubikit/core/fido/FidoProtocol.java
@@ -15,7 +15,7 @@
  */
 package com.yubico.yubikit.core.fido;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Version;
 import com.yubico.yubikit.core.application.CommandState;
 import com.yubico.yubikit.core.util.StringUtils;

--- a/core/src/main/java/com/yubico/yubikit/core/internal/Logger.java
+++ b/core/src/main/java/com/yubico/yubikit/core/internal/Logger.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.core.internal;
+
+import org.slf4j.event.Level;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MessageFormatter;
+
+import javax.annotation.Nullable;
+
+/**
+ * Used internally in YubiKit, don't use from applications.
+ */
+@SuppressWarnings("unused")
+public final class Logger {
+
+    @Nullable
+    private static com.yubico.yubikit.core.Logger instance = null;
+
+    public static void setLogger(@Nullable com.yubico.yubikit.core.Logger logger) {
+        instance = logger;
+    }
+
+    public static void trace(org.slf4j.Logger logger, String message) {
+        log(Level.TRACE, logger, message);
+    }
+
+    public static void trace(org.slf4j.Logger logger, String format, Object arg) {
+        log(Level.TRACE, logger, format, arg);
+    }
+
+    public static void trace(org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
+        log(Level.TRACE, logger, format, arg1, arg2);
+    }
+
+    public static void trace(org.slf4j.Logger logger, String format, Object... args) {
+        log(Level.TRACE, logger, format, args);
+    }
+
+    public static void debug(org.slf4j.Logger logger, String message) {
+        log(Level.DEBUG, logger, message);
+    }
+
+    public static void debug(org.slf4j.Logger logger, String format, Object arg) {
+        log(Level.DEBUG, logger, format, arg);
+    }
+
+    public static void debug(org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
+        log(Level.DEBUG, logger, format, arg1, arg2);
+    }
+
+    public static void debug(org.slf4j.Logger logger, String format, Object... args) {
+        log(Level.DEBUG, logger, format, args);
+    }
+
+    public static void info(org.slf4j.Logger logger, String message) {
+        log(Level.INFO, logger, message);
+    }
+
+    public static void info(org.slf4j.Logger logger, String format, Object arg) {
+        log(Level.INFO, logger, format, arg);
+    }
+
+    public static void info(org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
+        log(Level.INFO, logger, format, arg1, arg2);
+    }
+
+    public static void info(org.slf4j.Logger logger, String format, Object... args) {
+        log(Level.INFO, logger, format, args);
+    }
+
+    public static void warn(org.slf4j.Logger logger, String message) {
+        log(Level.WARN, logger, message);
+    }
+
+    public static void warn(org.slf4j.Logger logger, String format, Object arg) {
+        log(Level.WARN, logger, format, arg);
+    }
+
+    public static void warn(org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
+        log(Level.WARN, logger, format, arg1, arg2);
+    }
+
+    public static void warn(org.slf4j.Logger logger, String format, Object... args) {
+        log(Level.WARN, logger, format, args);
+    }
+
+    public static void error(org.slf4j.Logger logger, String message) {
+        log(Level.ERROR, logger, message);
+    }
+
+    public static void error(org.slf4j.Logger logger, String format, Object arg) {
+        Logger.log(Level.ERROR, logger, format, arg);
+    }
+
+    public static void error(org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
+        Logger.log(Level.ERROR, logger, format, arg1, arg2);
+    }
+
+    public static void error(org.slf4j.Logger logger, String format, Object... args) {
+        Logger.log(Level.ERROR, logger, format, args);
+    }
+
+    private static void log(Level level, org.slf4j.Logger logger, String message) {
+        if (instance != null) {
+            if (Level.ERROR == level) {
+                com.yubico.yubikit.core.Logger.e(message, new Exception("Throwable missing in logger.error"));
+            } else {
+                com.yubico.yubikit.core.Logger.d(message);
+            }
+        } else {
+            switch (level) {
+                case TRACE:
+                    logger.trace(message);
+                    break;
+                case DEBUG:
+                    logger.debug(message);
+                    break;
+                case INFO:
+                    logger.info(message);
+                    break;
+                case WARN:
+                    logger.warn(message);
+                    break;
+                case ERROR:
+                    logger.error(message);
+                    break;
+            }
+        }
+    }
+
+    private static void log(Level level, org.slf4j.Logger logger, String format, Object arg) {
+        if (instance != null) {
+            logToInstance(level, MessageFormatter.format(format, arg));
+        } else {
+            switch (level) {
+                case TRACE:
+                    logger.trace(format, arg);
+                    break;
+                case DEBUG:
+                    logger.debug(format, arg);
+                    break;
+                case INFO:
+                    logger.info(format, arg);
+                    break;
+                case WARN:
+                    logger.warn(format, arg);
+                    break;
+                case ERROR:
+                    logger.error(format, arg);
+                    break;
+            }
+        }
+    }
+
+    private static void log(Level level, org.slf4j.Logger logger, String format, Object arg1, Object arg2) {
+        if (instance != null) {
+            logToInstance(level, MessageFormatter.format(format, arg1, arg2));
+        } else {
+            switch (level) {
+                case TRACE:
+                    logger.trace(format, arg1, arg2);
+                    break;
+                case DEBUG:
+                    logger.debug(format, arg1, arg2);
+                    break;
+                case INFO:
+                    logger.info(format, arg1, arg2);
+                    break;
+                case WARN:
+                    logger.warn(format, arg1, arg2);
+                    break;
+                case ERROR:
+                    logger.error(format, arg1, arg2);
+                    break;
+            }
+        }
+    }
+
+    private static void log(Level level, org.slf4j.Logger logger, String format, Object... args) {
+        if (instance != null) {
+            logToInstance(level, MessageFormatter.arrayFormat(format, args));
+        } else {
+            switch (level) {
+                case TRACE:
+                    logger.trace(format, args);
+                    break;
+                case DEBUG:
+                    logger.debug(format, args);
+                    break;
+                case INFO:
+                    logger.info(format, args);
+                    break;
+                case WARN:
+                    logger.warn(format, args);
+                    break;
+                case ERROR:
+                    logger.error(format, args);
+                    break;
+            }
+        }
+    }
+
+    private static void logToInstance(Level level, FormattingTuple formattingTuple) {
+        if (instance != null) {
+
+            Throwable throwable = formattingTuple.getThrowable();
+            String message = formattingTuple.getMessage();
+
+            if (Level.ERROR == level) {
+                if (throwable != null) {
+                    com.yubico.yubikit.core.Logger.e(message, throwable);
+                } else {
+                    com.yubico.yubikit.core.Logger.e(message, new Throwable("Throwable missing in logger.error"));
+                }
+            } else {
+                if (throwable != null) {
+                    com.yubico.yubikit.core.Logger.d(message + " Throwable: " + throwable.getMessage());
+                } else {
+                    com.yubico.yubikit.core.Logger.d(message);
+                }
+            }
+        }
+    }
+
+
+}

--- a/core/src/main/java/com/yubico/yubikit/core/internal/package-info.java
+++ b/core/src/main/java/com/yubico/yubikit/core/internal/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@PackageNonnullByDefault
+package com.yubico.yubikit.core.internal;
+
+import com.yubico.yubikit.core.PackageNonnullByDefault;

--- a/core/src/main/java/com/yubico/yubikit/core/otp/OtpProtocol.java
+++ b/core/src/main/java/com/yubico/yubikit/core/otp/OtpProtocol.java
@@ -15,7 +15,7 @@
  */
 package com.yubico.yubikit.core.otp;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Version;
 import com.yubico.yubikit.core.application.CommandException;
 import com.yubico.yubikit.core.application.CommandState;

--- a/management/src/main/java/com/yubico/yubikit/management/ManagementSession.java
+++ b/management/src/main/java/com/yubico/yubikit/management/ManagementSession.java
@@ -16,7 +16,7 @@
 
 package com.yubico.yubikit.management;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.UsbInterface;
 import com.yubico.yubikit.core.Version;

--- a/oath/src/main/java/com/yubico/yubikit/oath/OathSession.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/OathSession.java
@@ -16,7 +16,7 @@
 
 package com.yubico.yubikit.oath;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Version;
 import com.yubico.yubikit.core.smartcard.AppId;
 import com.yubico.yubikit.core.application.ApplicationNotAvailableException;

--- a/piv/src/main/java/com/yubico/yubikit/piv/PivSession.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/PivSession.java
@@ -16,7 +16,7 @@
 
 package com.yubico.yubikit.piv;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Version;
 import com.yubico.yubikit.core.smartcard.AppId;
 import com.yubico.yubikit.core.application.ApplicationNotAvailableException;

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivCipherSpi.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivCipherSpi.java
@@ -16,7 +16,7 @@
 
 package com.yubico.yubikit.piv.jca;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.util.Callback;
 import com.yubico.yubikit.core.util.Result;
 import com.yubico.yubikit.piv.KeyType;

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivProvider.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivProvider.java
@@ -16,7 +16,7 @@
 
 package com.yubico.yubikit.piv.jca;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.util.Callback;
 import com.yubico.yubikit.core.util.Result;
 import com.yubico.yubikit.piv.KeyType;

--- a/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
+++ b/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
@@ -16,7 +16,7 @@
 
 package com.yubico.yubikit.support;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.UsbInterface;
 import com.yubico.yubikit.core.UsbPid;

--- a/yubiotp/src/main/java/com/yubico/yubikit/yubiotp/YubiOtpSession.java
+++ b/yubiotp/src/main/java/com/yubico/yubikit/yubiotp/YubiOtpSession.java
@@ -16,7 +16,7 @@
 
 package com.yubico.yubikit.yubiotp;
 
-import com.yubico.yubikit.core.Logger;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.Version;
 import com.yubico.yubikit.core.YubiKeyConnection;


### PR DESCRIPTION
We are in the state of deprecating `core.Logger` class in favor of `slf4j`. Internally in the libraries we use adapting calls (`Logger.debug(logger, msg)` etc.) which were added into the public `Logger` interface. This works great, but creates a lot of warnings that the libraries use deprecated class. The amount of the warnings might cause that we overlook an important warning.

This PR moves out the methods into a new _internal_ class. This effectively removes the warnings when using `core.internal.Logger.debug(logger, msg)` and similar calls.

This class has a javadoc informing that it should not be used by applications and is in a new `internal` package. It will be removed together with the deprecated `core.Logger` in the next major library release.