### PR TITLE
Add SpotBugs code scanning

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,10 +23,3 @@ jobs:
         with:
           name: maven-repo
           path: ~/.m2/repository/com/yubico/yubikit/
-
-      - name: Upload build reports
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: build-reports
-          path: ./*/build/reports/*

--- a/.github/workflows/spotbugs-scan.yml
+++ b/.github/workflows/spotbugs-scan.yml
@@ -57,13 +57,14 @@ jobs:
             "yubiotp";
           do
             SARIF="./build/spotbugs/spotbugs-$module.sarif"
-
-            cat $SARIF |
-              jq '.runs |= map( if .taxonomies == [null] then .taxonomies = [] else . end)' |
-              jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uri |= \"$module/src/main/java/\" + ." |
-              jq '.runs[].tool.driver.rules |= map( . += { fullDescription: { text: .shortDescription.text } } )' |
-              jq '.runs[].tool.driver.rules |= map( . += { help: { text: .helpUri } } )' |
-              jq -c '.' > $SARIF.json
+            jq '.runs |= map( if .taxonomies == [null] then .taxonomies = [] else . end)' < $SARIF |
+            jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uri |= \"$module/src/main/java/\" + ." |
+            jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uriBaseId |= \"%SRC_ROOT%\" " |
+            jq '.runs[].tool.driver.rules |= map( . += { fullDescription: { text: .shortDescription.text } } )' |
+            jq '.runs[].tool.driver.rules |= map( . += { name: ("SpotBugs_" + .id | ascii_downcase | sub("(^|_)(?<x>[a-z])";"\(.x|ascii_upcase)";"g")) } )' |
+            jq '.runs[].tool.driver.rules |= map( . += { help: { text: .helpUri } } )' |
+            jq 'del(.runs[].originalUriBaseIds)' |
+            jq -c '.' > $SARIF.json
             mv $SARIF.json $SARIF
           done
 

--- a/.github/workflows/spotbugs-scan.yml
+++ b/.github/workflows/spotbugs-scan.yml
@@ -2,9 +2,13 @@ name: "SpotBugs"
 
 on:
   push:
-    branches: [adamve/spotbugs-reports-v3]
+    branches:
+      - main
+      - adamve/spotbugs-reports-v3
   pull_request:
-    branches: [adamve/spotbugs-reports-v3]
+    branches:
+      - main
+      - adamve/spotbugs-reports-v3
   schedule:
     - cron: "25 16 * * 0"
 

--- a/.github/workflows/spotbugs-scan.yml
+++ b/.github/workflows/spotbugs-scan.yml
@@ -1,0 +1,70 @@
+name: "SpotBugs"
+
+on:
+  push:
+    branches: [adamve/spotbugs-reports-v3]
+  pull_request:
+    branches: [adamve/spotbugs-reports-v3]
+  schedule:
+    - cron: "25 16 * * 0"
+
+jobs:
+  analyze:
+    name: SpotBugs Analyze
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["java"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Build with Gradle
+        run: ./gradlew spotbugsRelease spotbugsMain
+
+      - name: Fix SARIF
+        run: >-
+          for module in \
+            "android" \
+            "AndroidDemo" \
+            "core" \
+            "fido" \
+            "management" \
+            "oath" \
+            "openpgp" \
+            "piv" \
+            "support" \
+            "testing" \
+            "yubiotp";
+          do
+            SARIF="./build/spotbugs/spotbugs-$module.sarif"
+
+            cat $SARIF |
+              jq '.runs |= map( if .taxonomies == [null] then .taxonomies = [] else . end)' |
+              jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uri |= \"$module/src/main/java/\" + ." |
+              jq '.runs[].tool.driver.rules |= map( . += { fullDescription: { text: .shortDescription.text } } )' |
+              jq '.runs[].tool.driver.rules |= map( . += { help: { text: .helpUri } } )' |
+              jq -c '.' > $SARIF.json
+            mv $SARIF.json $SARIF
+          done
+
+      - name: upload SARIF
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: build/spotbugs/
+          category: spotbugs-analysis

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,8 +36,7 @@ android {
 dependencies {
     api project(':core')
 
-    compileOnly 'androidx.annotation:annotation:1.7.0'
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.0'
+    compileOnly 'androidx.annotation:annotation:1.7.1'
 
     testImplementation project(':testing')
     testImplementation 'androidx.test.ext:junit:1.1.5'

--- a/build.gradle
+++ b/build.gradle
@@ -9,14 +9,13 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.4'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
 plugins {
     id 'maven-publish'
-    id 'com.github.spotbugs' version '5.0.14'
 }
 
 allprojects {
@@ -42,21 +41,6 @@ subprojects {
     tasks.withType(Javadoc).tap {
         configureEach {
             options.addStringOption('Xdoclint:all,-missing', '-quiet')
-        }
-    }
-
-    //noinspection UnnecessaryQualifiedReference
-    tasks.withType(com.github.spotbugs.snom.SpotBugsTask).tap {
-        configureEach {
-            if (it.name == 'spotbugsTest' || it.name == 'spotbugsDebug') {
-                enabled = false
-            } else {
-                group 'verification'
-                reports {
-                    xml.enabled = true
-                    html.enabled = true
-                }
-            }
         }
     }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,3 +1,14 @@
 plugins {
     id 'groovy-gradle-plugin'
 }
+
+repositories {
+    mavenCentral()
+    google()
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.4'
+    implementation 'com.android.tools.build:gradle:8.2.0'
+}

--- a/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
+++ b/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
@@ -1,27 +1,43 @@
+import com.github.spotbugs.snom.Confidence
+import com.github.spotbugs.snom.Effort
+
 plugins {
     id 'com.github.spotbugs'
 }
 
 dependencies {
-    spotbugs 'com.github.spotbugs:spotbugs:4.8.0'
+    spotbugs 'com.github.spotbugs:spotbugs:4.8.3'
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.12.0'
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.0'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.3'
 
     testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 spotbugs {
-    // ignore failures unless all issues are fixed
-    // find current issues in reports/spotbugs for each library
     ignoreFailures = true
-
-    showStackTraces = true
+    showStackTraces = false
     showProgress = false
 
-    effort = "max"
-    reportLevel = "low"
+    effort = Effort.MAX
+    reportLevel = Confidence.valueOf('LOW')
+}
 
-    reportsDir = project.layout.getBuildDirectory().dir('reports/spotbugs').get().asFile
+tasks.matching {
+    it.name == "spotbugsTest"
+}.configureEach {
+    enabled = false
+}
+
+tasks.matching {
+    it.name == "spotbugsMain" || it.name == "spotbugsRelease"
+}.configureEach {
+    enabled = true
+    reports.create("html") {
+        outputLocation = file("${project.rootDir}/build/spotbugs-html/spotbugs-${project.name}.html")
+    }
+    reports.create("sarif") {
+        outputLocation = file("${project.rootDir}/build/spotbugs/spotbugs-${project.name}.sarif")
+    }
 }

--- a/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
+++ b/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
@@ -20,8 +20,8 @@ spotbugs {
     showStackTraces = false
     showProgress = false
 
-    effort = Effort.MAX
-    reportLevel = Confidence.valueOf('LOW')
+    effort = Effort.MORE
+    reportLevel = Confidence.valueOf('DEFAULT')
 }
 
 tasks.matching {


### PR DESCRIPTION
This PR is to test whether uploading SARIF files generated by spotbugs applies found vulnerabilities in the Security/Code Scanning GitHub section. (No effect have been seen when this running in branch)

- SpotBugs related gradle code is moved to `project-convention-spotbugs.gradle`
- Produced SARIF files are uploaded to GitHub for analysis
- Produced HTML files are available to browse locally when using `./gradlew spotbugsMain spotbugsRelease --rerun-tasks`

Note: the `Fix Sarif` step uses `jq` to update the sarif format to be closer to the [GitHub specification](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#providing-data-to-track-code-scanning-alerts-across-runs) but I did not see any effect if required parameters were present or not.