### PR TITLE
Bump dependencies 

### DIFF
--- a/AndroidDemo/build.gradle
+++ b/AndroidDemo/build.gradle
@@ -7,11 +7,11 @@ plugins {
 
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdk 34
         versionName version
         versionCode 1
 
@@ -39,6 +39,7 @@ android {
 
     buildFeatures {
         viewBinding true
+        buildConfig true
     }
 
     namespace = 'com.yubico.yubikit.android.app'
@@ -55,27 +56,27 @@ dependencies {
     implementation project(':piv')
     implementation project(':support')
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1'
 
-    implementation 'androidx.core:core-ktx:1.10.1'
-    implementation 'androidx.fragment:fragment-ktx:1.5.7'
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.fragment:fragment-ktx:1.6.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.3.0'
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.10.0'
 
     // Lifecycle
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
 
     // Navigation
-    def nav_version = '2.5.3'
+    def nav_version = '2.7.4'
     implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation "androidx.navigation:navigation-dynamic-features-fragment:$nav_version"
 
-    implementation 'org.bouncycastle:bcpkix-jdk15to18:1.71'
+    implementation 'org.bouncycastle:bcpkix-jdk15to18:1.75'
     implementation 'commons-codec:commons-codec:1.15' // for Base32
 
     implementation 'com.github.tony19:logback-android:3.0.0'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdk 34
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -36,13 +36,13 @@ android {
 dependencies {
     api project(':core')
 
-    compileOnly 'androidx.annotation:annotation:1.6.0'
+    compileOnly 'androidx.annotation:annotation:1.7.0'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.3'
 
     testImplementation project(':testing')
     testImplementation 'androidx.test.ext:junit:1.1.5'
-    testImplementation 'org.robolectric:robolectric:4.9'
-    testImplementation 'org.mockito:mockito-core:5.4.0'
+    testImplementation 'org.robolectric:robolectric:4.10.3'
+    testImplementation 'org.mockito:mockito-core:5.6.0'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:runner:1.5.2'

--- a/android/publish.gradle
+++ b/android/publish.gradle
@@ -2,34 +2,37 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
-
-task javadoc(type: Javadoc) {
-    source = android.sourceSets.main.java.srcDirs
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    android.libraryVariants.all { variant ->
+android {
+    libraryVariants.configureEach { variant ->
         if (variant.name == 'release') {
-            owner.classpath += variant.javaCompileProvider.get().classpath
+            tasks.register('javadoc', Javadoc) {
+                source = android.sourceSets.main.java.srcDirs
+                classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+                owner.classpath += variant.javaCompileProvider.get().classpath
+                exclude '**/R.html', '**/R.*.html', '**/index.html'
+            }
+
+            // build a jar with javadoc
+            tasks.register('javadocJar', Jar) {
+                dependsOn javadoc
+                archiveClassifier.set('javadoc')
+                from javadoc.destinationDir
+            }
+
+            // build a jar with source
+            tasks.register('sourcesJar', Jar) {
+                archiveClassifier.set('sources')
+                from android.sourceSets.main.java.srcDirs
+            }
+
+            artifacts {
+                archives javadocJar
+                archives sourcesJar
+            }
         }
     }
-    exclude '**/R.html', '**/R.*.html', '**/index.html'
 }
 
-// build a jar with javadoc
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    archiveClassifier.set('javadoc')
-    from javadoc.destinationDir
-}
-
-// build a jar with source
-task sourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-    from android.sourceSets.main.java.srcDirs
-}
-
-artifacts {
-    archives javadocJar
-    archives sourcesJar
-}
 
 afterEvaluate {
     publishing {
@@ -58,7 +61,7 @@ afterEvaluate {
             }
         }
     }
-    tasks.withType(Sign) {
+    tasks.withType(Sign).configureEach {
         onlyIf { isReleaseVersion && System.getenv("NO_GPG_SIGN") != "true" }
     }
     signing {

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,14 @@
 
 buildscript {
     ext {
-        kotlin_version = '1.8.20'
+        kotlin_version = '1.9.10'
     }
     repositories {
         mavenCentral()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
+++ b/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
@@ -23,5 +23,5 @@ spotbugs {
     effort = "max"
     reportLevel = "low"
 
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = project.layout.getBuildDirectory().dir('reports/spotbugs').get().asFile
 }

--- a/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
+++ b/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 dependencies {
-    spotbugs 'com.github.spotbugs:spotbugs:4.7.3'
+    spotbugs 'com.github.spotbugs:spotbugs:4.8.0'
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.12.0'
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.3'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.0'
 
     testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 15 09:29:05 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/testing-android/build.gradle
+++ b/testing-android/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     api project(':piv')
     api project(':testing')
 
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.10.0'
 
     implementation 'androidx.multidex:multidex:2.0.1'
 

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/BasicWebAuthnClientInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/BasicWebAuthnClientInstrumentedTests.java
@@ -37,7 +37,7 @@ import java.util.Collection;
 public class BasicWebAuthnClientInstrumentedTests {
     @LargeTest
     @RunWith(Parameterized.class)
-    public static class ParametrizedBasicWebAuthnClientTests extends FidoInstrumentedTests {
+    public static class BasicWebAuthnClientParametrizedTests extends FidoInstrumentedTests {
 
         @Parameterized.Parameter
         public PinUvAuthProtocol pinUvAuthProtocol;

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2CredentialManagementInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2CredentialManagementInstrumentedTests.java
@@ -45,7 +45,7 @@ public class Ctap2CredentialManagementInstrumentedTests {
 
     @LargeTest
     @RunWith(Parameterized.class)
-    public static class ParametrizedCtap2CredentialManagementTests extends FidoInstrumentedTests {
+    public static class Ctap2CredentialManagementParametrizedTests extends FidoInstrumentedTests {
 
         @Parameterized.Parameter
         public PinUvAuthProtocol pinUvAuthProtocol;

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2SessionInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2SessionInstrumentedTests.java
@@ -38,7 +38,7 @@ import java.util.Collection;
 public class Ctap2SessionInstrumentedTests {
     @LargeTest
     @RunWith(Parameterized.class)
-    public static class ParametrizedCtap2SessionTests extends FidoInstrumentedTests {
+    public static class Ctap2SessionParametrizedTests extends FidoInstrumentedTests {
         @Parameterized.Parameter
         public PinUvAuthProtocol pinUvAuthProtocol;
 

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/EnterpriseAttestationInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/EnterpriseAttestationInstrumentedTests.java
@@ -38,7 +38,7 @@ import java.util.Collection;
 public class EnterpriseAttestationInstrumentedTests {
     @LargeTest
     @RunWith(Parameterized.class)
-    public static class ParametrizedEnterpriseAttestationTests extends FidoInstrumentedTests {
+    public static class EnterpriseAttestationParametrizedTests extends FidoInstrumentedTests {
 
         @Parameterized.Parameter
         public PinUvAuthProtocol pinUvAuthProtocol;

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/TestActivity.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/TestActivity.java
@@ -42,7 +42,8 @@ import java.util.concurrent.Semaphore;
 
 public class TestActivity extends AppCompatActivity {
 
-    private TextView testNameText;
+    private TextView testClassNameText;
+    private TextView testMethodNameText;
     private TextView statusText;
     private TextView bottomText;
     private ProgressBar progressBar;
@@ -60,7 +61,8 @@ public class TestActivity extends AppCompatActivity {
         setContentView(R.layout.test_activity);
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
-        testNameText = findViewById(R.id.testNameText);
+        testClassNameText = findViewById(R.id.testClassNameText);
+        testMethodNameText = findViewById(R.id.testMethodNameText);
         statusText = findViewById(R.id.statusText);
         bottomText = findViewById(R.id.bottomText);
         progressBar = findViewById(R.id.progressBar);
@@ -104,11 +106,12 @@ public class TestActivity extends AppCompatActivity {
         });
     }
 
-    public synchronized YubiKeyDevice awaitSession(String name) throws InterruptedException {
+    public synchronized YubiKeyDevice awaitSession(String testClassName, String testMethodName) throws InterruptedException {
         YubiKeyDevice device = sessionQueue.peek();
 
         runOnUiThread(() -> {
-            testNameText.setText(name);
+            testClassNameText.setText(testClassName);
+            testMethodNameText.setText(testMethodName);
             if (device instanceof UsbYubiKeyDevice) {
                 statusText.setText(R.string.processing);
             } else {

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2023 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package com.yubico.yubikit.testing.framework;
 
-import androidx.test.rule.ActivityTestRule;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
 
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.testing.TestActivity;
@@ -34,18 +34,29 @@ public class YKInstrumentedTests {
     public final TestName name = new TestName();
 
     @Rule
-    public final ActivityTestRule<TestActivity> rule = new ActivityTestRule<>(TestActivity.class);
+    public final ActivityScenarioRule<TestActivity> scenarioRule = new ActivityScenarioRule<>(TestActivity.class);
 
     @Before
-    public void getYubiKey() throws InterruptedException {
-        device = rule.getActivity().awaitSession(
-                getClass().getSimpleName() + " / " + name.getMethodName()
-        );
+    public void getYubiKey() {
+        scenarioRule.getScenario().onActivity(action -> {
+            try {
+                device = action.awaitSession(getClass().getSimpleName(), name.getMethodName());
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        });
     }
 
     @After
-    public void releaseYubiKey() throws InterruptedException {
-        rule.getActivity().returnSession(device);
-        device = null;
+    public void releaseYubiKey() {
+        scenarioRule.getScenario().onActivity(action -> {
+            try {
+                action.returnSession(device);
+                device = null;
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        });
     }
 }
+

--- a/testing-android/src/main/res/layout/test_activity.xml
+++ b/testing-android/src/main/res/layout/test_activity.xml
@@ -25,13 +25,22 @@
         android:layout_height="11sp" />
 
     <TextView
-        android:id="@+id/testNameText"
+        android:id="@+id/testClassNameText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text=""
-        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+        android:textAppearance="@style/TextAppearance.AppCompat.Small"
         android:textStyle="bold"
-        tools:text="Test name" />
+        tools:text="Test class name" />
+
+    <TextView
+        android:id="@+id/testMethodNameText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:textAppearance="@style/TextAppearance.AppCompat.Small"
+        android:textStyle="bold"
+        tools:text="Test method name" />
 
     <ProgressBar
         android:id="@+id/progressBar"
@@ -48,6 +57,6 @@
         android:layout_height="wrap_content"
         android:gravity="bottom"
         android:text=""
-        android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
         tools:text="Bottom text" />
 </LinearLayout>


### PR DESCRIPTION
Bumps dependencies and build options of the SDK. The most significant are:
- `targetSdk` of the SDK is now 34
- built with Gradle 8.3 and AGP 8.1.2

Other fixes include resolving deprecations in the build system and instrumented tests.