### PR TITLE
Implement RFC 4648 Base32 Encoding

### DIFF
--- a/AndroidDemo/build.gradle
+++ b/AndroidDemo/build.gradle
@@ -77,7 +77,6 @@ dependencies {
     implementation "androidx.navigation:navigation-dynamic-features-fragment:$nav_version"
 
     implementation 'org.bouncycastle:bcpkix-jdk15to18:1.77'
-    implementation 'commons-codec:commons-codec:1.16.1' // for Base32
 
     implementation 'com.github.tony19:logback-android:3.0.0'
 

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/oath/OathFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/oath/OathFragment.kt
@@ -31,13 +31,13 @@ import com.yubico.yubikit.android.app.ui.getSecret
 import com.yubico.yubikit.core.smartcard.ApduException
 import com.yubico.yubikit.core.smartcard.SW
 import com.yubico.yubikit.core.util.RandomUtils
+import com.yubico.yubikit.oath.Base32
 import com.yubico.yubikit.oath.CredentialData
 import com.yubico.yubikit.oath.HashAlgorithm
 import com.yubico.yubikit.oath.OathSession
 import com.yubico.yubikit.oath.OathType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.apache.commons.codec.binary.Base32
 
 class OathFragment : YubiKeyFragment<OathSession, OathViewModel>() {
     override val viewModel: OathViewModel by activityViewModels()
@@ -107,13 +107,13 @@ class OathFragment : YubiKeyFragment<OathSession, OathViewModel>() {
         }
 
         binding.textLayoutKey.setEndIconOnClickListener {
-            binding.editTextKey.setText(Base32().encodeToString(RandomUtils.getRandomBytes(10)))
+            binding.editTextKey.setText(Base32.encode(RandomUtils.getRandomBytes(10)))
         }
-        binding.editTextKey.setText(Base32().encodeToString(RandomUtils.getRandomBytes(10)))
+        binding.editTextKey.setText(Base32.encode(RandomUtils.getRandomBytes(10)))
 
         binding.btnSave.setOnClickListener {
             try {
-                val secret = Base32().decode(binding.editTextKey.text.toString())
+                val secret = Base32.decode(binding.editTextKey.text.toString())
                 val issuer = binding.editTextIssuer.text.toString()
                 if (issuer.isBlank()) {
                     binding.editTextIssuer.error = "Issuer must not be empty"

--- a/oath/build.gradle
+++ b/oath/build.gradle
@@ -2,8 +2,6 @@ apply plugin: 'yubikit-java-library'
 
 dependencies {
     api project(':core')
-
-    implementation 'commons-codec:commons-codec:1.16.1' // for Base32
 }
 
 ext.pomName = "Yubico YubiKit ${project.name.capitalize()}"

--- a/oath/src/main/java/com/yubico/yubikit/oath/Base32.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/Base32.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.oath;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+/**
+ * Base32 implementation of RFC4684, section 6
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc4648#section-6">Base 32 Encoding</a>
+ */
+@SuppressWarnings("SpellCheckingInspection")
+public class Base32 {
+    private static final char[] ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567=".toCharArray();
+
+    private static final char PADDING = '=';
+
+    private static final String[] ENCODE_PADDING = new String[]{
+            "", "======", "====", "===", "="
+    };
+
+    public static String encode(byte[] data) {
+        StringBuilder buf = new StringBuilder();
+
+        int len = data.length;
+        for (int i = 0; i < len; i += 5) {
+            int b0 = Byte.toUnsignedInt(data[i]);
+            int b1 = len > i + 1 ? Byte.toUnsignedInt(data[i + 1]) : 0;
+            int b2 = len > i + 2 ? Byte.toUnsignedInt(data[i + 2]) : 0;
+            int b3 = len > i + 3 ? Byte.toUnsignedInt(data[i + 3]) : 0;
+            int b4 = len > i + 4 ? Byte.toUnsignedInt(data[i + 4]) : 0;
+
+            buf.append(ALPHABET[b0 >> 3]);
+            buf.append(ALPHABET[b0 << 2 & 0x1c | b1 >> 6]);
+            if (len <= i + 1) break;
+            buf.append(ALPHABET[b1 >> 1 & 0x1f]);
+            buf.append(ALPHABET[b1 << 4 & 0x10 | b2 >> 4]);
+            if (len <= i + 2) break;
+            buf.append(ALPHABET[b2 << 1 & 0x1e | b3 >> 7]);
+            if (len <= i + 3) break;
+            buf.append(ALPHABET[b3 >> 2 & 0x1f]);
+            buf.append(ALPHABET[b3 << 3 & 0x1c | b4 >> 5]);
+            if (len <= i + 4) break;
+            buf.append(ALPHABET[b4 & 0x1f]);
+        }
+
+        buf.append(ENCODE_PADDING[len % 5]);
+        return buf.toString();
+    }
+
+    public static boolean isValid(String encoded) {
+        return encoded.matches("[A-Z2-7=]*");
+    }
+
+    public static byte[] decode(String encoded) {
+
+        if (!isValid(encoded)) {
+            throw new IllegalArgumentException("Invalid base32");
+        }
+
+        char[] padding = new char[(8 - encoded.length() % 8) % 8];
+        Arrays.fill(padding, PADDING);
+        String b32 = encoded.concat(new String(padding));
+
+        int len = b32.length();
+        int maxBufLength = len / 8 * 5;
+        byte[] buffer = new byte[maxBufLength];
+
+        ByteBuffer bb = ByteBuffer.wrap(buffer);
+
+        for (int i = 0; i < b32.length(); i += 8) {
+            final char[] chars = b32.toCharArray();
+
+            // input characters
+            char c0 = chars[i];
+            char c1 = chars[i + 1];
+            char c2 = chars[i + 2];
+            char c3 = chars[i + 3];
+            char c4 = chars[i + 4];
+            char c5 = chars[i + 5];
+            char c6 = chars[i + 6];
+            char c7 = chars[i + 7];
+
+            // input values
+            byte v0 = getValue(c0);
+            byte v1 = getValue(c1);
+            byte v2 = getValue(c2);
+            byte v3 = getValue(c3);
+            byte v4 = getValue(c4);
+            byte v5 = getValue(c5);
+            byte v6 = getValue(c6);
+            byte v7 = getValue(c7);
+
+            // validate padding characters
+            if (c0 == PADDING || c1 == PADDING) {
+                throw new IllegalArgumentException("Invalid base32 padding");
+            }
+
+            if ((c2 == PADDING && c3 != PADDING) ||
+                    (c3 == PADDING && c4 != PADDING) || (c4 == PADDING && c5 != PADDING) ||
+                    (c5 == PADDING && c6 != PADDING) || (c6 == PADDING && c7 != PADDING)) {
+                throw new IllegalArgumentException("Non-base32 digit found");
+            }
+
+            // build result until padding is found
+            bb.put((byte) (v0 << 3 | v1 >> 2));
+            if (c2 == PADDING) break;
+            bb.put((byte) (v1 << 6 | v2 << 1 | v3 >> 4));
+            if (c3 == PADDING) break;
+            bb.put((byte) (v3 << 4 | v4 >> 1));
+            if (c4 == PADDING) break;
+            bb.put((byte) (v4 << 7 | v5 << 2 | v6 >> 3));
+            if (c6 == PADDING) break;
+            bb.put((byte) (v6 << 5 | v7));
+        }
+
+        // update result length
+        int resultLength = bb.position();
+        byte[] result = Arrays.copyOf(buffer, (resultLength > 0 && buffer[resultLength - 1] == 0)
+                ? resultLength - 1 // strip last byte if 0
+                : resultLength);
+        Arrays.fill(buffer, (byte) 0);
+        return result;
+    }
+
+    private static byte getValue(char c) {
+        // compute the value
+        // if c is the padding character, use 0 to simplify bit operations
+        return c == PADDING ? 0 : (byte) ((c < 'A' ? c - '2' + 26 : c - 'A') & 0x1f);
+    }
+}

--- a/oath/src/main/java/com/yubico/yubikit/oath/CredentialData.java
+++ b/oath/src/main/java/com/yubico/yubikit/oath/CredentialData.java
@@ -18,8 +18,6 @@ package com.yubico.yubikit.oath;
 
 import com.yubico.yubikit.core.util.Pair;
 
-import org.apache.commons.codec.binary.Base32;
-
 import java.io.Serializable;
 import java.net.URI;
 import java.util.Arrays;
@@ -291,11 +289,10 @@ public class CredentialData implements Serializable {
      */
     private static byte[] decodeSecret(String secret) throws ParseUriException {
         secret = secret.toUpperCase();
-        Base32 base32 = new Base32();
-        if (base32.isInAlphabet(secret)) {
-            return base32.decode(secret);
+        try {
+            return Base32.decode(secret);
+        } catch (IllegalArgumentException illegalArgumentException) {
+            throw new ParseUriException("secret must be base32 encoded");
         }
-
-        throw new ParseUriException("secret must be base32 encoded");
     }
 }

--- a/oath/src/test/java/com/yubico/yubikit/oath/Base32Test.java
+++ b/oath/src/test/java/com/yubico/yubikit/oath/Base32Test.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.oath;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.yubico.yubikit.testing.Codec;
+
+import org.junit.Test;
+
+@SuppressWarnings("SpellCheckingInspection")
+public class Base32Test {
+
+    @Test
+    public void testValidInput() {
+        assertTrue(Base32.isValid(""));
+        assertTrue(Base32.isValid("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567="));
+    }
+
+    @Test
+    public void testInvalidInput() {
+        assertFalse(Base32.isValid("0189"));
+        assertFalse(Base32.isValid(";.*"));
+        assertFalse(Base32.isValid("😀"));
+        assertFalse(Base32.isValid("abcdefghijklmnopqrstuvwxyz234567="));
+    }
+
+    @Test
+    public void testEncode() {
+        assertEquals("", Base32.encode("".getBytes()));
+        assertEquals("MY======", Base32.encode("f".getBytes()));
+        assertEquals("MZXQ====", Base32.encode("fo".getBytes()));
+        assertEquals("MZXW6===", Base32.encode("foo".getBytes()));
+        assertEquals("MZXW6YQ=", Base32.encode("foob".getBytes()));
+        assertEquals("MZXW6YTB", Base32.encode("fooba".getBytes()));
+        assertEquals("MZXW6YTBOI======", Base32.encode("foobar".getBytes()));
+        assertEquals("PF2WE2LLNF2C243ENMQDELSYFYYCAIBAEE======", Base32.encode("yubikit-sdk 2.X.0   !".getBytes()));
+        assertEquals("KRUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEB2GQZJANRQXU6JAMRXWOLQ=", Base32.encode("The quick brown fox jumps over the lazy dog.".getBytes()));
+        assertEquals("WZEBZC7I6IQXTNMK", Base32.encode(Codec.fromHex("b6481c8be8f22179b58a")));
+        assertEquals("NG3EQHELVORLMDUPEILZWWGNKY======", Base32.encode(Codec.fromHex("69b6481c8baba2b60e8f22179b58cd56")));
+    }
+
+    @Test
+    public void testDecode() {
+        assertArrayEquals("".getBytes(), Base32.decode(""));
+        assertArrayEquals("f".getBytes(), Base32.decode("MY"));
+        assertArrayEquals("f".getBytes(), Base32.decode("MY======"));
+        assertArrayEquals("fo".getBytes(), Base32.decode("MZXQ"));
+        assertArrayEquals("fo".getBytes(), Base32.decode("MZXQ===="));
+        assertArrayEquals("foo".getBytes(), Base32.decode("MZXW6"));
+        assertArrayEquals("foo".getBytes(), Base32.decode("MZXW6==="));
+        assertArrayEquals("foob".getBytes(), Base32.decode("MZXW6YQ"));
+        assertArrayEquals("foob".getBytes(), Base32.decode("MZXW6YQ="));
+        assertArrayEquals("fooba".getBytes(), Base32.decode("MZXW6YTB"));
+        assertArrayEquals("foobar".getBytes(), Base32.decode("MZXW6YTBOI"));
+        assertArrayEquals("foobar".getBytes(), Base32.decode("MZXW6YTBOI======"));
+        assertArrayEquals("yubikit-sdk 2.X.0   !".getBytes(), Base32.decode("PF2WE2LLNF2C243ENMQDELSYFYYCAIBAEE"));
+        assertArrayEquals("yubikit-sdk 2.X.0   !".getBytes(), Base32.decode("PF2WE2LLNF2C243ENMQDELSYFYYCAIBAEE======"));
+        assertArrayEquals("The quick brown fox jumps over the lazy dog.".getBytes(), Base32.decode("KRUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEB2GQZJANRQXU6JAMRXWOLQ="));
+        assertArrayEquals(Codec.fromHex("b6481c8be8f22179b58a"), Base32.decode("WZEBZC7I6IQXTNMK"));
+        assertArrayEquals(Codec.fromHex("69b6481c8baba2b60e8f22179b58cd56"), Base32.decode("NG3EQHELVORLMDUPEILZWWGNKY======"));
+    }
+
+    @Test //(expected = IllegalArgumentException.class)
+    public void testDecodeThrows() {
+        try {
+            assertArrayEquals("invalid".getBytes(), Base32.decode("invalidinput"));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        try {
+            assertArrayEquals("".getBytes(), Base32.decode("M="));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        try {
+            assertArrayEquals("".getBytes(), Base32.decode("A=A"));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+}

--- a/oath/src/test/java/com/yubico/yubikit/oath/Base32Test.java
+++ b/oath/src/test/java/com/yubico/yubikit/oath/Base32Test.java
@@ -32,7 +32,14 @@ public class Base32Test {
     @Test
     public void testValidInput() {
         assertTrue(Base32.isValid(""));
-        assertTrue(Base32.isValid("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567="));
+        assertTrue(Base32.isValid("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"));
+        assertTrue(Base32.isValid("AA======"));
+        assertTrue(Base32.isValid("MZXQ===="));
+        assertTrue(Base32.isValid("AA"));
+        assertTrue(Base32.isValid("AAAA"));
+        assertTrue(Base32.isValid("AAAAA"));
+        assertTrue(Base32.isValid("AAAAAAA"));
+
     }
 
     @Test
@@ -40,7 +47,22 @@ public class Base32Test {
         assertFalse(Base32.isValid("0189"));
         assertFalse(Base32.isValid(";.*"));
         assertFalse(Base32.isValid("😀"));
-        assertFalse(Base32.isValid("abcdefghijklmnopqrstuvwxyz234567="));
+        assertFalse(Base32.isValid("abcdefghijklmnopqrstuvwxyz234567"));
+        assertFalse(Base32.isValid("AA="));
+        assertFalse(Base32.isValid("AA=="));
+        assertFalse(Base32.isValid("AA==="));
+        assertFalse(Base32.isValid("AA===="));
+        assertFalse(Base32.isValid("AA====="));
+        assertFalse(Base32.isValid("AA======="));
+        assertFalse(Base32.isValid("A"));
+        assertFalse(Base32.isValid("AAA"));
+        assertFalse(Base32.isValid("AAAAAA"));
+        assertFalse(Base32.isValid("="));
+        assertFalse(Base32.isValid("=="));
+        assertFalse(Base32.isValid("==="));
+        assertFalse(Base32.isValid("AAAAAAA=A"));
+        assertFalse(Base32.isValid("MZ=XW6YTB"));
+        assertFalse(Base32.isValid("MZXQ=="));
     }
 
     @Test
@@ -60,41 +82,79 @@ public class Base32Test {
 
     @Test
     public void testDecode() {
-        assertArrayEquals("".getBytes(), Base32.decode(""));
-        assertArrayEquals("f".getBytes(), Base32.decode("MY"));
         assertArrayEquals("f".getBytes(), Base32.decode("MY======"));
-        assertArrayEquals("fo".getBytes(), Base32.decode("MZXQ"));
         assertArrayEquals("fo".getBytes(), Base32.decode("MZXQ===="));
-        assertArrayEquals("foo".getBytes(), Base32.decode("MZXW6"));
         assertArrayEquals("foo".getBytes(), Base32.decode("MZXW6==="));
-        assertArrayEquals("foob".getBytes(), Base32.decode("MZXW6YQ"));
         assertArrayEquals("foob".getBytes(), Base32.decode("MZXW6YQ="));
         assertArrayEquals("fooba".getBytes(), Base32.decode("MZXW6YTB"));
-        assertArrayEquals("foobar".getBytes(), Base32.decode("MZXW6YTBOI"));
         assertArrayEquals("foobar".getBytes(), Base32.decode("MZXW6YTBOI======"));
-        assertArrayEquals("yubikit-sdk 2.X.0   !".getBytes(), Base32.decode("PF2WE2LLNF2C243ENMQDELSYFYYCAIBAEE"));
         assertArrayEquals("yubikit-sdk 2.X.0   !".getBytes(), Base32.decode("PF2WE2LLNF2C243ENMQDELSYFYYCAIBAEE======"));
         assertArrayEquals("The quick brown fox jumps over the lazy dog.".getBytes(), Base32.decode("KRUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEB2GQZJANRQXU6JAMRXWOLQ="));
-        assertArrayEquals(Codec.fromHex("b6481c8be8f22179b58a"), Base32.decode("WZEBZC7I6IQXTNMK"));
         assertArrayEquals(Codec.fromHex("69b6481c8baba2b60e8f22179b58cd56"), Base32.decode("NG3EQHELVORLMDUPEILZWWGNKY======"));
     }
 
-    @Test //(expected = IllegalArgumentException.class)
+    @Test
+    public void testDecodeWithoutPadding() {
+        assertArrayEquals("".getBytes(), Base32.decode(""));
+        assertArrayEquals("f".getBytes(), Base32.decode("MY"));
+        assertArrayEquals("fo".getBytes(), Base32.decode("MZXQ"));
+        assertArrayEquals("foo".getBytes(), Base32.decode("MZXW6"));
+        assertArrayEquals("foob".getBytes(), Base32.decode("MZXW6YQ"));
+        assertArrayEquals("fooba".getBytes(), Base32.decode("MZXW6YTB"));
+        assertArrayEquals("foobar".getBytes(), Base32.decode("MZXW6YTBOI"));
+        assertArrayEquals("yubikit-sdk 2.X.0   !".getBytes(), Base32.decode("PF2WE2LLNF2C243ENMQDELSYFYYCAIBAEE"));
+        assertArrayEquals("The quick brown fox jumps over the lazy dog.".getBytes(), Base32.decode("KRUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEB2GQZJANRQXU6JAMRXWOLQ"));
+        assertArrayEquals(Codec.fromHex("b6481c8be8f22179b58a"), Base32.decode("WZEBZC7I6IQXTNMK"));
+    }
+
+    @Test
     public void testDecodeThrows() {
+        byte[] invalid = new byte[]{0};
+
         try {
-            assertArrayEquals("invalid".getBytes(), Base32.decode("invalidinput"));
+            assertArrayEquals(invalid, Base32.decode("invalidinput"));
             fail();
         } catch (IllegalArgumentException ignored) {
         }
 
         try {
-            assertArrayEquals("".getBytes(), Base32.decode("M="));
+            assertArrayEquals(invalid, Base32.decode("M="));
             fail();
         } catch (IllegalArgumentException ignored) {
         }
 
         try {
-            assertArrayEquals("".getBytes(), Base32.decode("A=A"));
+            assertArrayEquals(invalid, Base32.decode("A=A"));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        try {
+            assertArrayEquals(invalid, Base32.decode("="));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        try {
+            assertArrayEquals(invalid, Base32.decode("MZXQ=="));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        try {
+            assertArrayEquals(invalid, Base32.decode("A"));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        try {
+            assertArrayEquals(invalid, Base32.decode("AAA"));
+            fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        try {
+            assertArrayEquals(invalid, Base32.decode("AAAAAA"));
             fail();
         } catch (IllegalArgumentException ignored) {
         }


### PR DESCRIPTION
In the latest version of commons-codec 1.16.1, Android incompatible changes have been introduced. Replaces Apache commons-codec base32 implementation with our own.  We only used that dependency for base32 secret handling in the OATH code.