### PR TITLE
Refactor handling of asymmetric keys

### DIFF
--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.lifecycleScope
 import com.yubico.yubikit.android.app.R
 import com.yubico.yubikit.android.app.databinding.FragmentPivCertifiateBinding
 import com.yubico.yubikit.android.app.ui.getSecret
+import com.yubico.yubikit.core.keys.PrivateKeyValues
 import com.yubico.yubikit.piv.KeyType
 import com.yubico.yubikit.piv.PinPolicy
 import com.yubico.yubikit.piv.Slot
@@ -152,7 +153,7 @@ class PivCertificateFragment : Fragment() {
             lifecycleScope.launch(Dispatchers.Main) {
                 pivViewModel.pendingAction.value = {
                     authenticate(pivViewModel.mgmtKeyType, pivViewModel.mgmtKey)
-                    putKey(slot, key, PinPolicy.DEFAULT, TouchPolicy.DEFAULT)
+                    putKey(slot, PrivateKeyValues.fromPrivateKey(key), PinPolicy.DEFAULT, TouchPolicy.DEFAULT)
                     putCertificate(slot, cert)
                     "Imported certificate ${cert.subjectDN} issued by ${cert.issuerDN}"
                 }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -15,7 +15,6 @@
     <string name="yubikit_otp_touch">Touch the sensor on your YubiKey.</string>
 
     <public name="yubikit_prompt_activity_title" type="string" />
-    <public name="yubikit_prompt_activity_title" type="string" />
     <public name="yubikit_prompt_image_desc" type="string" />
     <public name="yubikit_prompt_plug_in" type="string" />
     <public name="yubikit_prompt_plug_in_or_tap" type="string" />

--- a/core/src/main/java/com/yubico/yubikit/core/application/InvalidPinException.java
+++ b/core/src/main/java/com/yubico/yubikit/core/application/InvalidPinException.java
@@ -14,16 +14,24 @@
  * limitations under the License.
  */
 
-package com.yubico.yubikit.piv;
+package com.yubico.yubikit.core.application;
 
 /**
  * Thrown when the wrong PIN or PUK is used (or when the PIN or PUK is in a blocked state).
- *
- * @deprecated Use InvalidPinException from the code module instead
  */
-@Deprecated
-public class InvalidPinException extends com.yubico.yubikit.core.application.InvalidPinException {
+public class InvalidPinException extends CommandException {
+    private final int attemptsRemaining;
+
+    public InvalidPinException(int attemptsRemaining, String message) {
+        super(message);
+        this.attemptsRemaining = attemptsRemaining;
+    }
+
     public InvalidPinException(int attemptsRemaining) {
-        super(attemptsRemaining);
+        this(attemptsRemaining, "Invalid PIN/PUK. Remaining attempts: " + attemptsRemaining);
+    }
+
+    public int getAttemptsRemaining() {
+        return attemptsRemaining;
     }
 }

--- a/core/src/main/java/com/yubico/yubikit/core/fido/CtapException.java
+++ b/core/src/main/java/com/yubico/yubikit/core/fido/CtapException.java
@@ -22,8 +22,8 @@ import java.util.Locale;
 /**
  * An error on the CTAP-level, returned from the Authenticator.
  * <p>
- * These error codes are defined by the CTAP2 specification:
- * https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#error-responses
+ * These error codes are defined by the
+ * <a href="https://fidoalliance.org/specs/fido-v2.0-id-20180227/fido-client-to-authenticator-protocol-v2.0-id-20180227.html#error-responses">CTAP2 specification</a>
  */
 public class CtapException extends CommandException {
     public static final byte ERR_SUCCESS = 0x00;

--- a/core/src/main/java/com/yubico/yubikit/core/keys/EllipticCurveValues.java
+++ b/core/src/main/java/com/yubico/yubikit/core/keys/EllipticCurveValues.java
@@ -16,6 +16,8 @@
 
 package com.yubico.yubikit.core.keys;
 
+import com.yubico.yubikit.core.util.StringUtils;
+
 import java.util.Arrays;
 
 public enum EllipticCurveValues {
@@ -69,6 +71,15 @@ public enum EllipticCurveValues {
 
     byte[] getOid() {
         return Arrays.copyOf(oid, oid.length);
+    }
+
+    @Override
+    public String toString() {
+        return "EllipticCurveValues{" +
+                "name=" + name() +
+                ", bitLength=" + bitLength +
+                ", oid=" + StringUtils.bytesToHex(oid) +
+                '}';
     }
 
     public static EllipticCurveValues fromOid(byte[] oid) {

--- a/core/src/main/java/com/yubico/yubikit/core/keys/EllipticCurveValues.java
+++ b/core/src/main/java/com/yubico/yubikit/core/keys/EllipticCurveValues.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.core.keys;
+
+import java.util.Arrays;
+
+public enum EllipticCurveValues {
+    SECP256R1(
+            256,
+            new byte[]{0x2a, (byte) 0x86, 0x48, (byte) 0xce, 0x3d, 0x03, 0x01, 0x07}
+    ),
+    SECP256K1(
+            256,
+            new byte[]{0x2b, (byte) 0x81, 0x04, 0x00, 0x0a}
+    ),
+    SECP384R1(
+            384,
+            new byte[]{0x2b, (byte) 0x81, 0x04, 0x00, 0x22}
+    ),
+    SECP521R1(521,
+            new byte[]{0x2b, (byte) 0x81, 0x04, 0x00, 0x23}
+    ),
+    BrainpoolP256R1(
+            256,
+            new byte[]{0x2b, 0x24, 0x03, 0x03, 0x02, 0x08, 0x01, 0x01, 0x07}
+    ),
+    BrainpoolP384R1(
+            384,
+            new byte[]{0x2b, 0x24, 0x03, 0x03, 0x02, 0x08, 0x01, 0x01, 0x0b}
+    ),
+    BrainpoolP512R1(
+            512,
+            new byte[]{0x2b, 0x24, 0x03, 0x03, 0x02, 0x08, 0x01, 0x01, 0x0d}
+    ),
+    X25519(
+            256,
+            new byte[]{0x2b, 0x65, 0x6e}
+    ),
+    Ed25519(
+            256,
+            new byte[]{0x2b, 0x65, 0x70}
+    );
+
+    private final int bitLength;
+    private final byte[] oid;
+
+    EllipticCurveValues(int bitLength, byte[] oid) {
+        this.bitLength = bitLength;
+        this.oid = oid;
+    }
+
+    public int getBitLength() {
+        return bitLength;
+    }
+
+    byte[] getOid() {
+        return Arrays.copyOf(oid, oid.length);
+    }
+
+    public static EllipticCurveValues fromOid(byte[] oid) {
+        for (EllipticCurveValues match : EllipticCurveValues.values()) {
+            if (Arrays.equals(oid, match.oid)) {
+                return match;
+            }
+        }
+        throw new IllegalArgumentException("Not a supported EllipticCurve");
+    }
+}

--- a/core/src/main/java/com/yubico/yubikit/core/keys/PrivateKeyValues.java
+++ b/core/src/main/java/com/yubico/yubikit/core/keys/PrivateKeyValues.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.core.keys;
+
+import com.yubico.yubikit.core.application.BadResponseException;
+import com.yubico.yubikit.core.util.Tlv;
+import com.yubico.yubikit.core.util.Tlvs;
+
+import java.math.BigInteger;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+import javax.security.auth.DestroyFailedException;
+import javax.security.auth.Destroyable;
+
+/**
+ * Contains private key values to be imported into a YubiKey.
+ * <p>
+ * Can be created from a {@link PrivateKey} by using {@link #fromPrivateKey(PrivateKey)}.
+ * <p>
+ * Once used, clear the secret keying material by calling {@link #destroy()}.
+ */
+public abstract class PrivateKeyValues implements Destroyable {
+    private static final byte[] OID_ECDSA = new byte[]{0x2a, (byte) 0x86, 0x48, (byte) 0xce, 0x3d, 0x02, 0x01};
+    final int bitLength;
+    private boolean destroyed = false;
+
+    protected PrivateKeyValues(int bitLength) {
+        this.bitLength = bitLength;
+    }
+
+    public final int getBitLength() {
+        return bitLength;
+    }
+
+    @Override
+    public final boolean isDestroyed() {
+        return destroyed;
+    }
+
+    @Override
+    public void destroy() throws DestroyFailedException {
+        destroyed = true;
+    }
+
+
+    public static PrivateKeyValues fromPrivateKey(PrivateKey privateKey) {
+        if (privateKey instanceof RSAPrivateKey) {
+            return Rsa.fromRsaPrivateKey((RSAPrivateKey) privateKey);
+        } else {
+            byte[] encoded = privateKey.getEncoded();
+            try {
+                Map<Integer, byte[]> tlvs = Tlvs.decodeMap(Tlvs.unpackValue(0x30, encoded));
+                List<Tlv> sequence = Tlvs.decodeList(tlvs.get(0x30));
+                byte[] algorithm = sequence.get(0).getValue();
+                if (Arrays.equals(OID_ECDSA, algorithm)) {
+                    byte[] parameter = sequence.get(1).getValue();
+                    EllipticCurveValues curve = EllipticCurveValues.fromOid(parameter);
+                    sequence = Tlvs.decodeList(Tlvs.unpackValue(0x30, tlvs.get(0x04)));
+                    return new Ec(curve, sequence.get(1).getValue());
+                } else {
+                    for (EllipticCurveValues curve: Arrays.asList(EllipticCurveValues.Ed25519, EllipticCurveValues.X25519)) {
+                        if (Arrays.equals(curve.getOid(), algorithm)) {
+                            return new Ec(curve, Tlvs.unpackValue(0x04, tlvs.get(0x04)));
+                        }
+                    }
+                }
+            } catch (BadResponseException e) {
+                // ignore, fall through to exception
+            }
+        }
+
+        throw new IllegalArgumentException("Unsupported private key type");
+    }
+
+    public static class Ec extends PrivateKeyValues {
+        private final EllipticCurveValues ellipticCurveValues;
+        private final byte[] secret;
+
+
+        protected Ec(EllipticCurveValues ellipticCurveValues, byte[] secret) {
+            super(ellipticCurveValues.getBitLength());
+            this.ellipticCurveValues = ellipticCurveValues;
+            this.secret = Arrays.copyOf(secret, secret.length);
+        }
+
+        public EllipticCurveValues getCurveParams() {
+            return ellipticCurveValues;
+        }
+
+        public byte[] getSecret() {
+            return Arrays.copyOf(secret, secret.length);
+        }
+
+        @Override
+        public void destroy() throws DestroyFailedException {
+            Arrays.fill(secret, (byte) 0);
+            super.destroy();
+        }
+    }
+
+    public static class Rsa extends PrivateKeyValues {
+        private final BigInteger modulus;
+        private final BigInteger publicExponent;
+        private BigInteger primeP;
+        private BigInteger primeQ;
+        @Nullable
+        private BigInteger primeExponentP;
+        @Nullable
+        private BigInteger primeExponentQ;
+        @Nullable
+        private BigInteger crtCoefficient;
+
+        @Override
+        public String toString() {
+            return "Rsa{" +
+                    "modulus=" + modulus +
+                    ", publicExponent=" + publicExponent +
+                    ", primeP=" + primeP +
+                    ", primeQ=" + primeQ +
+                    ", primeExponentP=" + primeExponentP +
+                    ", primeExponentQ=" + primeExponentQ +
+                    ", crtCoefficient=" + crtCoefficient +
+                    ", bitLength=" + bitLength +
+                    '}';
+        }
+
+        protected Rsa(BigInteger modulus, BigInteger publicExponent, BigInteger primeP, BigInteger primeQ, @Nullable BigInteger primeExponentP, @Nullable BigInteger primeExponentQ, @Nullable BigInteger crtCoefficient) {
+            super(modulus.bitLength());
+            this.modulus = modulus;
+            this.publicExponent = publicExponent;
+            this.primeP = primeP;
+            this.primeQ = primeQ;
+            this.primeExponentP = primeExponentP;
+            this.primeExponentQ = primeExponentQ;
+            this.crtCoefficient = crtCoefficient;
+        }
+
+        public BigInteger getModulus() {
+            return modulus;
+        }
+
+        public BigInteger getPublicExponent() {
+            return publicExponent;
+        }
+
+        public BigInteger getPrimeP() {
+            return primeP;
+        }
+
+        public BigInteger getPrimeQ() {
+            return primeQ;
+        }
+
+        @Nullable
+        public BigInteger getPrimeExponentP() {
+            return primeExponentP;
+        }
+
+        @Nullable
+        public BigInteger getPrimeExponentQ() {
+            return primeExponentQ;
+        }
+
+        @Nullable
+        public BigInteger getCrtCoefficient() {
+            return crtCoefficient;
+        }
+
+        @Override
+        public void destroy() throws DestroyFailedException {
+            primeP = BigInteger.ZERO;
+            primeQ = BigInteger.ZERO;
+            primeExponentP = null;
+            primeExponentQ = null;
+            crtCoefficient = null;
+            super.destroy();
+        }
+
+        private static Rsa fromRsaPrivateKey(RSAPrivateKey key) {
+            List<BigInteger> values;
+            if (key instanceof RSAPrivateCrtKey) {
+                RSAPrivateCrtKey rsaPrivateKey = (RSAPrivateCrtKey) key;
+                values = Arrays.asList(
+                        rsaPrivateKey.getModulus(),
+                        rsaPrivateKey.getPublicExponent(),
+                        rsaPrivateKey.getPrivateExponent(),
+                        rsaPrivateKey.getPrimeP(),
+                        rsaPrivateKey.getPrimeQ(),
+                        rsaPrivateKey.getPrimeExponentP(),
+                        rsaPrivateKey.getPrimeExponentQ(),
+                        rsaPrivateKey.getCrtCoefficient()
+                );
+            } else if ("PKCS#8".equals(key.getFormat())) {
+                values = parsePkcs8RsaKeyValues(key.getEncoded());
+            } else {
+                throw new IllegalArgumentException("Unsupported private key encoding");
+            }
+            if (values.get(1).intValue() != 65537) {
+                throw new IllegalArgumentException("Unsupported RSA public exponent");
+            }
+
+            return new Rsa(
+                    values.get(0), // n
+                    values.get(1),  // e = 65537
+                    values.get(3), // p
+                    values.get(4), // q
+                    values.get(5), // dmp1
+                    values.get(6), // dmq1
+                    values.get(7)  // iqmp
+            );
+        }
+
+        /*
+        Parse a DER encoded PKCS#8 RSA key
+         */
+        static List<BigInteger> parsePkcs8RsaKeyValues(byte[] derKey) {
+            try {
+                List<Tlv> numbers = Tlvs.decodeList(
+                        Tlvs.decodeMap(
+                                Tlvs.decodeMap(
+                                        Tlvs.unpackValue(0x30, derKey)
+                                ).get(0x04)
+                        ).get(0x30)
+                );
+                List<BigInteger> values = new ArrayList<>();
+                for (Tlv number : numbers) {
+                    values.add(new BigInteger(number.getValue()));
+                }
+                BigInteger first = values.remove(0);
+                if (first.intValue() != 0) {
+                    throw new IllegalArgumentException("Expected value 0");
+                }
+                return values;
+            } catch (BadResponseException e) {
+                throw new IllegalArgumentException(e.getMessage());
+            }
+        }
+    }
+}

--- a/core/src/main/java/com/yubico/yubikit/core/keys/PrivateKeyValues.java
+++ b/core/src/main/java/com/yubico/yubikit/core/keys/PrivateKeyValues.java
@@ -64,6 +64,12 @@ public abstract class PrivateKeyValues implements Destroyable {
     }
 
 
+    /**
+     * Constructs a PrivateKeyValues instance using values from a JCA {@link PrivateKey}.
+     *
+     * @param privateKey the private key to extract values from
+     * @return private key values
+     */
     public static PrivateKeyValues fromPrivateKey(PrivateKey privateKey) {
         if (privateKey instanceof RSAPrivateKey) {
             return Rsa.fromRsaPrivateKey((RSAPrivateKey) privateKey);
@@ -79,7 +85,7 @@ public abstract class PrivateKeyValues implements Destroyable {
                     sequence = Tlvs.decodeList(Tlvs.unpackValue(0x30, tlvs.get(0x04)));
                     return new Ec(curve, sequence.get(1).getValue());
                 } else {
-                    for (EllipticCurveValues curve: Arrays.asList(EllipticCurveValues.Ed25519, EllipticCurveValues.X25519)) {
+                    for (EllipticCurveValues curve : Arrays.asList(EllipticCurveValues.Ed25519, EllipticCurveValues.X25519)) {
                         if (Arrays.equals(curve.getOid(), algorithm)) {
                             return new Ec(curve, Tlvs.unpackValue(0x04, tlvs.get(0x04)));
                         }
@@ -117,6 +123,15 @@ public abstract class PrivateKeyValues implements Destroyable {
             Arrays.fill(secret, (byte) 0);
             super.destroy();
         }
+
+        @Override
+        public String toString() {
+            return "PrivateKeyValues.Ec{" +
+                    "curve=" + ellipticCurveValues.name() +
+                    ", bitLength=" + bitLength +
+                    ", destroyed=" + isDestroyed() +
+                    '}';
+        }
     }
 
     public static class Rsa extends PrivateKeyValues {
@@ -133,15 +148,13 @@ public abstract class PrivateKeyValues implements Destroyable {
 
         @Override
         public String toString() {
-            return "Rsa{" +
+            boolean hasCrt = crtCoefficient != null;
+            return "PrivateKeyValues.Rsa{" +
                     "modulus=" + modulus +
                     ", publicExponent=" + publicExponent +
-                    ", primeP=" + primeP +
-                    ", primeQ=" + primeQ +
-                    ", primeExponentP=" + primeExponentP +
-                    ", primeExponentQ=" + primeExponentQ +
-                    ", crtCoefficient=" + crtCoefficient +
                     ", bitLength=" + bitLength +
+                    ", hasCrtValues=" + hasCrt +
+                    ", destroyed=" + isDestroyed() +
                     '}';
         }
 
@@ -154,6 +167,13 @@ public abstract class PrivateKeyValues implements Destroyable {
             this.primeExponentP = primeExponentP;
             this.primeExponentQ = primeExponentQ;
             this.crtCoefficient = crtCoefficient;
+            if (!(
+                    (primeExponentP != null && primeExponentQ != null && crtCoefficient != null)
+                            || (primeExponentP == null && primeExponentQ == null && crtCoefficient == null)
+            )) {
+                throw new IllegalArgumentException("All CRT values must either be present or omitted");
+            }
+
         }
 
         public BigInteger getModulus() {
@@ -222,7 +242,7 @@ public abstract class PrivateKeyValues implements Destroyable {
 
             return new Rsa(
                     values.get(0), // n
-                    values.get(1),  // e = 65537
+                    values.get(1), // e
                     values.get(3), // p
                     values.get(4), // q
                     values.get(5), // dmp1

--- a/core/src/main/java/com/yubico/yubikit/core/keys/PublicKeyValues.java
+++ b/core/src/main/java/com/yubico/yubikit/core/keys/PublicKeyValues.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.core.keys;
+
+import static com.yubico.yubikit.core.util.ByteUtils.intToLength;
+
+import com.yubico.yubikit.core.application.BadResponseException;
+import com.yubico.yubikit.core.util.Tlv;
+import com.yubico.yubikit.core.util.Tlvs;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public abstract class PublicKeyValues {
+    private static final byte[] OID_ECDSA = new byte[]{0x2a, (byte) 0x86, 0x48, (byte) 0xce, 0x3d, 0x02, 0x01};
+    private static final byte[] OID_RSA_ENCRYPTION = new byte[]{0x2a, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xf7, 0x0d, 0x01, 0x01, 0x01};
+
+    protected final int bitLength;
+
+    protected PublicKeyValues(int bitLength) {
+        this.bitLength = bitLength;
+    }
+
+    public final int getBitLength() {
+        return bitLength;
+    }
+
+    public abstract byte[] getEncoded();
+
+    public abstract PublicKey toPublicKey() throws NoSuchAlgorithmException, InvalidKeySpecException;
+
+    public static PublicKeyValues fromPublicKey(PublicKey publicKey) {
+        if (publicKey instanceof RSAPublicKey) {
+            return new Rsa(((RSAPublicKey) publicKey).getModulus(), ((RSAPublicKey) publicKey).getPublicExponent());
+        }
+        byte[] encoded = publicKey.getEncoded();
+        try {
+            Map<Integer, byte[]> tlvs = Tlvs.decodeMap(Tlvs.unpackValue(0x30, encoded));
+            List<Tlv> sequence = Tlvs.decodeList(tlvs.get(0x30));
+            byte[] algorithm = sequence.get(0).getValue();
+            byte[] bitString = tlvs.get(0x03);
+            byte[] encodedKey = Arrays.copyOfRange(bitString, 1, bitString.length);
+            if (Arrays.equals(OID_ECDSA, algorithm)) {
+                byte[] parameter = sequence.get(1).getValue();
+                EllipticCurveValues curve = EllipticCurveValues.fromOid(parameter);
+                return Ec.fromEncodedPoint(curve, encodedKey);
+            } else {
+                for (EllipticCurveValues curve : Arrays.asList(EllipticCurveValues.Ed25519, EllipticCurveValues.X25519)) {
+                    if (Arrays.equals(curve.getOid(), algorithm)) {
+                        return new Cv25519(curve, encodedKey);
+                    }
+                }
+            }
+        } catch (BadResponseException e) {
+            throw new RuntimeException(e);
+        }
+
+        throw new IllegalStateException();
+    }
+
+    public static class Cv25519 extends PublicKeyValues {
+        private final EllipticCurveValues ellipticCurveValues;
+        private final byte[] bytes;
+
+        public Cv25519(EllipticCurveValues ellipticCurveValues, byte[] bytes) {
+            super(ellipticCurveValues.getBitLength());
+            if (!(ellipticCurveValues == EllipticCurveValues.Ed25519 || ellipticCurveValues == EllipticCurveValues.X25519)) {
+                throw new IllegalArgumentException("InvalidCurve");
+            }
+            this.ellipticCurveValues = ellipticCurveValues;
+            this.bytes = Arrays.copyOf(bytes, bytes.length);
+        }
+
+        public EllipticCurveValues getCurveParams() {
+            return ellipticCurveValues;
+        }
+
+        public byte[] getBytes() {
+            return Arrays.copyOf(bytes, bytes.length);
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            return new Tlv(0x30, Tlvs.encodeList(Arrays.asList(
+                    new Tlv(0x30, new Tlv(0x06, ellipticCurveValues.getOid()).getBytes()),
+                    new Tlv(0x03, ByteBuffer.allocate(1 + bytes.length).put((byte) 0).put(bytes).array())
+            ))).getBytes();
+        }
+
+        @Override
+        public PublicKey toPublicKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
+            KeyFactory keyFactory = KeyFactory.getInstance(ellipticCurveValues.name());
+            return keyFactory.generatePublic(new X509EncodedKeySpec(getEncoded()));
+        }
+    }
+
+    public static class Ec extends PublicKeyValues {
+        private final EllipticCurveValues ellipticCurveValues;
+        private final BigInteger x;
+        private final BigInteger y;
+
+        public Ec(EllipticCurveValues ellipticCurveValues, BigInteger x, BigInteger y) {
+            super(ellipticCurveValues.getBitLength());
+            if (ellipticCurveValues == EllipticCurveValues.Ed25519 || ellipticCurveValues == EllipticCurveValues.X25519) {
+                throw new IllegalArgumentException("InvalidCurve");
+            }
+            this.ellipticCurveValues = ellipticCurveValues;
+            this.x = x;
+            this.y = y;
+        }
+
+        public EllipticCurveValues getCurveParams() {
+            return ellipticCurveValues;
+        }
+
+        public BigInteger getX() {
+            return x;
+        }
+
+        public BigInteger getY() {
+            return y;
+        }
+
+        public byte[] getEncodedPoint() {
+            int coordSize = (int) Math.ceil(ellipticCurveValues.getBitLength() / 8.0);
+            return ByteBuffer.allocate(1 + 2 * coordSize)
+                    .put((byte) 0x04)
+                    .put(intToLength(x, coordSize))
+                    .put(intToLength(y, coordSize))
+                    .array();
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            byte[] encodedPoint = getEncodedPoint();
+            return new Tlv(0x30, Tlvs.encodeList(Arrays.asList(
+                    new Tlv(0x30, Tlvs.encodeList(Arrays.asList(
+                            new Tlv(0x06, OID_ECDSA),
+                            new Tlv(0x06, ellipticCurveValues.getOid())
+                    ))),
+                    new Tlv(0x03, ByteBuffer.allocate(1 + encodedPoint.length).put((byte) 0).put(encodedPoint).array())
+            ))).getBytes();
+        }
+
+        @Override
+        public ECPublicKey toPublicKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            return (ECPublicKey) keyFactory.generatePublic(new X509EncodedKeySpec(getEncoded()));
+        }
+
+        public static Ec fromEncodedPoint(EllipticCurveValues curve, byte[] encoded) {
+            ByteBuffer buf = ByteBuffer.wrap(encoded);
+            if (buf.get() != 0x04) {
+                throw new IllegalArgumentException("Only uncompressed public keys are supported");
+            }
+            byte[] coordBuf = new byte[(encoded.length - 1) / 2];
+            buf.get(coordBuf);
+            BigInteger x = new BigInteger(1, coordBuf);
+            buf.get(coordBuf);
+            BigInteger y = new BigInteger(1, coordBuf);
+            return new Ec(curve, x, y);
+        }
+    }
+
+    public static class Rsa extends PublicKeyValues {
+        private final BigInteger modulus;
+        private final BigInteger publicExponent;
+
+        public Rsa(BigInteger modulus, BigInteger publicExponent) {
+            super(modulus.bitLength());
+            this.modulus = modulus;
+            this.publicExponent = publicExponent;
+        }
+
+        public BigInteger getModulus() {
+            return modulus;
+        }
+
+        public BigInteger getPublicExponent() {
+            return publicExponent;
+        }
+
+        @Override
+        public byte[] getEncoded() {
+            byte[] bitstring = new Tlv(0x30, Tlvs.encodeList(Arrays.asList(
+                    new Tlv(0x02, modulus.toByteArray()),
+                    new Tlv(0x02, publicExponent.toByteArray())
+            ))).getBytes();
+            return new Tlv(0x30, Tlvs.encodeList(Arrays.asList(
+                    new Tlv(0x30, Tlvs.encodeList(Arrays.asList(
+                            new Tlv(0x06, OID_RSA_ENCRYPTION),
+                            new Tlv(0x05, new byte[0])
+                    ))),
+                    new Tlv(0x03, ByteBuffer
+                            .allocate(1 + bitstring.length)
+                            .put((byte) 0)
+                            .put(bitstring)
+                            .array()
+                    )
+            ))).getBytes();
+        }
+
+        @Override
+        public RSAPublicKey toPublicKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
+            KeyFactory factory = KeyFactory.getInstance("RSA");
+            return (RSAPublicKey) factory.generatePublic(new RSAPublicKeySpec(modulus, publicExponent));
+        }
+    }
+}

--- a/core/src/main/java/com/yubico/yubikit/core/keys/PublicKeyValues.java
+++ b/core/src/main/java/com/yubico/yubikit/core/keys/PublicKeyValues.java
@@ -19,6 +19,7 @@ package com.yubico.yubikit.core.keys;
 import static com.yubico.yubikit.core.util.ByteUtils.intToLength;
 
 import com.yubico.yubikit.core.application.BadResponseException;
+import com.yubico.yubikit.core.util.StringUtils;
 import com.yubico.yubikit.core.util.Tlv;
 import com.yubico.yubikit.core.util.Tlvs;
 
@@ -36,6 +37,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Values defining a public key, such as an RSA or EC key.
+ */
 public abstract class PublicKeyValues {
     private static final byte[] OID_ECDSA = new byte[]{0x2a, (byte) 0x86, 0x48, (byte) 0xce, 0x3d, 0x02, 0x01};
     private static final byte[] OID_RSA_ENCRYPTION = new byte[]{0x2a, (byte) 0x86, 0x48, (byte) 0x86, (byte) 0xf7, 0x0d, 0x01, 0x01, 0x01};
@@ -52,6 +56,14 @@ public abstract class PublicKeyValues {
 
     public abstract byte[] getEncoded();
 
+    /**
+     * Instantiates a JCA PublicKey using the contained parameters.
+     * This requires a SecurityProvider capable of handling the key type.
+     *
+     * @return a public key, usable for cryptographic operations
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeySpecException
+     */
     public abstract PublicKey toPublicKey() throws NoSuchAlgorithmException, InvalidKeySpecException;
 
     public static PublicKeyValues fromPublicKey(PublicKey publicKey) {
@@ -117,6 +129,15 @@ public abstract class PublicKeyValues {
             KeyFactory keyFactory = KeyFactory.getInstance(ellipticCurveValues.name());
             return keyFactory.generatePublic(new X509EncodedKeySpec(getEncoded()));
         }
+
+        @Override
+        public String toString() {
+            return "PublicKeyValues.Cv25519{" +
+                    "curve=" + ellipticCurveValues.name() +
+                    ", publicKey=" + StringUtils.bytesToHex(bytes) +
+                    ", bitLength=" + bitLength +
+                    '}';
+        }
     }
 
     public static class Ec extends PublicKeyValues {
@@ -171,6 +192,16 @@ public abstract class PublicKeyValues {
         public ECPublicKey toPublicKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
             KeyFactory keyFactory = KeyFactory.getInstance("EC");
             return (ECPublicKey) keyFactory.generatePublic(new X509EncodedKeySpec(getEncoded()));
+        }
+
+        @Override
+        public String toString() {
+            return "PublicKeyValues.Ec{" +
+                    "curve=" + ellipticCurveValues.name() +
+                    ", x=" + x +
+                    ", y=" + y +
+                    ", bitLength=" + bitLength +
+                    '}';
         }
 
         public static Ec fromEncodedPoint(EllipticCurveValues curve, byte[] encoded) {
@@ -229,6 +260,15 @@ public abstract class PublicKeyValues {
         public RSAPublicKey toPublicKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
             KeyFactory factory = KeyFactory.getInstance("RSA");
             return (RSAPublicKey) factory.generatePublic(new RSAPublicKeySpec(modulus, publicExponent));
+        }
+
+        @Override
+        public String toString() {
+            return "PublicKeyValues.Rsa{" +
+                    "modulus=" + modulus +
+                    ", publicExponent=" + publicExponent +
+                    ", bitLength=" + bitLength +
+                    '}';
         }
     }
 }

--- a/core/src/main/java/com/yubico/yubikit/core/keys/package-info.java
+++ b/core/src/main/java/com/yubico/yubikit/core/keys/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@PackageNonnullByDefault
+package com.yubico.yubikit.core.keys;
+
+import com.yubico.yubikit.core.PackageNonnullByDefault;

--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/Apdu.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/Apdu.java
@@ -39,6 +39,7 @@ public class Apdu {
      * @param p1   the first instruction parameter byte
      * @param p2   the second instruction parameter byte
      * @param data the command data
+     * @param le   the length of expected data in the response
      */
     private Apdu(byte cla, byte ins, byte p1, byte p2, @Nullable byte[] data, int le) {
         this.cla = cla;

--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/Apdu.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/Apdu.java
@@ -29,6 +29,7 @@ public class Apdu {
     private final byte p1;
     private final byte p2;
     private final byte[] data;
+    private final int le;
 
     /**
      * Creates a new command APDU from a list of parameters specified by the ISO/IEC 7816-4 standard.
@@ -39,24 +40,33 @@ public class Apdu {
      * @param p2   the second instruction parameter byte
      * @param data the command data
      */
-    private Apdu(byte cla, byte ins, byte p1, byte p2, @Nullable byte[] data) {
+    private Apdu(byte cla, byte ins, byte p1, byte p2, @Nullable byte[] data, int le) {
         this.cla = cla;
         this.ins = ins;
         this.p1 = p1;
         this.p2 = p2;
         this.data = data == null ? new byte[0] : data;
+        this.le = le;
+    }
+
+    private Apdu(byte cla, byte ins, byte p1, byte p2, @Nullable byte[] data) {
+        this(cla, ins, p1, p2, data, 0);
     }
 
     /**
      * Constructor using int's for convenience. See {@link #Apdu(byte, byte, byte, byte, byte[])}.
      */
-    public Apdu(int cla, int ins, int p1, int p2, @Nullable byte[] data) {
+    public Apdu(int cla, int ins, int p1, int p2, @Nullable byte[] data, int le) {
         this(validateByte(cla, "CLA"),
                 validateByte(ins, "INS"),
                 validateByte(p1, "P1"),
                 validateByte(p2, "P2"),
-                data
+                data,
+                le
         );
+    }
+    public Apdu(int cla, int ins, int p1, int p2, @Nullable byte[] data) {
+        this(cla, ins, p1, p2, data, 0);
     }
 
     /**
@@ -92,6 +102,10 @@ public class Apdu {
      */
     public byte getP2() {
         return p2;
+    }
+
+    public int getLe() {
+        return le;
     }
 
     /*

--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/SmartCardProtocol.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/SmartCardProtocol.java
@@ -149,17 +149,17 @@ public class SmartCardProtocol implements Closeable {
             case SHORT:
                 int offset = 0;
                 while (data.length - offset > SHORT_APDU_MAX_CHUNK) {
-                    response = new ApduResponse(connection.sendAndReceive(encodeShortApdu((byte) (command.getCla() | 0x10), command.getIns(), command.getP1(), command.getP2(), data, offset, SHORT_APDU_MAX_CHUNK)));
+                    response = new ApduResponse(connection.sendAndReceive(encodeShortApdu((byte) (command.getCla() | 0x10), command.getIns(), command.getP1(), command.getP2(), data, offset, SHORT_APDU_MAX_CHUNK, command.getLe())));
                     if (response.getSw() != SW.OK) {
                         throw new ApduException(response.getSw());
                     }
                     offset += SHORT_APDU_MAX_CHUNK;
                 }
-                response = new ApduResponse(connection.sendAndReceive(encodeShortApdu(command.getCla(), command.getIns(), command.getP1(), command.getP2(), data, offset, data.length - offset)));
+                response = new ApduResponse(connection.sendAndReceive(encodeShortApdu(command.getCla(), command.getIns(), command.getP1(), command.getP2(), data, offset, data.length - offset, command.getLe())));
                 getData = new byte[]{0x00, insSendRemaining, 0x00, 0x00, 0x00};
                 break;
             case EXTENDED:
-                response = new ApduResponse(connection.sendAndReceive(encodeExtendedApdu(command.getCla(), command.getIns(), command.getP1(), command.getP2(), data)));
+                response = new ApduResponse(connection.sendAndReceive(encodeExtendedApdu(command.getCla(), command.getIns(), command.getP1(), command.getP2(), data, command.getLe())));
                 getData = new byte[]{0x00, insSendRemaining, 0x00, 0x00, 0x00, 0x00, 0x00};
                 break;
             default:
@@ -187,29 +187,41 @@ public class SmartCardProtocol implements Closeable {
         return responseData;
     }
 
-    private static byte[] encodeShortApdu(byte cla, byte ins, byte p1, byte p2, byte[] data, int offset, int length) {
+    private static byte[] encodeShortApdu(byte cla, byte ins, byte p1, byte p2, byte[] data, int offset, int length, int le) {
         if (length > SHORT_APDU_MAX_CHUNK) {
             throw new IllegalArgumentException("Length must be no greater than " + SHORT_APDU_MAX_CHUNK);
         }
-        return ByteBuffer.allocate(5 + length)
+        if (le < 0 || le > SHORT_APDU_MAX_CHUNK) {
+            throw new IllegalArgumentException("Le must be between 0 and " + SHORT_APDU_MAX_CHUNK);
+        }
+
+        ByteBuffer buf = ByteBuffer.allocate(4 + (length > 0 ? 1 : 0) + length + (le > 0 ? 1 : 0))
                 .put(cla)
                 .put(ins)
                 .put(p1)
-                .put(p2)
-                .put((byte) length)
-                .put(data, offset, length)
-                .array();
+                .put(p2);
+        if (length > 0) {
+            buf.put((byte) length).put(data, offset, length);
+        }
+        if (le > 0) {
+            buf.put((byte) le);
+        }
+        return buf.array();
     }
 
-    private static byte[] encodeExtendedApdu(byte cla, byte ins, byte p1, byte p2, byte[] data) {
-        return ByteBuffer.allocate(7 + data.length)
+    private static byte[] encodeExtendedApdu(byte cla, byte ins, byte p1, byte p2, byte[] data, int le) {
+        ByteBuffer buf = ByteBuffer.allocate(5 + (data.length > 0 ? 2 : 0) + data.length + (le > 0 ? 2 : 0))
                 .put(cla)
                 .put(ins)
                 .put(p1)
                 .put(p2)
-                .put((byte) 0x00)
-                .putShort((short) data.length)
-                .put(data)
-                .array();
+                .put((byte) 0x00);
+        if (data.length > 0) {
+            buf.putShort((short) data.length).put(data);
+        }
+        if (le > 0) {
+            buf.putShort((short) le);
+        }
+        return buf.array();
     }
 }

--- a/core/src/main/java/com/yubico/yubikit/core/util/ByteUtils.java
+++ b/core/src/main/java/com/yubico/yubikit/core/util/ByteUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.core.util;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+/**
+ * Used internally in YubiKit, don't use from applications.
+ */
+public final class ByteUtils {
+    /**
+     * Serializes a BigInteger as an unsigned integer of the given length.
+     * @param value the integer to serialize
+     * @param length the length of the byte[] to return
+     * @return the value as an unsigned integer
+     */
+    public static byte[] intToLength(BigInteger value, int length) {
+        byte[] data = value.toByteArray();
+        if (data.length == length) {
+            return data;
+        } else if (data.length < length) {
+            byte[] padded = new byte[length];
+            System.arraycopy(data, 0, padded, length - data.length, data.length);
+            return padded;
+        } else if (data.length == length + 1 && data[0] == 0) {
+            // BigInteger may have a leading zero, since it's signed.
+            return Arrays.copyOfRange(data, 1, data.length);
+        } else {
+            throw new IllegalArgumentException("value is too large to be represented in " + length + " bytes");
+        }
+    }
+}

--- a/core/src/test/java/com/yubico/yubikit/core/keys/PrivateKeyValuesTest.java
+++ b/core/src/test/java/com/yubico/yubikit/core/keys/PrivateKeyValuesTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.core.keys;
+
+import com.yubico.yubikit.testing.Codec;
+
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+
+public class PrivateKeyValuesTest {
+    @Test
+    public void testParsePkcs8RsaKeyValues() throws UnsupportedEncodingException {
+        PrivateKeyValues.Rsa.parsePkcs8RsaKeyValues(Codec.fromBase64("MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBALWeZ0E5O2l/iHfc" +
+                "k9mokf1iWH2eZDWQoJoQKUOAeVoKUecNp250J5tL3EHONqWoF6VLO+B+6jTET4Iz" +
+                "97BeUj7gOJHmEw+nqFfguTVmNeeiZ711TNYNpF7kwW7yWghWG+Q7iQEoMXfY3x4B" +
+                "L33H2gKRWtMHK66GJViL1l9s3qDXAgMBAAECgYBO753pFzrfS3LAxbns6/snqcrU" +
+                "LjdXoJhs3YFRuVEE9V9LkP+oXguoz3vXjgzqSvib+ur3U7HvZTM5X+TTXutXdQ5C" +
+                "yORLLtXEZcyCKQI9ihH5fSNJRWRbJ3xe+xi5NANRkRDkro7tm4a5ZD4PYvO4r29y" +
+                "VB5PXlMkOTLoxNSwwQJBAN5lW93Agi9Ge5B2+B2EnKSlUvj0+jJBkHYAFTiHyTZV" +
+                "Ej6baeHBvJklhVczpWvTXb6Nr8cjAKVshFbdQoBwHmkCQQDRD7djZGIWH1Lz0rkL" +
+                "01nDj4z4QYMgUs3AQhnrXPBjEgNzphtJ2u7QrCSOBQQHlmAPBDJ/MTxFJMzDIJGD" +
+                "A10/AkATJjEZz/ilr3D2SHgmuoNuXdneG+HrL+ALeQhavL5jkkGm6GTejnr5yNRJ" +
+                "ZOYKecGppbOL9wSYOdbPT+/o9T55AkATXCY6cRBYRhxTcf8q5i6Y2pFOaBqxgpmF" +
+                "JVnrHtcwBXoGWqqKQ1j8QAS+lh5SaY2JtnTKrI+NQ6Qmqbxv6n7XAkBkhLO7pplI" +
+                "nVh2WjqXOV4ZAoOAAJlfpG5+z6mWzCZ9+286OJQLr6OVVQMcYExUO9yVocZQX+4X" +
+                "qEIF0qAB7m31"));
+    }
+}

--- a/core/src/test/java/com/yubico/yubikit/core/keys/PublicKeyValuesTest.java
+++ b/core/src/test/java/com/yubico/yubikit/core/keys/PublicKeyValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Yubico.
+ * Copyright (C) 2023 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,28 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.yubico.yubikit.piv;
+
+package com.yubico.yubikit.core.keys;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.yubico.yubikit.testing.Codec;
 
 import org.junit.Test;
 
-import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-@SuppressWarnings("SpellCheckingInspection")
-public class PivSessionTest {
+public class PublicKeyValuesTest {
     @Test
     public void testDecodeP256Key() throws InvalidKeySpecException, NoSuchAlgorithmException {
         byte[] encoded = Codec.fromHex("046B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C2964FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5");
-        ECPublicKey key = (ECPublicKey) PivSession.publicEccKey(KeyType.ECCP256, encoded);
+        ECPublicKey key = PublicKeyValues.Ec.fromEncodedPoint(EllipticCurveValues.SECP256R1, encoded).toPublicKey();
         assertThat(key.getAlgorithm(), equalTo("EC"));
         assertThat(key.getParams().getCurve().getField().getFieldSize(), equalTo(256));
     }
@@ -42,7 +41,7 @@ public class PivSessionTest {
     @Test
     public void testDecodeP384Key() throws InvalidKeySpecException, NoSuchAlgorithmException {
         byte[] encoded = Codec.fromHex("0408D999057BA3D2D969260045C55B97F089025959A6F434D651D207D19FB96E9E4FE0E86EBE0E64F85B96A9C75295DF618E80F1FA5B1B3CEDB7BFE8DFFD6DBA74B275D875BC6CC43E904E505F256AB4255FFD43E94D39E22D61501E700A940E80");
-        ECPublicKey key = (ECPublicKey) PivSession.publicEccKey(KeyType.ECCP384, encoded);
+        ECPublicKey key = PublicKeyValues.Ec.fromEncodedPoint(EllipticCurveValues.SECP384R1, encoded).toPublicKey();
         assertThat(key.getAlgorithm(), equalTo("EC"));
         assertThat(key.getParams().getCurve().getField().getFieldSize(), equalTo(384));
     }
@@ -51,7 +50,7 @@ public class PivSessionTest {
     public void testDecodeRsa1024() throws InvalidKeySpecException, NoSuchAlgorithmException {
         BigInteger modulus = new BigInteger(Codec.fromHex("00C061DB5C051CE961F42898068E084D81EAB3245A6884CF8F8B379587E81C87A96CD4DC83FED14DB5EB6AC60B173797F6692B93AC285CDBD4F91F4968E65CDA579F82D2071ADFFE85F5FF424E8D9A33BFAC1B56C0975BC5B15710F475D45923880575F15B326314251C4DA5C9640EF240F3EF49E61398F700449F16C6F06D532D"));
         BigInteger exponent = BigInteger.valueOf(65537);
-        RSAPublicKey key = (RSAPublicKey) PivSession.publicRsaKey(modulus, exponent);
+        RSAPublicKey key = new PublicKeyValues.Rsa(modulus, exponent).toPublicKey();
         assertThat(key.getAlgorithm(), equalTo("RSA"));
         assertThat(key.getModulus(), equalTo(modulus));
         assertThat(key.getPublicExponent(), equalTo(exponent));
@@ -62,28 +61,10 @@ public class PivSessionTest {
     public void testDecodeRsa2048() throws InvalidKeySpecException, NoSuchAlgorithmException {
         BigInteger modulus = new BigInteger(Codec.fromHex("00C6FC5B4D5C28B9CDD9047C5481B1F6A6A66683E3B9566E91CBBC9E852EAD96796C914A92315C1B408045270D3C672FC7DA97F2258DBDE0681BD4E5D1112EEBB75AACDC712E62FCD4391513AE867C0E3C70B77032FBBEF774AADE544C6D76B0D296FEC3A5E2BF8ED7BFD3A0F9E48CA60F4CD36162DC3AEE6A0CC47E6BA92704E88E6A110622B3E9FC0C7CAA083A9D93BEB2902F16D06261751E5FA5B8F65E56A6C37B4EA27704AC2FCC7309211022ECFF04BF874A33ACB905699A40A617AF95EDE3308B3B438BFA888B5E82E3CFA7D403E2D32A7B554736ED947FC245943B656B1893032B82F82B6CAFB65BC491AFC645CD676B776F61A0B99FCB990606DA43E5"));
         BigInteger exponent = BigInteger.valueOf(65537);
-        RSAPublicKey key = (RSAPublicKey) PivSession.publicRsaKey(modulus, exponent);
+        RSAPublicKey key = new PublicKeyValues.Rsa(modulus, exponent).toPublicKey();
         assertThat(key.getAlgorithm(), equalTo("RSA"));
         assertThat(key.getModulus(), equalTo(modulus));
         assertThat(key.getPublicExponent(), equalTo(exponent));
         assertThat(key.getModulus().bitLength(), equalTo(2048));
-    }
-
-    @Test
-    public void testParsePkcs8RsaKeyValues() throws UnsupportedEncodingException {
-        PivSession.parsePkcs8RsaKeyValues(Codec.fromBase64("MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBALWeZ0E5O2l/iHfc" +
-                "k9mokf1iWH2eZDWQoJoQKUOAeVoKUecNp250J5tL3EHONqWoF6VLO+B+6jTET4Iz" +
-                "97BeUj7gOJHmEw+nqFfguTVmNeeiZ711TNYNpF7kwW7yWghWG+Q7iQEoMXfY3x4B" +
-                "L33H2gKRWtMHK66GJViL1l9s3qDXAgMBAAECgYBO753pFzrfS3LAxbns6/snqcrU" +
-                "LjdXoJhs3YFRuVEE9V9LkP+oXguoz3vXjgzqSvib+ur3U7HvZTM5X+TTXutXdQ5C" +
-                "yORLLtXEZcyCKQI9ihH5fSNJRWRbJ3xe+xi5NANRkRDkro7tm4a5ZD4PYvO4r29y" +
-                "VB5PXlMkOTLoxNSwwQJBAN5lW93Agi9Ge5B2+B2EnKSlUvj0+jJBkHYAFTiHyTZV" +
-                "Ej6baeHBvJklhVczpWvTXb6Nr8cjAKVshFbdQoBwHmkCQQDRD7djZGIWH1Lz0rkL" +
-                "01nDj4z4QYMgUs3AQhnrXPBjEgNzphtJ2u7QrCSOBQQHlmAPBDJ/MTxFJMzDIJGD" +
-                "A10/AkATJjEZz/ilr3D2SHgmuoNuXdneG+HrL+ALeQhavL5jkkGm6GTejnr5yNRJ" +
-                "ZOYKecGppbOL9wSYOdbPT+/o9T55AkATXCY6cRBYRhxTcf8q5i6Y2pFOaBqxgpmF" +
-                "JVnrHtcwBXoGWqqKQ1j8QAS+lh5SaY2JtnTKrI+NQ6Qmqbxv6n7XAkBkhLO7pplI" +
-                "nVh2WjqXOV4ZAoOAAJlfpG5+z6mWzCZ9+286OJQLr6OVVQMcYExUO9yVocZQX+4X" +
-                "qEIF0qAB7m31"));
     }
 }

--- a/piv/src/main/java/com/yubico/yubikit/piv/Padding.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/Padding.java
@@ -31,6 +31,7 @@ import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 
+@Deprecated
 class Padding {
     private static final String RAW_RSA = "RSA/ECB/NoPadding";
     private static final Pattern ECDSA_HASH_PATTERN = Pattern.compile("^(.+)withECDSA$", Pattern.CASE_INSENSITIVE);

--- a/piv/src/main/java/com/yubico/yubikit/piv/Slot.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/Slot.java
@@ -59,6 +59,7 @@ public enum Slot {
 
     /**
      * Gets the String alias for the slot, which is a HEX representation of the slot value.
+     *
      * @return the slot alias
      */
     public String getStringAlias() {
@@ -79,8 +80,9 @@ public enum Slot {
 
     /**
      * Returns the PIV slot corresponding to the given String alias.
-     *
+     * <p>
      * The alias should be the HEX representation of the slot value.
+     *
      * @param alias a slot value as HEX string
      * @return a Slot
      */

--- a/piv/src/main/java/com/yubico/yubikit/piv/SlotMetadata.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/SlotMetadata.java
@@ -15,7 +15,11 @@
  */
 package com.yubico.yubikit.piv;
 
+import com.yubico.yubikit.core.keys.PublicKeyValues;
+
+import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
 
 /**
@@ -70,7 +74,20 @@ public class SlotMetadata {
     /**
      * Returns the public key corresponding to the key in the slot.
      */
-    public PublicKey getPublicKey() {
+    public PublicKeyValues getPublicKeyValues() {
         return PivSession.parsePublicKeyFromDevice(keyType, publicKeyEncoded);
+    }
+
+    /**
+     * Returns the public key corresponding to the key in the slot.
+     * @deprecated Use {@link #getPublicKeyValues()}.toPublicKey() instead.
+     */
+    @Deprecated
+    public PublicKey getPublicKey() {
+        try {
+            return getPublicKeyValues().toPublicKey();
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
-include ':AndroidDemo', ':core', ':android', ':oath', ':yubiotp', ':management', ':piv', ':support', ':testing', ':testing-android'
+include ':core', ':oath', ':yubiotp', ':management', ':piv', ':openpgp', ':support', ':testing'
+include ':android', ':AndroidDemo', ':testing-android'

--- a/testing-android/build.gradle
+++ b/testing-android/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     implementation 'com.google.android.material:material:1.9.0'
 
     implementation 'androidx.multidex:multidex:2.0.1'
+
+    implementation 'com.github.tony19:logback-android:3.0.0'
 }
 
 description = "This module contains instrumented test framework and tests for yubikit-android."

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/TestActivity.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/TestActivity.java
@@ -18,6 +18,7 @@ package com.yubico.yubikit.testing;
 
 import android.os.Bundle;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -57,6 +58,7 @@ public class TestActivity extends AppCompatActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.test_activity);
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
         testNameText = findViewById(R.id.testNameText);
         statusText = findViewById(R.id.statusText);


### PR DESCRIPTION
This PR mainly changes how public and private keys are used in the SDK to allow for usage (mainly in PivSession) without requiring a JCA SecurityProvider with the needed algorithms, unless cryptographic operations need to be used. It comes with some deprecations to be removed in the next major version of this project.