### PR TITLE
Adapt to Android 14

### DIFF
--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbDeviceManager.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbDeviceManager.java
@@ -118,7 +118,11 @@ final class UsbDeviceManager {
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
                     flags |= PendingIntent.FLAG_MUTABLE;
                 }
-                PendingIntent pendingUsbPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), flags);
+
+                Intent intent = new Intent(ACTION_USB_PERMISSION);
+                intent.setPackage(context.getPackageName());
+
+                PendingIntent pendingUsbPermissionIntent = PendingIntent.getBroadcast(context, 0, intent, flags);
                 UsbManager usbManager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
                 usbManager.requestPermission(usbDevice, pendingUsbPermissionIntent);
                 awaitingPermissions.add(usbDevice);

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbDeviceManager.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbDeviceManager.java
@@ -16,6 +16,7 @@
 
 package com.yubico.yubikit.android.transport.usb;
 
+import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -23,6 +24,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
 
 import com.yubico.yubikit.core.internal.Logger;
 
@@ -109,7 +111,7 @@ final class UsbDeviceManager {
         synchronized (awaitingPermissions) {
             if (!awaitingPermissions.contains(usbDevice)) {
                 if (awaitingPermissions.isEmpty()) {
-                    context.registerReceiver(permissionReceiver, new IntentFilter(ACTION_USB_PERMISSION));
+                    registerPermissionsReceiver(context, permissionReceiver);
                 }
                 Logger.debug(logger, "Requesting permission for UsbDevice: {}", usbDevice.getDeviceName());
                 int flags = 0;
@@ -201,6 +203,15 @@ final class UsbDeviceManager {
                     onPermission(context, device, usbManager.hasPermission(device));
                 }
             }
+        }
+    }
+
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    private static void registerPermissionsReceiver(Context context, PermissionBroadcastReceiver permissionReceiver) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(permissionReceiver, new IntentFilter(ACTION_USB_PERMISSION), Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(permissionReceiver, new IntentFilter(ACTION_USB_PERMISSION));
         }
     }
 }


### PR DESCRIPTION
Android 14 introduces behaviour changes for all apps and apps targeting Android 14. After review only the following behaviour changes needed to be updated:
- [Security - Restrictions to implicit and pending intents](https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents)
- [Security - Runtime-registered broadcasts receivers must specify export behavior](https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported)

This PR adapts YubiKit with the needed changes. Tested with Android 14 Beta 2.