### PR TITLE
Fix MC/GA UserVerificationRequirement.DISCOURAGED

### DIFF
--- a/fido/src/main/java/com/yubico/yubikit/fido/client/BasicWebAuthnClient.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/BasicWebAuthnClient.java
@@ -19,7 +19,6 @@ package com.yubico.yubikit.fido.client;
 import com.yubico.yubikit.core.application.CommandException;
 import com.yubico.yubikit.core.application.CommandState;
 import com.yubico.yubikit.core.fido.CtapException;
-import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.fido.ctap.ClientPin;
 import com.yubico.yubikit.fido.ctap.CredentialManagement;
 import com.yubico.yubikit.fido.ctap.Ctap2Session;
@@ -188,7 +187,6 @@ public class BasicWebAuthnClient implements Closeable {
             if (e.getCtapError() == CtapException.ERR_PIN_INVALID) {
                 throw new PinInvalidClientError(e, clientPin.getPinRetries().getCount());
             }
-            Logger.debug(logger, "makeCredential CTAP error: {}", String.format("0x%02x", e.getCtapError()));
             throw ClientError.wrapCtapException(e);
         }
     }
@@ -432,9 +430,8 @@ public class BasicWebAuthnClient implements Closeable {
                 pinToken = clientPin.getUvToken(ClientPin.PIN_PERMISSION_MC, rpId, null);
                 pinUvAuthParam = clientPin.getPinUvAuth().authenticate(pinToken, clientDataHash);
                 pinUvAuthProtocol = clientPin.getPinUvAuth().getVersion();
-            } else if (pinConfigured && Boolean.TRUE.equals(ctapOptions.get(OPTION_RESIDENT_KEY))) {
-                // the authenticator supports pin and a discoverable credential creation has been
-                // requested, but no PIN was provided
+            } else if (pinConfigured) {
+                // the authenticator supports pin but no PIN was provided
                 throw new PinRequiredClientError();
             }
 
