### PR TITLE
[fido] Clear sensitive data after use

### DIFF
--- a/fido/src/main/java/com/yubico/yubikit/fido/client/BasicWebAuthnClient.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/BasicWebAuthnClient.java
@@ -416,11 +416,10 @@ public class BasicWebAuthnClient implements Closeable {
                     pinUvAuthProtocol,
                     state
             );
-        } catch (Exception e) {
+        } finally {
             if (pinToken != null) {
                 Arrays.fill(pinToken, (byte) 0);
             }
-            throw e;
         }
     }
 


### PR DESCRIPTION
Memory containing user provided pin will be cleared after the pin is used/or on error. For `BasicWebAuthnClient.ctapMakeCredential` and `BasicWebAuthnClient.ctapGetAssertions` `try {} finally {}` blocks were added.