### PR TITLE
Use new APIs on Android 13+

### DIFF
--- a/android/src/main/java/com/yubico/yubikit/android/ui/YubiKeyPromptActivity.java
+++ b/android/src/main/java/com/yubico/yubikit/android/ui/YubiKeyPromptActivity.java
@@ -19,6 +19,7 @@ package com.yubico.yubikit.android.ui;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -211,7 +212,10 @@ public class YubiKeyPromptActivity extends Activity {
         allowNfc = args.getBoolean(ARG_ALLOW_NFC, true);
 
         // Get the action to perform on YubiKey connected
-        Class<?> actionType = (Class<?>) args.getSerializable(ARG_ACTION_CLASS);
+        @SuppressWarnings("deprecation")
+        Class<?> actionType = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                ? (Class<?>) args.getSerializable(ARG_ACTION_CLASS, Class.class)
+                : (Class<?>) args.getSerializable(ARG_ACTION_CLASS);
         try {
             if (actionType != null && YubiKeyPromptAction.class.isAssignableFrom(actionType)) {
                 action = (YubiKeyPromptAction) actionType.newInstance();


### PR DESCRIPTION
Updates yubikit to use type-safer methods:

[`Intent.getParcelableExtra(String)`](https://developer.android.com/reference/android/content/Intent#getParcelableExtra(java.lang.String)) -> [`Intent.getParcelableExtra(String, Class)`](https://developer.android.com/reference/android/content/Intent#getParcelableExtra(java.lang.String,%20java.lang.Class%3CT%3E))

[`Bundle.getSerializable(String)`](https://developer.android.com/reference/android/os/Bundle#getSerializable(java.lang.String)) -> [`Bundle.getSerializable(String, Class)`](https://developer.android.com/reference/android/os/Bundle#getSerializable(java.lang.String,%20java.lang.Class%3CT%3E))