@@ -555,7 +552,6 @@ public class BasicWebAuthnClient implements Closeable {
             if (e.getCtapError() == CtapException.ERR_PIN_INVALID) {
                 throw new PinInvalidClientError(e, clientPin.getPinRetries().getCount());
             }
-            Logger.debug(logger, "getAssertion CTAP error: {}", String.format("0x%02x", e.getCtapError()));
             throw ClientError.wrapCtapException(e);
         } finally {
             if (pinToken != null) {

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/BasicWebAuthnClientInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/BasicWebAuthnClientInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/BasicWebAuthnClientInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/BasicWebAuthnClientInstrumentedTests.java
@@ -20,6 +20,7 @@ import static com.yubico.yubikit.testing.fido.Ctap2ClientPinInstrumentedTests.su
 
 import androidx.test.filters.LargeTest;
 
+import com.yubico.yubikit.fido.ctap.ClientPin;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocolV1;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocolV2;
@@ -54,7 +55,18 @@ public class BasicWebAuthnClientInstrumentedTests {
             withCtap2Session(
                     (device, session) -> supportsPinUvAuthProtocol(session, pinUvAuthProtocol),
                     BasicWebAuthnClientTests::testMakeCredentialGetAssertion,
-                    pinUvAuthProtocol);
+                    pinUvAuthProtocol,
+                    TestData.PIN);
+        }
+
+        @Test
+        public void testMakeCredentialGetAssertionTokenUvOnly() throws Throwable {
+            withCtap2Session(
+                    (device, session) -> supportsPinUvAuthProtocol(session, pinUvAuthProtocol)
+                            && ClientPin.isTokenSupported(session.getCachedInfo()),
+                    BasicWebAuthnClientTests::testMakeCredentialGetAssertion,
+                    pinUvAuthProtocol,
+                    null);
         }
 
         @Test

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/UvDiscouragedInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/UvDiscouragedInstrumentedTests.java
@@ -18,7 +18,7 @@ package com.yubico.yubikit.testing.fido;
 
 import androidx.test.filters.LargeTest;
 
-import com.yubico.yubikit.fido.client.ClientError;
+import com.yubico.yubikit.fido.client.PinRequiredClientError;
 import com.yubico.yubikit.fido.ctap.Ctap2Session;
 import com.yubico.yubikit.testing.framework.FidoInstrumentedTests;
 
@@ -43,9 +43,9 @@ public class UvDiscouragedInstrumentedTests extends FidoInstrumentedTests {
 
     /**
      * Run this test only on devices with PIN set
-     * this is expected to fail with 0x36
+     * Expected to fail with PinRequiredClientError
      */
-    @Test(expected = ClientError.class)
+    @Test(expected = PinRequiredClientError.class)
     public void testMakeCredentialGetAssertionOnProtected() throws Throwable {
         withCtap2Session(
                 "This device has no PIN set",

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/UvDiscouragedInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/UvDiscouragedInstrumentedTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.testing.fido;
+
+import androidx.test.filters.LargeTest;
+
+import com.yubico.yubikit.fido.client.ClientError;
+import com.yubico.yubikit.fido.ctap.Ctap2Session;
+import com.yubico.yubikit.testing.framework.FidoInstrumentedTests;
+
+import org.junit.Test;
+
+@LargeTest
+public class UvDiscouragedInstrumentedTests extends FidoInstrumentedTests {
+
+    static boolean hasPin(Ctap2Session session) {
+        final Ctap2Session.InfoData info = session.getCachedInfo();
+        return Boolean.TRUE.equals(info.getOptions().get("clientPin"));
+    }
+
+    @Test
+    public void testMakeCredentialGetAssertion() throws Throwable {
+        withCtap2Session(
+                "This device has a PIN set",
+                (device, session) -> !hasPin(session),
+                BasicWebAuthnClientTests::testUvDiscouragedMakeCredentialGetAssertion);
+    }
+
+
+    /**
+     * Run this test only on devices with PIN set
+     * this is expected to fail with 0x36
+     */
+    @Test(expected = ClientError.class)
+    public void testMakeCredentialGetAssertionOnProtected() throws Throwable {
+        withCtap2Session(
+                "This device has no PIN set",
+                (device, session) -> hasPin(session),
+                BasicWebAuthnClientTests::testUvDiscouragedMakeCredentialGetAssertion);
+    }
+}

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/BasicWebAuthnClientTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/BasicWebAuthnClientTests.java
@@ -71,6 +71,8 @@ public class BasicWebAuthnClientTests {
 
         Ctap2ClientPinTests.ensureDefaultPinSet(session, Ctap2ClientPinTests.getPinUvAuthProtocol(args));
 
+        char[] pin = (char[]) args[1];
+
         BasicWebAuthnClient webauthn = new BasicWebAuthnClient(session);
         List<byte[]> deleteCredIds = new ArrayList<>();
 
@@ -89,7 +91,7 @@ public class BasicWebAuthnClientTests {
                 TestData.CLIENT_DATA_JSON_CREATE,
                 creationOptionsNonRk,
                 Objects.requireNonNull(creationOptionsNonRk.getRp().getId()),
-                TestData.PIN,
+                pin,
                 null,
                 null
         );
@@ -112,7 +114,7 @@ public class BasicWebAuthnClientTests {
                 TestData.CLIENT_DATA_JSON_CREATE,
                 creationOptionsRk,
                 Objects.requireNonNull(creationOptionsRk.getRp().getId()),
-                TestData.PIN,
+                pin,
                 null,
                 null
         );
@@ -137,7 +139,7 @@ public class BasicWebAuthnClientTests {
                     TestData.CLIENT_DATA_JSON_GET,
                     requestOptions,
                     TestData.RP_ID,
-                    TestData.PIN,
+                    pin,
                     null
             );
             AuthenticatorAssertionResponse response = (AuthenticatorAssertionResponse) credential.getResponse();


### PR DESCRIPTION
Pass correct values of pinUvAuthParam and pinUvAuthProtocol to makeCredential.

Before this fix, we wrongly passed `0` pinUvAuthProtocol value instead of `null`. 

The new integration test verify makeCredential and getAssertion with `null` PIN and UserVerificationRequirement.DISCOURAGED. This way it is possible to create rk = true and rk = false credentials on FIDO2 keys which don't have PIN set. FIDO2 keys with set PIN will return `0x36` PIN_REQUIRED error.