### PR TITLE
Fix minor DeviceInfo issues

### DIFF
--- a/management/src/main/java/com/yubico/yubikit/management/DeviceConfig.java
+++ b/management/src/main/java/com/yubico/yubikit/management/DeviceConfig.java
@@ -69,7 +69,7 @@ public class DeviceConfig {
         this.autoEjectTimeout = autoEjectTimeout;
         this.challengeResponseTimeout = challengeResponseTimeout;
         this.deviceFlags = deviceFlags;
-        this.nfcRestricted = false;
+        this.nfcRestricted = null;
     }
 
     DeviceConfig(Builder builder) {

--- a/management/src/main/java/com/yubico/yubikit/management/DeviceInfo.java
+++ b/management/src/main/java/com/yubico/yubikit/management/DeviceInfo.java
@@ -60,6 +60,7 @@ public class DeviceInfo {
     private final boolean isLocked;
     private final boolean isFips;
     private final boolean isSky;
+    @Nullable
     private final String partNumber;
     private final int fipsCapable;
     private final int fipsApproved;
@@ -201,6 +202,7 @@ public class DeviceInfo {
     /**
      * Returns part number
      */
+    @Nullable
     public String getPartNumber() {
         return partNumber;
     }
@@ -255,7 +257,8 @@ public class DeviceInfo {
         int formFactorTagData = readInt(data.get(TAG_FORMFACTOR));
         boolean isFips = (formFactorTagData & 0x80) != 0;
         boolean isSky = (formFactorTagData & 0x40) != 0;
-        String partNumber = "";
+        @Nullable
+        String partNumber = null;
         int fipsCapable = fromFips(readInt(data.get(TAG_FIPS_CAPABLE)));
         int fipsApproved = fromFips(readInt(data.get(TAG_FIPS_APPROVED)));
         boolean pinComplexity = readInt(data.get(TAG_PIN_COMPLEXITY)) == 1;
@@ -265,7 +268,6 @@ public class DeviceInfo {
         Version version = data.containsKey(TAG_FIRMWARE_VERSION)
                 ? Version.fromBytes(data.get(TAG_FIRMWARE_VERSION))
                 : defaultVersion;
-
 
         final Version versionZero = new Version(0,0,0);
 
@@ -363,6 +365,7 @@ public class DeviceInfo {
         private boolean isLocked = false;
         private boolean isFips = false;
         private boolean isSky = false;
+        @Nullable
         private String partNumber = "";
         private int fipsCapable = 0;
         private int fipsApproved = 0;
@@ -417,7 +420,7 @@ public class DeviceInfo {
             return this;
         }
 
-        public Builder partNumber(String partNumber) {
+        public Builder partNumber(@Nullable String partNumber) {
             this.partNumber = partNumber;
             return this;
         }

--- a/management/src/main/java/com/yubico/yubikit/management/DeviceInfo.java
+++ b/management/src/main/java/com/yubico/yubikit/management/DeviceInfo.java
@@ -266,13 +266,24 @@ public class DeviceInfo {
                 ? Version.fromBytes(data.get(TAG_FIRMWARE_VERSION))
                 : defaultVersion;
 
-        Version fpsVersion = data.containsKey(TAG_FPS_VERSION)
-                ? Version.fromBytes(data.get(TAG_FPS_VERSION))
-                : null;
 
-        Version stmVersion = data.containsKey(TAG_STM_VERSION)
-                ? Version.fromBytes(data.get(TAG_STM_VERSION))
-                : null;
+        final Version versionZero = new Version(0,0,0);
+
+        Version fpsVersion = null;
+        if (data.containsKey(TAG_FPS_VERSION)) {
+            Version tempVersion = Version.fromBytes(data.get(TAG_FPS_VERSION));
+            if (!tempVersion.equals(versionZero)) {
+                fpsVersion = tempVersion;
+            }
+        }
+
+        Version stmVersion = null;
+        if (data.containsKey(TAG_STM_VERSION)) {
+            Version tempVersion = Version.fromBytes(data.get(TAG_STM_VERSION));
+            if (!tempVersion.equals(versionZero)) {
+                stmVersion = tempVersion;
+            }
+        }
 
         short autoEjectTimeout = (short) readInt(data.get(TAG_AUTO_EJECT_TIMEOUT));
         byte challengeResponseTimeout = (byte) readInt(data.get(TAG_CHALLENGE_RESPONSE_TIMEOUT));

--- a/management/src/test/java/com/yubico/yubikit/management/DeviceInfoTest.java
+++ b/management/src/test/java/com/yubico/yubikit/management/DeviceInfoTest.java
@@ -93,7 +93,7 @@ public class DeviceInfoTest {
     @Test
     public void testParsePartNumber() {
         // valid UTF-8
-        assertEquals("", defaultInfo().getPartNumber());
+        assertNull(defaultInfo().getPartNumber());
         assertEquals("", infoOf(0x13, new byte[0]).getPartNumber());
         assertEquals("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_=+-",
                 infoOf(0x13, fromHex("6162636465666768696A6B6C6D6E6F707172737475767778797A41" +
@@ -107,13 +107,13 @@ public class DeviceInfoTest {
                 infoOf(0x13, fromHex("30313233343536373839414243444546")).getPartNumber());
 
         // invalid UTF-8
-        assertEquals("", infoOf(0x13, fromHex("c328")).getPartNumber());
-        assertEquals("", infoOf(0x13, fromHex("a0a1")).getPartNumber());
-        assertEquals("", infoOf(0x13, fromHex("e228a1")).getPartNumber());
-        assertEquals("", infoOf(0x13, fromHex("e28228")).getPartNumber());
-        assertEquals("", infoOf(0x13, fromHex("f0288cbc")).getPartNumber());
-        assertEquals("", infoOf(0x13, fromHex("f09028bc")).getPartNumber());
-        assertEquals("", infoOf(0x13, fromHex("f0288c28")).getPartNumber());
+        assertNull(infoOf(0x13, fromHex("c328")).getPartNumber());
+        assertNull(infoOf(0x13, fromHex("a0a1")).getPartNumber());
+        assertNull(infoOf(0x13, fromHex("e228a1")).getPartNumber());
+        assertNull(infoOf(0x13, fromHex("e28228")).getPartNumber());
+        assertNull(infoOf(0x13, fromHex("f0288cbc")).getPartNumber());
+        assertNull(infoOf(0x13, fromHex("f09028bc")).getPartNumber());
+        assertNull(infoOf(0x13, fromHex("f0288c28")).getPartNumber());
     }
 
     @Test

--- a/management/src/test/java/com/yubico/yubikit/management/DeviceInfoTest.java
+++ b/management/src/test/java/com/yubico/yubikit/management/DeviceInfoTest.java
@@ -154,12 +154,18 @@ public class DeviceInfoTest {
     @Test
     public void testParseFpsVersion() {
         assertNull(defaultInfo().getFpsVersion());
+        assertNull(infoOf(0x20, fromHex("000000")).getFpsVersion());
+        assertNull(infoOf(0x20, fromHex("000000000000000000")).getFpsVersion());
+        assertEquals(new Version(0,0,1), infoOf(0x20, fromHex("000001")).getFpsVersion());
         assertEquals(new Version(5, 6, 6), infoOf(0x20, fromHex("050606")).getFpsVersion());
     }
 
     @Test
     public void testParseStmVersion() {
         assertNull(defaultInfo().getStmVersion());
+        assertNull(infoOf(0x21, fromHex("000000")).getStmVersion());
+        assertNull(infoOf(0x21, fromHex("000000000000000000")).getStmVersion());
+        assertEquals(new Version(0,0,1), infoOf(0x21, fromHex("000001")).getStmVersion());
         assertEquals(new Version(7, 0, 5), infoOf(0x21, fromHex("070005")).getStmVersion());
     }
 

--- a/testing/src/main/java/com/yubico/yubikit/testing/management/ManagementDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/management/ManagementDeviceTests.java
@@ -20,9 +20,11 @@ import com.yubico.yubikit.management.DeviceConfig;
 import com.yubico.yubikit.management.ManagementSession;
 
 import org.junit.Assert;
+import org.junit.Assume;
 
 public class ManagementDeviceTests {
     public static void testNfcRestricted(ManagementSession managementSession) throws Exception {
+        Assume.assumeTrue(managementSession.getVersion().isAtLeast(5,7,0));
         managementSession.updateDeviceConfig(
                 new DeviceConfig.Builder().nfcRestricted(true).build(),
                 false, null, null);


### PR DESCRIPTION
Fixes following:

- STM and FPS versions, parsed as `0.0.0` will be treated as `null`.
- Fix to default value of `nfcRestricted`
- Change of type of `partNumber` to be nullable