### PR TITLE
Improve DeviceInfo and DeviceConfig

### DIFF
--- a/management/src/main/java/com/yubico/yubikit/management/DeviceConfig.java
+++ b/management/src/main/java/com/yubico/yubikit/management/DeviceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Yubico.
+ * Copyright (C) 2020-2022,2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -134,6 +135,22 @@ public class DeviceConfig {
             throw new IllegalStateException("DeviceConfiguration too large");
         }
         return ByteBuffer.allocate(data.length + 1).put((byte) data.length).put(data).array();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DeviceConfig that = (DeviceConfig) o;
+        return Objects.equals(enabledCapabilities, that.enabledCapabilities) &&
+                Objects.equals(autoEjectTimeout, that.autoEjectTimeout) &&
+                Objects.equals(challengeResponseTimeout, that.challengeResponseTimeout) &&
+                Objects.equals(deviceFlags, that.deviceFlags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabledCapabilities, autoEjectTimeout, challengeResponseTimeout, deviceFlags);
     }
 
     /**

--- a/management/src/test/java/com/yubico/yubikit/management/DeviceConfigBuilderTest.java
+++ b/management/src/test/java/com/yubico/yubikit/management/DeviceConfigBuilderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.management;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.yubico.yubikit.core.Transport;
+
+import org.junit.Test;
+
+public class DeviceConfigBuilderTest {
+
+    @Test
+    public void testDefaults() {
+        DeviceConfig defaultConfig = new DeviceConfig.Builder().build();
+        assertNull(defaultConfig.getEnabledCapabilities(Transport.USB));
+        assertNull(defaultConfig.getEnabledCapabilities(Transport.NFC));
+        assertNull(defaultConfig.getAutoEjectTimeout());
+        assertNull(defaultConfig.getChallengeResponseTimeout());
+        assertNull(defaultConfig.getDeviceFlags());
+    }
+
+    @Test
+    public void testBuild() {
+        DeviceConfig defaultConfig = new DeviceConfig.Builder()
+                .enabledCapabilities(Transport.USB, 12345)
+                .enabledCapabilities(Transport.NFC, 67890)
+                .autoEjectTimeout((short)128)
+                .challengeResponseTimeout((byte)55)
+                .deviceFlags(98765)
+                .build();
+        assertEquals(Integer.valueOf(12345), defaultConfig.getEnabledCapabilities(Transport.USB));
+        assertEquals(Integer.valueOf(67890), defaultConfig.getEnabledCapabilities(Transport.NFC));
+        assertEquals(Short.valueOf((short)128), defaultConfig.getAutoEjectTimeout());
+        assertEquals(Byte.valueOf((byte)55), defaultConfig.getChallengeResponseTimeout());
+        assertEquals(Integer.valueOf(98765), defaultConfig.getDeviceFlags());
+    }
+}

--- a/management/src/test/java/com/yubico/yubikit/management/DeviceInfoBuilderTest.java
+++ b/management/src/test/java/com/yubico/yubikit/management/DeviceInfoBuilderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.management;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.yubico.yubikit.core.Transport;
+import com.yubico.yubikit.core.Version;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DeviceInfoBuilderTest {
+
+    @Test
+    public void testDefaults() {
+        DeviceConfig defaultConfig = new DeviceConfig.Builder().build();
+        DeviceInfo defaultInfo = new DeviceInfo.Builder().build();
+        assertEquals(defaultConfig, defaultInfo.getConfig());
+        assertNull(defaultInfo.getSerialNumber());
+        assertEquals(new Version(0, 0, 0), defaultInfo.getVersion());
+        assertEquals(FormFactor.UNKNOWN, defaultInfo.getFormFactor());
+        assertEquals(0, defaultInfo.getSupportedCapabilities(Transport.USB));
+        assertEquals(0, defaultInfo.getSupportedCapabilities(Transport.NFC));
+        assertFalse(defaultInfo.isLocked());
+        assertFalse(defaultInfo.isFips());
+        assertFalse(defaultInfo.isSky());
+        assertFalse(defaultInfo.getPinComplexity());
+        assertFalse(defaultInfo.hasTransport(Transport.USB));
+        assertFalse(defaultInfo.hasTransport(Transport.NFC));
+    }
+
+    @Test
+    public void testConstruction() {
+        Map<Transport, Integer> supportedCapabilities = new HashMap<>();
+        supportedCapabilities.put(Transport.USB, 123);
+        supportedCapabilities.put(Transport.NFC, 456);
+        DeviceConfig deviceConfig = new DeviceConfig.Builder().build();
+        DeviceInfo deviceInfo = new DeviceInfo.Builder()
+                .config(deviceConfig)
+                .serialNumber(987654321)
+                .version(new Version(3, 1, 1))
+                .formFactor(FormFactor.USB_A_KEYCHAIN)
+                .supportedCapabilities(supportedCapabilities)
+                .isLocked(true)
+                .isFips(true)
+                .isSky(true)
+                .pinComplexity(true)
+                .build();
+        assertEquals(deviceConfig, deviceInfo.getConfig());
+        assertEquals(Integer.valueOf(987654321), deviceInfo.getSerialNumber());
+        assertEquals(new Version(3, 1, 1), deviceInfo.getVersion());
+        assertEquals(FormFactor.USB_A_KEYCHAIN, deviceInfo.getFormFactor());
+        assertEquals(123, deviceInfo.getSupportedCapabilities(Transport.USB));
+        assertEquals(456, deviceInfo.getSupportedCapabilities(Transport.NFC));
+        assertTrue(deviceInfo.isLocked());
+        assertTrue(deviceInfo.isFips());
+        assertTrue(deviceInfo.isSky());
+        assertTrue(deviceInfo.getPinComplexity());
+        assertTrue(deviceInfo.hasTransport(Transport.USB));
+        assertTrue(deviceInfo.hasTransport(Transport.NFC));
+    }
+}

--- a/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
+++ b/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,16 +146,11 @@ public class DeviceUtil {
         supportedCapabilities.put(Transport.USB, capabilities);
         supportedCapabilities.put(Transport.NFC, capabilities);
 
-        return new DeviceInfo(
-                new DeviceConfig.Builder().build(),
-                serial,
-                version,
-                FormFactor.UNKNOWN,
-                supportedCapabilities,
-                false,
-                false,
-                false);
-
+        return new DeviceInfo.Builder()
+                .serialNumber(serial)
+                .version(version)
+                .supportedCapabilities(supportedCapabilities)
+                .build();
     }
 
     static DeviceInfo readInfoOtp(OtpConnection connection, YubiKeyType keyType, int interfaces)
@@ -224,15 +219,11 @@ public class DeviceUtil {
             capabilities.put(Transport.USB, Capability.OTP.bit);
         }
 
-        return new DeviceInfo(
-                new DeviceConfig.Builder().build(), // defaults
-                serial,
-                version,
-                FormFactor.UNKNOWN,
-                capabilities,
-                false,
-                false,
-                false);
+        return new DeviceInfo.Builder()
+                .serialNumber(serial)
+                .version(version)
+                .supportedCapabilities(capabilities)
+                .build();
     }
 
     static DeviceInfo readInfoFido(FidoConnection connection, YubiKeyType keyType)
@@ -256,15 +247,11 @@ public class DeviceUtil {
                 supportedApps.put(Transport.NFC, supportedApps.get(Transport.USB));
             }
 
-            return new DeviceInfo(
-                    new DeviceConfig.Builder().build(), // defaults
-                    null,
-                    version,
-                    FormFactor.USB_A_KEYCHAIN,
-                    supportedApps,
-                    false,
-                    false,
-                    false);
+            return new DeviceInfo.Builder()
+                    .version(version)
+                    .formFactor(FormFactor.USB_A_KEYCHAIN)
+                    .supportedCapabilities(supportedApps)
+                    .build();
         }
     }
 
@@ -358,6 +345,7 @@ public class DeviceUtil {
         final boolean isSky = info.isSky() || keyType == YubiKeyType.SKY;
         final boolean isFips = info.isFips() ||
                 (version.isAtLeast(4, 4, 0) && version.isLessThan(4, 5, 0));
+        final boolean pinComplexity = info.getPinComplexity();
 
         // Set nfc_enabled if missing (pre YubiKey 5)
         if (info.hasTransport(Transport.NFC) && enabledNfcCapabilities == null) {
@@ -410,17 +398,17 @@ public class DeviceUtil {
             capabilities.put(Transport.NFC, supportedNfcCapabilities);
         }
 
-        return new DeviceInfo(
-                configBuilder.build(),
-                info.getSerialNumber(),
-                version,
-                formFactor,
-                capabilities,
-                info.isLocked(),
-                isFips,
-                isSky
-        );
-
+        return new DeviceInfo.Builder()
+                .config(configBuilder.build())
+                .version(version)
+                .formFactor(formFactor)
+                .serialNumber(info.getSerialNumber())
+                .supportedCapabilities(capabilities)
+                .isLocked(info.isLocked())
+                .isFips(isFips)
+                .isSky(isSky)
+                .pinComplexity(pinComplexity)
+                .build();
     }
 
     /**

--- a/support/src/test/java/com/yubico/yubikit/support/Util.java
+++ b/support/src/test/java/com/yubico/yubikit/support/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.yubico.yubikit.support;
 
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.Version;
-import com.yubico.yubikit.management.DeviceConfig;
 import com.yubico.yubikit.management.DeviceInfo;
 import com.yubico.yubikit.management.FormFactor;
 
@@ -63,12 +62,13 @@ public class Util {
                     }
                 }
             };
-            return new DeviceInfo(new DeviceConfig.Builder().build(),
-                    serialNumber,
-                    new Version(5, 3, 0),
-                    formFactor,
-                    supportedCapabilities,
-                    false, false, isSky);
+            return new DeviceInfo.Builder()
+                    .serialNumber(serialNumber)
+                    .version(new Version(5, 3, 0))
+                    .formFactor(formFactor)
+                    .supportedCapabilities(supportedCapabilities)
+                    .isSky(isSky)
+                    .build();
         }
     }
 


### PR DESCRIPTION
- Implements Builder design pattern for DeviceInfo and deprecates existing constructors.
- Adds support for reading DeviceConfig data from all existing pages.
- Adds missing unit tests for both DeviceConfig and DeviceInfo classes.  