### PR TITLE
Build system updates

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,24 +8,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Build with Gradle
         run: NO_GPG_SIGN=true ./gradlew --stacktrace check test build javadocJar publishToMavenLocal
 
       - name: Upload jars
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: maven-repo
           path: ~/.m2/repository/com/yubico/yubikit/
 
       - name: Upload build reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: build-reports

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -36,8 +36,8 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
-        distribution: 'zulu'
-        java-version: '11.0.16'
+        distribution: 'temurin'
+        java-version: '17'
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2

--- a/AndroidDemo/build.gradle
+++ b/AndroidDemo/build.gradle
@@ -39,11 +39,9 @@ android {
 
     buildFeatures {
         viewBinding true
-        buildConfig true
     }
 
     namespace = 'com.yubico.yubikit.android.app'
-
 }
 
 dependencies {

--- a/AndroidDemo/build.gradle
+++ b/AndroidDemo/build.gradle
@@ -1,8 +1,13 @@
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+    id 'project-convention-spotbugs'
+    id 'project-convention-logging'
+}
+
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 19
@@ -34,16 +39,16 @@ android {
 
     buildFeatures {
         viewBinding true
+        buildConfig true
     }
 
     namespace = 'com.yubico.yubikit.android.app'
+
 }
 
 dependencies {
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.6'
-
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 
     implementation project(':android')
     implementation project(':management')
@@ -52,18 +57,18 @@ dependencies {
     implementation project(':piv')
     implementation project(':support')
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.3'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.fragment:fragment-ktx:1.5.5'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.fragment:fragment-ktx:1.5.7'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.2.1'
+    implementation 'androidx.recyclerview:recyclerview:1.3.0'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'com.google.android.material:material:1.9.0'
 
     // Lifecycle
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
 
     // Navigation
@@ -82,4 +87,8 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
+}
+
+configurations.implementation {
+    exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
 }

--- a/AndroidDemo/build.gradle
+++ b/AndroidDemo/build.gradle
@@ -48,7 +48,7 @@ android {
 
 dependencies {
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.6'
 
     implementation project(':android')
     implementation project(':management')
@@ -87,8 +87,4 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
-}
-
-configurations.implementation {
-    exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,11 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.library'
+    id 'project-convention-spotbugs'
+    id 'project-convention-logging'
+}
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 19
@@ -32,16 +36,12 @@ android {
 dependencies {
     api project(':core')
 
-    implementation 'org.slf4j:slf4j-api:2.0.7'
-
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.2.2'
-    compileOnly 'androidx.annotation:annotation:1.5.0'
+    compileOnly 'androidx.annotation:annotation:1.6.0'
 
     testImplementation project(':testing')
     testImplementation 'androidx.test.ext:junit:1.1.5'
-    testImplementation 'org.robolectric:robolectric:4.5.1'
-    testImplementation 'org.mockito:mockito-core:4.10.0'
+    testImplementation 'org.robolectric:robolectric:4.9'
+    testImplementation 'org.mockito:mockito-core:5.3.0'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:runner:1.5.2'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     api project(':core')
 
     compileOnly 'androidx.annotation:annotation:1.6.0'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.3'
 
     testImplementation project(':testing')
     testImplementation 'androidx.test.ext:junit:1.1.5'

--- a/build.gradle
+++ b/build.gradle
@@ -2,22 +2,21 @@
 
 buildscript {
     ext {
-        kotlin_version = '1.7.21'
+        kotlin_version = '1.8.20'
     }
     repositories {
         mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 plugins {
-    id 'java-library'
     id 'maven-publish'
-    id "com.github.spotbugs" version "4.5.0"
+    id 'com.github.spotbugs' version '5.0.14'
 }
 
 allprojects {
@@ -32,18 +31,22 @@ subprojects {
     version = '2.2.1-SNAPSHOT'
     ext.pomName = "Yubico YubiKit ${project.name.capitalize()}"
 
-    apply plugin: 'com.github.spotbugs'
+    tasks.withType(Javadoc).tap {
+        configureEach {
+            options.addStringOption('Xdoclint:all,-missing', '-quiet')
+        }
+    }
 
-    tasks.withType(Javadoc) {
-        options.addStringOption('Xdoclint:all,-missing', '-quiet')
+    //noinspection UnnecessaryQualifiedReference
+    tasks.withType(com.github.spotbugs.snom.SpotBugsTask).tap {
+        configureEach {
+            group 'verification'
+            reports {
+                xml.enabled = true
+                html.enabled = true
+            }
+        }
     }
 }
 
-dependencies {
-    spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.11.0'
-}
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-}

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,20 @@ allprojects {
         mavenCentral()
         google()
     }
+
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile).configureEach {
+            options.compilerArgs.addAll(['-Xlint:deprecation', '-Xlint:unchecked'])
+        }
+    }
+
     group = 'com.yubico.yubikit'
 }
 
 subprojects {
     version = '2.2.1-SNAPSHOT'
     ext.pomName = "Yubico YubiKit ${project.name.capitalize()}"
+
 
     tasks.withType(Javadoc).tap {
         configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -56,5 +56,3 @@ subprojects {
         }
     }
 }
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -48,10 +48,14 @@ subprojects {
     //noinspection UnnecessaryQualifiedReference
     tasks.withType(com.github.spotbugs.snom.SpotBugsTask).tap {
         configureEach {
-            group 'verification'
-            reports {
-                xml.enabled = true
-                html.enabled = true
+            if (it.name == 'spotbugsTest' || it.name == 'spotbugsDebug') {
+                enabled = false
+            } else {
+                group 'verification'
+                reports {
+                    xml.enabled = true
+                    html.enabled = true
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'groovy-gradle-plugin'
+}

--- a/buildSrc/src/main/groovy/project-convention-java-library.gradle
+++ b/buildSrc/src/main/groovy/project-convention-java-library.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'java-library'
+    id 'project-convention-spotbugs'
+}
+
+java {
+    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
+compileJava {
+    options.compilerArgs.addAll(['--release', '8'])
+}

--- a/buildSrc/src/main/groovy/project-convention-logging.gradle
+++ b/buildSrc/src/main/groovy/project-convention-logging.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    implementation 'org.slf4j:slf4j-api:2.0.7'
+}

--- a/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
+++ b/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'com.github.spotbugs'
+}
+
+dependencies {
+    spotbugs 'com.github.spotbugs:spotbugs:4.7.3'
+    spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.12.0'
+
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.3'
+
+    testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
+}
+
+spotbugs {
+    // ignore failures unless all issues are fixed
+    // find current issues in reports/spotbugs for each library
+    ignoreFailures = true
+
+    showStackTraces = true
+    showProgress = true
+
+    effort = "max"
+    reportLevel = "low"
+
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+}

--- a/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
+++ b/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
@@ -18,7 +18,7 @@ spotbugs {
     ignoreFailures = true
 
     showStackTraces = true
-    showProgress = true
+    showProgress = false
 
     effort = "max"
     reportLevel = "low"

--- a/buildSrc/src/main/groovy/yubikit-java-library.gradle
+++ b/buildSrc/src/main/groovy/yubikit-java-library.gradle
@@ -1,0 +1,10 @@
+plugins {
+    id 'project-convention-java-library'
+    id 'project-convention-logging'
+}
+
+dependencies {
+
+    testImplementation project(':testing')
+    testImplementation 'junit:junit:4.13.2'
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,18 +1,7 @@
-apply plugin: 'java-library'
+apply plugin: 'yubikit-java-library'
 
 dependencies {
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-
     api 'org.slf4j:slf4j-api:2.0.7'
-
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation project(':testing')
-}
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-compileJava {
-    options.compilerArgs.addAll(['--release', '8'])
 }
 
 description = "The core module is the base library, with common interfaces and utilities used throughout the rest of the modules."

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 15 09:29:05 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
-zipStoreBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 15 09:29:05 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 11 15:31:08 CET 2023
+#Mon May 15 09:29:05 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/management/build.gradle
+++ b/management/build.gradle
@@ -1,17 +1,7 @@
-apply plugin: 'java-library'
+apply plugin: 'yubikit-java-library'
 
 dependencies {
     api project(':core')
-
-    implementation 'org.slf4j:slf4j-api:2.0.7'
-
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-}
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-compileJava {
-    options.compilerArgs.addAll(['--release', '8'])
 }
 
 ext.pomName = "Yubico YubiKit Management"

--- a/oath/build.gradle
+++ b/oath/build.gradle
@@ -1,21 +1,9 @@
-apply plugin: 'java-library'
+apply plugin: 'yubikit-java-library'
 
 dependencies {
     api project(':core')
 
-    implementation 'org.slf4j:slf4j-api:2.0.7'
-
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-
     implementation 'commons-codec:commons-codec:1.15'
-
-    testImplementation 'junit:junit:4.13.2'
-}
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-compileJava {
-    options.compilerArgs.addAll(['--release', '8'])
 }
 
 ext.pomName = "Yubico YubiKit ${project.name.capitalize()}"

--- a/piv/build.gradle
+++ b/piv/build.gradle
@@ -1,20 +1,7 @@
-apply plugin: 'java-library'
+apply plugin: 'yubikit-java-library'
 
 dependencies {
     api project(':core')
-
-    implementation 'org.slf4j:slf4j-api:2.0.7'
-
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation project(':testing')
-}
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-compileJava {
-    options.compilerArgs.addAll(['--release', '8'])
 }
 
 ext.pomName = "Yubico YubiKit ${project.name.capitalize()}"

--- a/piv/src/test/java/com/yubico/yubikit/piv/GzipUtilsTest.java
+++ b/piv/src/test/java/com/yubico/yubikit/piv/GzipUtilsTest.java
@@ -53,8 +53,8 @@ public class GzipUtilsTest {
 
     @Test
     public void compressesBigData() throws Throwable {
-        byte[] data = new byte[128 * 1024 * 1024]; // 128MB
-        for (int index = 0; index < 128 * 1024 * 1024; index++) {
+        byte[] data = new byte[128 * 1024]; // 128kB
+        for (int index = 0; index < 128 * 1024; index++) {
             data[index] = (byte) ((index & 0xff) - (byte) (index >> 8) * (index & 0xef));
         }
         compressAndDecompress(data);
@@ -80,7 +80,7 @@ public class GzipUtilsTest {
     private void compressAndDecompress(byte[] data) throws Throwable {
         byte[] c = compress(data);
         byte[] d = decompress(c);
-        if (data.length < 1024) { // don't log our 128MB test
+        if (data.length < 1024) { // don't log our 128kB test
             logger.trace("Data to compress  : {}", StringUtils.bytesToHex(data));
             logger.trace("compressed data   : {}", StringUtils.bytesToHex(c));
             logger.trace("Decompressed data : {}", StringUtils.bytesToHex(d));

--- a/piv/src/test/java/com/yubico/yubikit/piv/KeyTypeTest.java
+++ b/piv/src/test/java/com/yubico/yubikit/piv/KeyTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Yubico.
+ * Copyright (C) 2020-2023 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/piv/src/test/java/com/yubico/yubikit/piv/KeyTypeTest.java
+++ b/piv/src/test/java/com/yubico/yubikit/piv/KeyTypeTest.java
@@ -30,7 +30,6 @@ import java.security.spec.ECGenParameterSpec;
 public class KeyTypeTest {
     private static KeyPair secp256r1;
     private static KeyPair secp384r1;
-    private static KeyPair secp256k1;
     private static KeyPair secp521r1;
     private static KeyPair rsa1024;
     private static KeyPair rsa2048;
@@ -41,8 +40,6 @@ public class KeyTypeTest {
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(KeyType.Algorithm.EC.name());
         kpg.initialize(new ECGenParameterSpec("secp256r1"), new SecureRandom());
         secp256r1 = kpg.generateKeyPair();
-        kpg.initialize(new ECGenParameterSpec("secp256k1"), new SecureRandom());
-        secp256k1 = kpg.generateKeyPair();
         kpg.initialize(new ECGenParameterSpec("secp384r1"), new SecureRandom());
         secp384r1 = kpg.generateKeyPair();
         kpg.initialize(new ECGenParameterSpec("secp521r1"), new SecureRandom());
@@ -65,17 +62,6 @@ public class KeyTypeTest {
         MatcherAssert.assertThat(KeyType.fromKey(secp384r1.getPrivate()), CoreMatchers.is(KeyType.ECCP384));
         MatcherAssert.assertThat(KeyType.fromKey(secp384r1.getPublic()), CoreMatchers.is(KeyType.ECCP384));
     }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testP256K1Public() {
-        KeyType.fromKey(secp256k1.getPublic());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testP256K1Private() {
-        KeyType.fromKey(secp256k1.getPrivate());
-    }
-
 
     @Test(expected = IllegalArgumentException.class)
     public void testP521R1Public() {

--- a/publish.gradle
+++ b/publish.gradle
@@ -17,7 +17,7 @@ publishing {
             pom(pomData)
         }
     }
-    tasks.withType(Sign) {
+    tasks.withType(Sign).configureEach {
         onlyIf { isReleaseVersion && System.getenv("NO_GPG_SIGN") != "true" }
     }
 

--- a/support/build.gradle
+++ b/support/build.gradle
@@ -1,22 +1,8 @@
-apply plugin: 'java-library'
+apply plugin: 'yubikit-java-library'
 
 dependencies {
     api project(':management')
     api project(':yubiotp')
-
-    implementation 'org.slf4j:slf4j-api:2.0.7'
-
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
-    testImplementation project(':testing')
-}
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-compileJava {
-    options.compilerArgs.addAll(['--release', '8'])
 }
 
 ext.pomName = "Yubico YubiKit ${project.name.capitalize()}"

--- a/testing-android/build.gradle
+++ b/testing-android/build.gradle
@@ -1,7 +1,10 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.library'
+    id 'project-convention-logging'
+}
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     defaultConfig {
         minSdkVersion 19
@@ -34,9 +37,7 @@ android {
 
 dependencies {
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.6'
-
-    implementation 'org.slf4j:slf4j-api:2.0.7'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 
     implementation 'androidx.test:core:1.5.0'
     implementation 'androidx.test:rules:1.5.0'
@@ -47,7 +48,7 @@ dependencies {
     api project(':piv')
     api project(':testing')
 
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'com.google.android.material:material:1.9.0'
 
     implementation 'androidx.multidex:multidex:2.0.1'
 }

--- a/testing-android/build.gradle
+++ b/testing-android/build.gradle
@@ -37,7 +37,7 @@ android {
 
 dependencies {
 
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.6'
 
     implementation 'androidx.test:core:1.5.0'
     implementation 'androidx.test:rules:1.5.0'

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,8 +1,6 @@
-apply plugin: 'java-library'
+apply plugin: 'project-convention-java-library'
 
 dependencies {
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-
     implementation 'com.github.tony19:logback-android:3.0.0'
 
     api project(':core')
@@ -14,10 +12,4 @@ dependencies {
     api 'junit:junit:4.13.2'
 
     implementation 'org.bouncycastle:bcpkix-jdk15to18:1.71'
-}
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-compileJava {
-    options.compilerArgs.addAll(['--release', '8'])
 }

--- a/yubiotp/build.gradle
+++ b/yubiotp/build.gradle
@@ -1,20 +1,7 @@
-apply plugin: 'java-library'
+apply plugin: 'yubikit-java-library'
 
 dependencies {
     api project(':core')
-
-    implementation 'org.slf4j:slf4j-api:2.0.7'
-
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.2.2'
-
-    testImplementation 'junit:junit:4.13.2'
-}
-
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-compileJava {
-    options.compilerArgs.addAll(['--release', '8'])
 }
 
 ext.pomName = "Yubico YubiKit ${project.name.capitalize()}"


### PR DESCRIPTION
The SDK was using outdated dependencies, this PR updated the project dependencies (gradle, android gradle plugin, **spotbugs**, testing libraries).

Other improvements:
- added `buildSrc` which contains groovy plugins which are reused by the modules (logging, spotbugs, java compile options such as `targetCompatibility`/`sourceCompatibility`). The plugins are:
  -  `project-convention-java-library` - sets common compile options and dependencies
  -  `project-convention-logging` - sets dependencies for logging
  -  `project-convention-spotbugs` - sets options for spotbugs
  -  `yubikit-java-library` - uses the previous and is the plugin included in the java libraries
- reviewed spotbugs plugin we use and added html output, which will be present in the artifacts. 
- updated compatibility with jdk17