### PR TITLE
Support Ed25519 and X25519

### DIFF
--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/MainActivity.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/MainActivity.kt
@@ -59,8 +59,9 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        // needed for Ed25519 and X25519
         Security.removeProvider("BC")
-        Security.insertProviderAt(BouncyCastleProvider(), 1)
+        Security.addProvider(BouncyCastleProvider())
 
         val toolbar: Toolbar = findViewById(R.id.toolbar)
         setSupportActionBar(toolbar)

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/MainActivity.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/MainActivity.kt
@@ -31,19 +31,16 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
-
 import com.google.android.material.navigation.NavigationView
-
 import com.yubico.yubikit.android.YubiKitManager
 import com.yubico.yubikit.android.app.databinding.DialogAboutBinding
 import com.yubico.yubikit.android.transport.nfc.NfcConfiguration
 import com.yubico.yubikit.android.transport.nfc.NfcNotAvailable
 import com.yubico.yubikit.android.transport.usb.UsbConfiguration
-
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.slf4j.LoggerFactory
-
-import java.util.*
-
+import java.security.Security
+import java.util.Locale
 import kotlin.properties.Delegates
 
 class MainActivity : AppCompatActivity() {
@@ -61,6 +58,9 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        Security.removeProvider("BC")
+        Security.insertProviderAt(BouncyCastleProvider(), 1)
 
         val toolbar: Toolbar = findViewById(R.id.toolbar)
         setSupportActionBar(toolbar)

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
@@ -130,8 +130,6 @@ class PivCertificateFragment : Fragment() {
         binding.title.text = getString(requireArguments().getInt(ARG_TITLE))
         showCerts(false)
 
-        pivViewModel.certificates
-
         pivViewModel.certificates.observe(viewLifecycleOwner, Observer {
             it ?: return@Observer
             val cert = it.get(slot.value)

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
@@ -136,15 +136,16 @@ class PivCertificateFragment : Fragment() {
             showCerts(cert != null)
             if (cert != null) {
                 val expiration = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT).format(cert.notAfter)
-                val keyType = KeyType.fromKey(cert.publicKey)
-                val keyTypeStr = try {
-                    keyType.toString()
+                val keyType = try {
+                    KeyType.fromKey(cert.publicKey)
                 } catch (e: IllegalArgumentException) {
-                    cert.publicKey.algorithm
+                    null
                 }
-                binding.certInfo.text =
-                    "Issuer: ${cert.issuerDN}\nSubject name: ${cert.subjectDN}\nExpiration date: $expiration\nKey type: $keyTypeStr"
-                binding.sign.isEnabled = keyType != KeyType.X25519
+                binding.certInfo.text = "Issuer: ${cert.issuerDN}\n" +
+                        "Subject name: ${cert.subjectDN}\n" +
+                        "Expiration date: $expiration\n" +
+                        "Key type: ${keyType?.toString() ?: cert.publicKey.algorithm}"
+                binding.sign.isEnabled = (keyType != null && keyType != KeyType.X25519)
             }
         })
 

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
@@ -156,7 +156,7 @@ class PivCertificateFragment : Fragment() {
                 .generatePrivate(PKCS8EncodedKeySpec(Base64.decode(DER_KEY, Base64.DEFAULT)))
             lifecycleScope.launch(Dispatchers.Main) {
                 pivViewModel.pendingAction.value = {
-                    authenticate(managementKeyType, pivViewModel.mgmtKey)
+                    authenticate(pivViewModel.mgmtKey)
                     putKey(slot, PrivateKeyValues.fromPrivateKey(key), PinPolicy.DEFAULT, TouchPolicy.DEFAULT)
                     putCertificate(slot, cert)
                     "Imported certificate ${cert.subjectDN} issued by ${cert.issuerDN}"
@@ -201,7 +201,7 @@ class PivCertificateFragment : Fragment() {
         // Delete the certificate
         binding.delete.setOnClickListener {
             pivViewModel.pendingAction.value = {
-                authenticate(managementKeyType, pivViewModel.mgmtKey)
+                authenticate(pivViewModel.mgmtKey)
                 deleteCertificate(slot)
                 "Deleted certificate in slot $slot"
             }
@@ -270,7 +270,7 @@ class PivCertificateFragment : Fragment() {
     {
         getSecret(requireContext(), R.string.enter_pin)?.let { pin ->
             pivViewModel.pendingAction.value = {
-                authenticate(managementKeyType, pivViewModel.mgmtKey)
+                authenticate(pivViewModel.mgmtKey)
 
                 val provider = PivProvider(this)
                 val factory = KeyPairGenerator.getInstance(keyPairGen(keyType), provider)

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Yubico.
+ * Copyright (C) 2019-2022,2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.asn1.x9.X9ObjectIdentifiers
 import org.bouncycastle.cert.X509v3CertificateBuilder
 import org.bouncycastle.operator.ContentSigner
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.OutputStream
@@ -55,6 +56,7 @@ import java.security.cert.X509Certificate
 import java.security.spec.PKCS8EncodedKeySpec
 import java.text.SimpleDateFormat
 import java.util.*
+
 
 @Suppress("SpellCheckingInspection")
 private const val DER_KEY =
@@ -128,19 +130,23 @@ class PivCertificateFragment : Fragment() {
         binding.title.text = getString(requireArguments().getInt(ARG_TITLE))
         showCerts(false)
 
+        pivViewModel.certificates
+
         pivViewModel.certificates.observe(viewLifecycleOwner, Observer {
             it ?: return@Observer
             val cert = it.get(slot.value)
             showCerts(cert != null)
             if (cert != null) {
                 val expiration = SimpleDateFormat("yyyy-MM-dd", Locale.ROOT).format(cert.notAfter)
-                val keyType = try {
-                    KeyType.fromKey(cert.publicKey).toString()
+                val keyType = KeyType.fromKey(cert.publicKey)
+                val keyTypeStr = try {
+                    keyType.toString()
                 } catch (e: IllegalArgumentException) {
                     cert.publicKey.algorithm
                 }
                 binding.certInfo.text =
-                    "Issuer: ${cert.issuerDN}\nSubject name: ${cert.subjectDN}\nExpiration date: $expiration\nKey type: $keyType"
+                    "Issuer: ${cert.issuerDN}\nSubject name: ${cert.subjectDN}\nExpiration date: $expiration\nKey type: $keyTypeStr"
+                binding.sign.isEnabled = keyType != KeyType.X25519
             }
         })
 
@@ -163,162 +169,26 @@ class PivCertificateFragment : Fragment() {
         // Generate a key, then a self-signed certificate, and import
         binding.generateEcCert.setOnClickListener {
             lifecycleScope.launch(Dispatchers.Main) {
-                getSecret(requireContext(), R.string.enter_pin)?.let { pin ->
-                    pivViewModel.pendingAction.value = {
-                        authenticate(pivViewModel.getMgmtKeyType(this), pivViewModel.mgmtKey)
-
-                        val provider = PivProvider(this)
-                        val factory = KeyPairGenerator.getInstance("YKPivEC", provider)
-                        factory.initialize(
-                            PivAlgorithmParameterSpec(
-                                slot,
-                                KeyType.ECCP256,
-                                PinPolicy.DEFAULT,
-                                TouchPolicy.DEFAULT,
-                                pin.toCharArray()
-                            )
-                        )
-                        val keyPair = factory.generateKeyPair()
-
-                        // Generate a certificate
-                        val name = X500Name("CN=Generated EC Example")
-                        val serverCertGen = X509v3CertificateBuilder(
-                            name,
-                            BigInteger("123456789"),
-                            Date(),
-                            Date(),
-                            name,
-                            SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(keyPair.public.encoded))
-                        )
-                        val certBytes = serverCertGen.build(object : ContentSigner {
-                            val messageBuffer = ByteArrayOutputStream()
-                            override fun getAlgorithmIdentifier(): AlgorithmIdentifier =
-                                AlgorithmIdentifier(X9ObjectIdentifiers.ecdsa_with_SHA256)
-
-                            override fun getOutputStream(): OutputStream = messageBuffer
-                            override fun getSignature(): ByteArray {
-                                return Signature.getInstance("SHA256withECDSA", provider).apply {
-                                    initSign(keyPair.private)
-                                    update(messageBuffer.toByteArray())
-                                }.sign()
-                            }
-                        }).encoded
-
-                        val cert = CertificateFactory.getInstance("X.509")
-                            .generateCertificate(ByteArrayInputStream(certBytes)) as X509Certificate
-                        putCertificate(slot, cert)
-
-                        "Generated EC key in slot $slot"
-                    }
-                }
+                generateKeyAndCert(slot, KeyType.ECCP256, "SHA256withECDSA")
             }
         }
 
         // Generate a key, then a self-signed certificate, and import
         binding.generateEd25519Cert.setOnClickListener {
             lifecycleScope.launch(Dispatchers.Main) {
-                getSecret(requireContext(), R.string.enter_pin)?.let { pin ->
-                    pivViewModel.pendingAction.value = {
-                        authenticate(pivViewModel.getMgmtKeyType(this), pivViewModel.mgmtKey)
+                generateKeyAndCert(slot, KeyType.ED25519, "ED25519")
+            }
+        }
 
-                        val provider = PivProvider(this)
-                        val factory = KeyPairGenerator.getInstance("YKPivEC", provider)
-                        factory.initialize(
-                            PivAlgorithmParameterSpec(
-                                slot,
-                                KeyType.ED25519,
-                                PinPolicy.DEFAULT,
-                                TouchPolicy.DEFAULT,
-                                pin.toCharArray()
-                            )
-                        )
-                        val keyPair = factory.generateKeyPair()
-
-                        // Generate a certificate
-                        val name = X500Name("CN=Generated Ed25519 Example")
-                        val serverCertGen = X509v3CertificateBuilder(
-                            name,
-                            BigInteger("123456789"),
-                            Date(),
-                            Date(),
-                            name,
-                            SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(keyPair.public.encoded))
-                        )
-
-                        val certBytes = serverCertGen.build(object : ContentSigner {
-                            val messageBuffer = ByteArrayOutputStream()
-                            override fun getAlgorithmIdentifier(): AlgorithmIdentifier =
-                                AlgorithmIdentifier(X9ObjectIdentifiers.ecdsa_with_SHA256)
-
-                            override fun getOutputStream(): OutputStream = messageBuffer
-                            override fun getSignature(): ByteArray {
-                                return Signature.getInstance("Ed25519", provider).apply {
-                                    initSign(keyPair.private)
-                                    update(messageBuffer.toByteArray())
-                                }.sign()
-                            }
-                        }).encoded
-
-                        val cert = CertificateFactory.getInstance("X.509")
-                            .generateCertificate(ByteArrayInputStream(certBytes)) as X509Certificate
-                        putCertificate(slot, cert)
-
-                        "Generated Ed25519 key in slot $slot"
-                    }
-                }
+        binding.generateX25519Cert.setOnClickListener {
+            lifecycleScope.launch(Dispatchers.Main) {
+                generateKeyAndCert(slot, KeyType.X25519, "ED25519")
             }
         }
 
         binding.generateRsaCert.setOnClickListener {
             lifecycleScope.launch(Dispatchers.Main) {
-                getSecret(requireContext(), R.string.enter_pin)?.let { pin ->
-                    pivViewModel.pendingAction.value = {
-                        authenticate(pivViewModel.getMgmtKeyType(this), pivViewModel.mgmtKey)
-
-                        val provider = PivProvider(this)
-                        val factory = KeyPairGenerator.getInstance("YKPivRSA", provider)
-                        factory.initialize(
-                            PivAlgorithmParameterSpec(
-                                slot,
-                                KeyType.RSA2048,
-                                PinPolicy.DEFAULT,
-                                TouchPolicy.DEFAULT,
-                                pin.toCharArray()
-                            )
-                        )
-                        val keyPair = factory.generateKeyPair()
-
-                        // Generate a certificate
-                        val name = X500Name("CN=Generated RSA Example")
-                        val serverCertGen = X509v3CertificateBuilder(
-                            name,
-                            BigInteger("123456789"),
-                            Date(),
-                            Date(),
-                            name,
-                            SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(keyPair.public.encoded))
-                        )
-                        val certBytes = serverCertGen.build(object : ContentSigner {
-                            val messageBuffer = ByteArrayOutputStream()
-                            override fun getAlgorithmIdentifier(): AlgorithmIdentifier =
-                                AlgorithmIdentifier(X9ObjectIdentifiers.ecdsa_with_SHA256)
-
-                            override fun getOutputStream(): OutputStream = messageBuffer
-                            override fun getSignature(): ByteArray {
-                                return Signature.getInstance("SHA256withRSA", provider).apply {
-                                    initSign(keyPair.private)
-                                    update(messageBuffer.toByteArray())
-                                }.sign()
-                            }
-                        }).encoded
-
-                        val cert = CertificateFactory.getInstance("X.509")
-                            .generateCertificate(ByteArrayInputStream(certBytes)) as X509Certificate
-                        putCertificate(slot, cert)
-
-                        "Generated RSA key in slot $slot"
-                    }
-                }
+                generateKeyAndCert(slot, KeyType.RSA2048, "SHA256withRSA")
             }
         }
 
@@ -371,7 +241,7 @@ class PivCertificateFragment : Fragment() {
                         }.verify(signature)
 
                         if (result) {
-                            "Signature ${Base64.encodeToString(signature, Base64.DEFAULT)}"
+                            "Signature verified: ${Base64.encodeToString(signature, Base64.DEFAULT)}"
                         } else {
                             "Signature verification failed"
                         }
@@ -387,6 +257,84 @@ class PivCertificateFragment : Fragment() {
 
         binding.delete.isEnabled = visible
         binding.sign.isEnabled = visible
+    }
+
+    private fun keyPairGen(keyType: KeyType) : String =
+       when(keyType) {
+            KeyType.ECCP256, KeyType.ECCP384, KeyType.ED25519, KeyType.X25519 -> "YKPivEC"
+           else -> "YkPivRSA"
+       }
+
+    private suspend fun generateKeyAndCert(
+        slot: Slot,
+        keyType: KeyType,
+        signatureAlgorithm: String)
+    {
+        getSecret(requireContext(), R.string.enter_pin)?.let { pin ->
+            pivViewModel.pendingAction.value = {
+                authenticate(pivViewModel.getMgmtKeyType(this), pivViewModel.mgmtKey)
+
+                val provider = PivProvider(this)
+                val factory = KeyPairGenerator.getInstance(keyPairGen(keyType), provider)
+                factory.initialize(
+                    PivAlgorithmParameterSpec(
+                        slot,
+                        keyType,
+                        PinPolicy.DEFAULT,
+                        TouchPolicy.DEFAULT,
+                        pin.toCharArray()
+                    )
+                )
+                val keyPair = factory.generateKeyPair()
+
+                // Generate a certificate
+                val name = X500Name("CN=Generated ${keyType.name} Example")
+                val serverCertGen = X509v3CertificateBuilder(
+                    name,
+                    BigInteger("123456789"),
+                    Date(),
+                    Date(),
+                    name,
+                    SubjectPublicKeyInfo.getInstance(ASN1Sequence.getInstance(keyPair.public.encoded))
+                )
+
+                val signer = if (keyType == KeyType.X25519) {
+                    val kpg = KeyPairGenerator.getInstance(signatureAlgorithm)
+                    kpg.initialize(255)
+
+                    JcaContentSignerBuilder(signatureAlgorithm).build(kpg.generateKeyPair().private)
+                } else CertContentSigner(
+                    provider,
+                    keyPair.private,
+                    signatureAlgorithm
+                )
+
+                val cert =
+                    CertificateFactory.getInstance("X.509")
+                        .generateCertificate(
+                            ByteArrayInputStream(serverCertGen.build(signer).encoded)
+                        ) as X509Certificate
+                putCertificate(slot, cert)
+
+                "Generated ${keyType.name} key in slot $slot"
+            }
+        }
+    }
+
+    private class CertContentSigner(
+        private val provider: PivProvider,
+        private val privateKey: PrivateKey,
+        private val signatureAlgorithm: String
+        ) : ContentSigner {
+        val messageBuffer = ByteArrayOutputStream()
+        override fun getAlgorithmIdentifier() = AlgorithmIdentifier(X9ObjectIdentifiers.ecdsa_with_SHA256)
+        override fun getOutputStream(): OutputStream = messageBuffer
+        override fun getSignature(): ByteArray {
+            return Signature.getInstance(signatureAlgorithm, provider).apply {
+                initSign(privateKey)
+                update(messageBuffer.toByteArray())
+            }.sign()
+        }
     }
 
     companion object {

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivCertificateFragment.kt
@@ -158,7 +158,7 @@ class PivCertificateFragment : Fragment() {
                 .generatePrivate(PKCS8EncodedKeySpec(Base64.decode(DER_KEY, Base64.DEFAULT)))
             lifecycleScope.launch(Dispatchers.Main) {
                 pivViewModel.pendingAction.value = {
-                    authenticate(pivViewModel.getMgmtKeyType(this), pivViewModel.mgmtKey)
+                    authenticate(managementKeyType, pivViewModel.mgmtKey)
                     putKey(slot, PrivateKeyValues.fromPrivateKey(key), PinPolicy.DEFAULT, TouchPolicy.DEFAULT)
                     putCertificate(slot, cert)
                     "Imported certificate ${cert.subjectDN} issued by ${cert.issuerDN}"
@@ -203,7 +203,7 @@ class PivCertificateFragment : Fragment() {
         // Delete the certificate
         binding.delete.setOnClickListener {
             pivViewModel.pendingAction.value = {
-                authenticate(pivViewModel.getMgmtKeyType(this), pivViewModel.mgmtKey)
+                authenticate(managementKeyType, pivViewModel.mgmtKey)
                 deleteCertificate(slot)
                 "Deleted certificate in slot $slot"
             }
@@ -272,7 +272,7 @@ class PivCertificateFragment : Fragment() {
     {
         getSecret(requireContext(), R.string.enter_pin)?.let { pin ->
             pivViewModel.pendingAction.value = {
-                authenticate(pivViewModel.getMgmtKeyType(this), pivViewModel.mgmtKey)
+                authenticate(managementKeyType, pivViewModel.mgmtKey)
 
                 val provider = PivProvider(this)
                 val factory = KeyPairGenerator.getInstance(keyPairGen(keyType), provider)

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivViewModel.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivViewModel.kt
@@ -51,14 +51,6 @@ class PivViewModel : YubiKeyViewModel<PivSession>() {
     var mgmtKey: ByteArray =
         byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8)
 
-    fun getMgmtKeyType(session: PivSession) : ManagementKeyType {
-        return try {
-            session.managementKeyMetadata.keyType
-        } catch (ignored: UnsupportedOperationException) {
-            ManagementKeyType.TDES
-        }
-    }
-
     override fun getSession(
         device: YubiKeyDevice,
         onError: (Throwable) -> Unit,

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivViewModel.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivViewModel.kt
@@ -48,9 +48,16 @@ class PivViewModel : YubiKeyViewModel<PivSession>() {
     private val _certificates = MutableLiveData<SparseArray<X509Certificate>?>()
     val certificates: LiveData<SparseArray<X509Certificate>?> = _certificates
 
-    var mgmtKeyType = ManagementKeyType.TDES
     var mgmtKey: ByteArray =
         byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8)
+
+    fun getMgmtKeyType(session: PivSession) : ManagementKeyType {
+        return try {
+            session.managementKeyMetadata.keyType
+        } catch (ignored: Exception) {
+            ManagementKeyType.TDES
+        }
+    }
 
     override fun getSession(
         device: YubiKeyDevice,

--- a/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivViewModel.kt
+++ b/AndroidDemo/src/main/java/com/yubico/yubikit/android/app/ui/piv/PivViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ class PivViewModel : YubiKeyViewModel<PivSession>() {
     fun getMgmtKeyType(session: PivSession) : ManagementKeyType {
         return try {
             session.managementKeyMetadata.keyType
-        } catch (ignored: Exception) {
+        } catch (ignored: UnsupportedOperationException) {
             ManagementKeyType.TDES
         }
     }

--- a/AndroidDemo/src/main/res/layout/fragment_piv_certifiate.xml
+++ b/AndroidDemo/src/main/res/layout/fragment_piv_certifiate.xml
@@ -90,7 +90,6 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:enabled="false"
                     android:text="@string/piv_generate_x25519_cert" />
             </TableRow>
 

--- a/AndroidDemo/src/main/res/layout/fragment_piv_certifiate.xml
+++ b/AndroidDemo/src/main/res/layout/fragment_piv_certifiate.xml
@@ -76,6 +76,27 @@
             <TableRow
                 android:layout_weight="1"
                 android:gravity="center"
+                android:weightSum="2" >
+
+                <Button
+                    android:id="@+id/generate_ed25519_cert"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/piv_generate_ed25519_cert" />
+
+                <Button
+                    android:id="@+id/generate_x25519_cert"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:enabled="false"
+                    android:text="@string/piv_generate_x25519_cert" />
+            </TableRow>
+
+            <TableRow
+                android:layout_weight="1"
+                android:gravity="center"
                 android:weightSum="2">
 
                 <Button

--- a/AndroidDemo/src/main/res/values/strings.xml
+++ b/AndroidDemo/src/main/res/values/strings.xml
@@ -45,6 +45,8 @@
     <string name="piv_attest">Attest</string>
     <string name="piv_generate_ec_cert">Generate EC256</string>
     <string name="piv_generate_rsa_cert">Generate RSA2048</string>
+    <string name="piv_generate_ed25519_cert">Generate ED25519</string>
+    <string name="piv_generate_x25519_cert">Generate X25519</string>
     <string name="piv_import_cert">Import</string>
     <string name="piv_message_hint">Message</string>
     <string name="piv_sign">Sign</string>

--- a/core/src/main/java/com/yubico/yubikit/core/keys/PrivateKeyValues.java
+++ b/core/src/main/java/com/yubico/yubikit/core/keys/PrivateKeyValues.java
@@ -102,7 +102,6 @@ public abstract class PrivateKeyValues implements Destroyable {
         private final EllipticCurveValues ellipticCurveValues;
         private final byte[] secret;
 
-
         protected Ec(EllipticCurveValues ellipticCurveValues, byte[] secret) {
             super(ellipticCurveValues.getBitLength());
             this.ellipticCurveValues = ellipticCurveValues;

--- a/piv/build.gradle
+++ b/piv/build.gradle
@@ -6,6 +6,10 @@ dependencies {
 
 test {
     systemProperty "org.slf4j.simpleLogger.defaultLogLevel", "trace"
+
+    dependencies {
+        implementation 'org.bouncycastle:bcpkix-jdk15to18:1.77'
+    }
 }
 
 ext.pomName = "Yubico YubiKit ${project.name.capitalize()}"

--- a/piv/build.gradle
+++ b/piv/build.gradle
@@ -6,10 +6,6 @@ dependencies {
 
 test {
     systemProperty "org.slf4j.simpleLogger.defaultLogLevel", "trace"
-
-    dependencies {
-        implementation 'org.bouncycastle:bcpkix-jdk15to18:1.77'
-    }
 }
 
 ext.pomName = "Yubico YubiKit ${project.name.capitalize()}"

--- a/piv/src/main/java/com/yubico/yubikit/piv/KeyType.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/KeyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Yubico.
+ * Copyright (C) 2019-2022,2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@ package com.yubico.yubikit.piv;
 import com.yubico.yubikit.core.keys.EllipticCurveValues;
 import com.yubico.yubikit.core.keys.PrivateKeyValues;
 import com.yubico.yubikit.core.keys.PublicKeyValues;
+
+import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey;
+import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
 
 import java.security.Key;
 import java.security.interfaces.ECPrivateKey;
@@ -46,7 +49,15 @@ public enum KeyType {
     /**
      * Elliptic Curve key, using NIST Curve P-384.
      */
-    ECCP384((byte) 0x14, new EcKeyParams(EllipticCurveValues.SECP384R1));
+    ECCP384((byte) 0x14, new EcKeyParams(EllipticCurveValues.SECP384R1)),
+    /**
+     * Edwards Digital Signature Algorithm (EdDSA) key, using Curve25519.
+     */
+    ED25519((byte) 0xE0, new EcKeyParams(EllipticCurveValues.Ed25519)),
+    /**
+     * Elliptic-Curve Diffie-Hellman (ECDH) protocol key, using Curve25519.
+     */
+    X25519((byte) 0xE1, new EcKeyParams(EllipticCurveValues.X25519));
 
     public final byte value;
     public final KeyParams params;
@@ -105,6 +116,10 @@ public enum KeyType {
                 ellipticCurveValues = ((PublicKeyValues.Ec) PublicKeyValues.fromPublicKey((ECPublicKey) key)).getCurveParams();
             } else if (key instanceof ECPrivateKey) {
                 ellipticCurveValues = ((PrivateKeyValues.Ec) PrivateKeyValues.fromPrivateKey((ECPrivateKey) key)).getCurveParams();
+            } else if (key instanceof BCEdDSAPrivateKey) {
+                ellipticCurveValues = ((PrivateKeyValues.Ec) PrivateKeyValues.fromPrivateKey((BCEdDSAPrivateKey) key)).getCurveParams();
+            } else if (key instanceof BCEdDSAPublicKey) {
+                ellipticCurveValues = ((PublicKeyValues.Cv25519) PublicKeyValues.fromPublicKey((BCEdDSAPublicKey) key)).getCurveParams();
             } else {
                 throw new IllegalArgumentException("Unsupported key type");
             }

--- a/piv/src/main/java/com/yubico/yubikit/piv/KeyType.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/KeyType.java
@@ -20,14 +20,9 @@ import com.yubico.yubikit.core.keys.EllipticCurveValues;
 import com.yubico.yubikit.core.keys.PrivateKeyValues;
 import com.yubico.yubikit.core.keys.PublicKeyValues;
 
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey;
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCXDHPrivateKey;
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCXDHPublicKey;
-
 import java.security.Key;
-import java.security.interfaces.ECPrivateKey;
-import java.security.interfaces.ECPublicKey;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.security.interfaces.RSAKey;
 
 import javax.annotation.Nonnull;
@@ -114,18 +109,17 @@ public enum KeyType {
             }
         } else {
             EllipticCurveValues ellipticCurveValues;
-            if (key instanceof ECPublicKey) {
-                ellipticCurveValues = ((PublicKeyValues.Ec) PublicKeyValues.fromPublicKey((ECPublicKey) key)).getCurveParams();
-            } else if (key instanceof ECPrivateKey) {
-                ellipticCurveValues = ((PrivateKeyValues.Ec) PrivateKeyValues.fromPrivateKey((ECPrivateKey) key)).getCurveParams();
-            } else if (key instanceof BCEdDSAPrivateKey) {
-                ellipticCurveValues = ((PrivateKeyValues.Ec) PrivateKeyValues.fromPrivateKey((BCEdDSAPrivateKey) key)).getCurveParams();
-            } else if (key instanceof BCEdDSAPublicKey) {
-                ellipticCurveValues = ((PublicKeyValues.Cv25519) PublicKeyValues.fromPublicKey((BCEdDSAPublicKey) key)).getCurveParams();
-            } else if (key instanceof BCXDHPublicKey) {
-                ellipticCurveValues = ((PublicKeyValues.Cv25519) PublicKeyValues.fromPublicKey((BCXDHPublicKey) key)).getCurveParams();
-            } else if (key instanceof BCXDHPrivateKey) {
-                ellipticCurveValues = ((PrivateKeyValues.Ec) PrivateKeyValues.fromPrivateKey((BCXDHPrivateKey) key)).getCurveParams();
+            if (key instanceof PublicKey) {
+                PublicKeyValues publicKeyValues = PublicKeyValues.fromPublicKey( (PublicKey) key);
+                if (publicKeyValues instanceof PublicKeyValues.Ec) {
+                    ellipticCurveValues = ((PublicKeyValues.Ec) publicKeyValues).getCurveParams();
+                } else if (publicKeyValues instanceof PublicKeyValues.Cv25519) {
+                    ellipticCurveValues = ((PublicKeyValues.Cv25519) publicKeyValues).getCurveParams();
+                } else {
+                    throw new IllegalArgumentException("Unsupported public key type");
+                }
+            } else if (key instanceof PrivateKey) {
+                ellipticCurveValues = ((PrivateKeyValues.Ec) PrivateKeyValues.fromPrivateKey((PrivateKey) key)).getCurveParams();
             } else {
                 throw new IllegalArgumentException("Unsupported key type");
             }

--- a/piv/src/main/java/com/yubico/yubikit/piv/KeyType.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/KeyType.java
@@ -22,6 +22,8 @@ import com.yubico.yubikit.core.keys.PublicKeyValues;
 
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey;
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
+import org.bouncycastle.jcajce.provider.asymmetric.edec.BCXDHPrivateKey;
+import org.bouncycastle.jcajce.provider.asymmetric.edec.BCXDHPublicKey;
 
 import java.security.Key;
 import java.security.interfaces.ECPrivateKey;
@@ -120,6 +122,10 @@ public enum KeyType {
                 ellipticCurveValues = ((PrivateKeyValues.Ec) PrivateKeyValues.fromPrivateKey((BCEdDSAPrivateKey) key)).getCurveParams();
             } else if (key instanceof BCEdDSAPublicKey) {
                 ellipticCurveValues = ((PublicKeyValues.Cv25519) PublicKeyValues.fromPublicKey((BCEdDSAPublicKey) key)).getCurveParams();
+            } else if (key instanceof BCXDHPublicKey) {
+                ellipticCurveValues = ((PublicKeyValues.Cv25519) PublicKeyValues.fromPublicKey((BCXDHPublicKey) key)).getCurveParams();
+            } else if (key instanceof BCXDHPrivateKey) {
+                ellipticCurveValues = ((PrivateKeyValues.Ec) PrivateKeyValues.fromPrivateKey((BCXDHPrivateKey) key)).getCurveParams();
             } else {
                 throw new IllegalArgumentException("Unsupported key type");
             }

--- a/piv/src/main/java/com/yubico/yubikit/piv/PivSession.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/PivSession.java
@@ -38,7 +38,6 @@ import com.yubico.yubikit.core.util.StringUtils;
 import com.yubico.yubikit.core.util.Tlv;
 import com.yubico.yubikit.core.util.Tlvs;
 
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCXDHPublicKey;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
@@ -481,9 +480,9 @@ public class PivSession extends ApplicationSession<PivSession> {
      * @param slot            the slot containing the private EC key
      * @param publicKeyValues the peer public key for the operation
      * @return the shared secret, comprising the x-coordinate of the ECDH result point.
-     * @throws IOException          in case of connection error
-     * @throws ApduException        in case of an error response from the YubiKey
-     * @throws BadResponseException in case of incorrect YubiKey response
+     * @throws IOException              in case of connection error
+     * @throws ApduException            in case of an error response from the YubiKey
+     * @throws BadResponseException     in case of incorrect YubiKey response
      * @throws NoSuchAlgorithmException in case of unsupported PublicKey type
      */
     public byte[] calculateSecret(Slot slot, PublicKeyValues publicKeyValues) throws IOException, ApduException, BadResponseException, NoSuchAlgorithmException, InvalidKeySpecException {
@@ -491,10 +490,10 @@ public class PivSession extends ApplicationSession<PivSession> {
         KeyType keyType = KeyType.fromKey(publicKey);
         Logger.debug(logger, "Performing key agreement with key in slot {} of type {}", slot, keyType);
         if (keyType == KeyType.X25519) {
-            return usePrivateKey(slot, keyType, ((BCXDHPublicKey) publicKey).getUEncoding(), true);
+            return usePrivateKey(slot, keyType, ((PublicKeyValues.Cv25519) publicKeyValues).getBytes(), true);
         } else {
             ECPoint w = ((ECPublicKey) publicKey).getW();
-            byte[] encodedPoint = new PublicKeyValues.Ec(((KeyType.EcKeyParams)keyType.params).getCurveParams(), w.getAffineX(), w.getAffineY()).getEncodedPoint();
+            byte[] encodedPoint = new PublicKeyValues.Ec(((KeyType.EcKeyParams) keyType.params).getCurveParams(), w.getAffineX(), w.getAffineY()).getEncodedPoint();
             return usePrivateKey(slot, keyType, encodedPoint, true);
         }
     }

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivEcSignatureSpi.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivEcSignatureSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022,2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 public abstract class PivEcSignatureSpi extends SignatureSpi {
     private final Callback<Callback<Result<PivSession, Exception>>> provider;
     @Nullable
-    private PivPrivateKey.EcKey privateKey;
+    private PivPrivateKey privateKey;
 
     protected PivEcSignatureSpi(Callback<Callback<Result<PivSession, Exception>>> provider) {
         this.provider = provider;
@@ -50,6 +50,8 @@ public abstract class PivEcSignatureSpi extends SignatureSpi {
     protected void engineInitSign(PrivateKey privateKey) throws InvalidKeyException {
         if (privateKey instanceof PivPrivateKey.EcKey) {
             this.privateKey = (PivPrivateKey.EcKey) privateKey;
+        } else if (privateKey instanceof PivPrivateKey.Ed25519Key) {
+            this.privateKey = (PivPrivateKey.Ed25519Key) privateKey;
         } else {
             throw new InvalidKeyException("Unsupported key type");
         }

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivEcSignatureSpi.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivEcSignatureSpi.java
@@ -52,6 +52,8 @@ public abstract class PivEcSignatureSpi extends SignatureSpi {
             this.privateKey = (PivPrivateKey.EcKey) privateKey;
         } else if (privateKey instanceof PivPrivateKey.Ed25519Key) {
             this.privateKey = (PivPrivateKey.Ed25519Key) privateKey;
+        } else if (privateKey instanceof PivPrivateKey.X25519Key) {
+            this.privateKey = (PivPrivateKey.X25519Key) privateKey;
         } else {
             throw new InvalidKeyException("Unsupported key type");
         }

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivKeyAgreementSpi.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivKeyAgreementSpi.java
@@ -78,7 +78,7 @@ public class PivKeyAgreementSpi extends KeyAgreementSpi {
             ECPublicKey ecPublicKey = (ECPublicKey) key;
 
             if (pivEcPrivateKey.getParams().getCurve().equals(ecPublicKey.getParams().getCurve())) {
-                publicKeyValues = PublicKeyValues.fromPublicKey((PublicKey) key);
+                publicKeyValues = PublicKeyValues.fromPublicKey(ecPublicKey);
                 return null;
             }
         } else if (privateKey instanceof PivPrivateKey.X25519Key && key instanceof PublicKey) {

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivKeyPairGeneratorSpi.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivKeyPairGeneratorSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022,2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ abstract class PivKeyPairGeneratorSpi extends KeyPairGeneratorSpi {
             BlockingQueue<Result<KeyPair, Exception>> queue = new ArrayBlockingQueue<>(1);
             provider.invoke(result -> queue.add(Result.of(() -> {
                 PivSession session = result.getValue();
-                PublicKey publicKey = session.generateKey(spec.slot, spec.keyType, spec.pinPolicy, spec.touchPolicy);
+                PublicKey publicKey = session.generateKeyValues(spec.slot, spec.keyType, spec.pinPolicy, spec.touchPolicy).toPublicKey();
                 PrivateKey privateKey = PivPrivateKey.from(publicKey, spec.slot, spec.pinPolicy, spec.touchPolicy, spec.pin);
                 return new KeyPair(publicKey, privateKey);
             })));

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivKeyStoreSpi.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivKeyStoreSpi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022,2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.yubico.yubikit.piv.jca;
 
 import com.yubico.yubikit.core.application.BadResponseException;
+import com.yubico.yubikit.core.keys.PrivateKeyValues;
 import com.yubico.yubikit.core.smartcard.ApduException;
 import com.yubico.yubikit.core.smartcard.SW;
 import com.yubico.yubikit.core.util.Callback;
@@ -59,7 +60,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
         provider.invoke(result -> queue.add(Result.of(() -> {
             PivSession piv = result.getValue();
             if (key != null) {
-                piv.putKey(slot, key, pinPolicy, touchPolicy);
+                piv.putKey(slot, PrivateKeyValues.fromPrivateKey(key), pinPolicy, touchPolicy);
             }
             if (certificate != null) {
                 piv.putCertificate(slot, certificate);
@@ -79,7 +80,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
                 PivSession session = result.getValue();
                 if (session.supports(PivSession.FEATURE_METADATA)) {
                     SlotMetadata data = session.getSlotMetadata(slot);
-                    return PivPrivateKey.from(data.getPublicKey(), slot, data.getPinPolicy(), data.getTouchPolicy(), password);
+                    return PivPrivateKey.from(data.getPublicKeyValues().toPublicKey(), slot, data.getPinPolicy(), data.getTouchPolicy(), password);
                 } else {
                     PublicKey publicKey = session.getCertificate(slot).getPublicKey();
                     return PivPrivateKey.from(publicKey, slot, null, null, password);
@@ -143,7 +144,7 @@ public class PivKeyStoreSpi extends KeyStoreSpi {
                 PrivateKey key;
                 if (session.supports(PivSession.FEATURE_METADATA)) {
                     SlotMetadata data = session.getSlotMetadata(slot);
-                    key = PivPrivateKey.from(data.getPublicKey(), slot, data.getPinPolicy(), data.getTouchPolicy(), pin);
+                    key = PivPrivateKey.from(data.getPublicKeyValues().toPublicKey(), slot, data.getPinPolicy(), data.getTouchPolicy(), pin);
                 } else {
                     PublicKey publicKey = certificate.getPublicKey();
                     key = PivPrivateKey.from(publicKey, slot, null, null, pin);

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivPrivateKey.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022,2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,8 @@ public abstract class PivPrivateKey implements PrivateKey, Destroyable {
         KeyType keyType = KeyType.fromKey(publicKey);
         if (keyType.params.algorithm == KeyType.Algorithm.RSA) {
             return new PivPrivateKey.RsaKey(slot, keyType, pinPolicy, touchPolicy, ((RSAPublicKey) publicKey).getModulus(), pin);
+        } else if (keyType == KeyType.ED25519) {
+            return new PivPrivateKey.Ed25519Key(slot, keyType, pinPolicy, touchPolicy, pin);
         } else {
             return new PivPrivateKey.EcKey(slot, keyType, pinPolicy, touchPolicy, ((ECPublicKey) publicKey).getParams(), pin);
         }
@@ -188,6 +190,12 @@ public abstract class PivPrivateKey implements PrivateKey, Destroyable {
         @Override
         public BigInteger getModulus() {
             return modulus;
+        }
+    }
+
+    static class Ed25519Key extends PivPrivateKey implements PrivateKey {
+        private Ed25519Key(Slot slot, KeyType keyType, @Nullable PinPolicy pinPolicy, @Nullable TouchPolicy touchPolicy, @Nullable char[] pin) {
+            super(slot, keyType, pinPolicy, touchPolicy, pin);
         }
     }
 }

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivProvider.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import javax.crypto.NoSuchPaddingException;
 public class PivProvider extends Provider {
     private static final Map<String, String> ecAttributes = Collections.singletonMap("SupportedKeyClasses", PivPrivateKey.EcKey.class.getName());
     private static final Map<String, String> rsaAttributes = Collections.singletonMap("SupportedKeyClasses", PivPrivateKey.RsaKey.class.getName());
+    private static final Map<String, String> cv25519Attributes = Collections.singletonMap("SupportedKeyClasses", PivPrivateKey.Ed25519Key.class.getName());
 
     private final Callback<Callback<Result<PivSession, Exception>>> sessionRequester;
     private final Map<KeyType, KeyPair> rsaDummyKeys = new HashMap<>();
@@ -73,6 +74,13 @@ public class PivProvider extends Provider {
 
         //noinspection SpellCheckingInspection
         putService(new Service(this, "Signature", "NONEwithECDSA", PivEcSignatureSpi.Prehashed.class.getName(), null, ecAttributes) {
+            @Override
+            public Object newInstance(Object constructorParameter) {
+                return new PivEcSignatureSpi.Prehashed(sessionRequester);
+            }
+        });
+
+        putService(new Service(this, "Signature", "Ed25519", PivEcSignatureSpi.Prehashed.class.getName(), null, cv25519Attributes) {
             @Override
             public Object newInstance(Object constructorParameter) {
                 return new PivEcSignatureSpi.Prehashed(sessionRequester);

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivProvider.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivProvider.java
@@ -41,7 +41,8 @@ import javax.crypto.NoSuchPaddingException;
 public class PivProvider extends Provider {
     private static final Map<String, String> ecAttributes = Collections.singletonMap("SupportedKeyClasses", PivPrivateKey.EcKey.class.getName());
     private static final Map<String, String> rsaAttributes = Collections.singletonMap("SupportedKeyClasses", PivPrivateKey.RsaKey.class.getName());
-    private static final Map<String, String> cv25519Attributes = Collections.singletonMap("SupportedKeyClasses", PivPrivateKey.Ed25519Key.class.getName());
+    private static final Map<String, String> ed25519Attributes = Collections.singletonMap("SupportedKeyClasses", PivPrivateKey.Ed25519Key.class.getName());
+    private static final Map<String, String> x25519Attributes = Collections.singletonMap("SupportedKeyClasses", PivPrivateKey.X25519Key.class.getName());
 
     private final Callback<Callback<Result<PivSession, Exception>>> sessionRequester;
     private final Map<KeyType, KeyPair> rsaDummyKeys = new HashMap<>();
@@ -80,10 +81,24 @@ public class PivProvider extends Provider {
             }
         });
 
-        putService(new Service(this, "Signature", "Ed25519", PivEcSignatureSpi.Prehashed.class.getName(), null, cv25519Attributes) {
+        putService(new Service(this, "Signature", "Ed25519", PivEcSignatureSpi.Prehashed.class.getName(), null, ed25519Attributes) {
             @Override
             public Object newInstance(Object constructorParameter) {
                 return new PivEcSignatureSpi.Prehashed(sessionRequester);
+            }
+        });
+
+        putService(new Service(this, "Signature", "X25519", PivEcSignatureSpi.Prehashed.class.getName(), null, x25519Attributes) {
+            @Override
+            public Object newInstance(Object constructorParameter) {
+                return new PivEcSignatureSpi.Prehashed(sessionRequester);
+            }
+        });
+
+        putService(new Service(this, "KeyAgreement", "X25519", PivKeyAgreementSpi.class.getName(), null, x25519Attributes) {
+            @Override
+            public Object newInstance(Object constructorParameter) {
+                return new PivKeyAgreementSpi(sessionRequester);
             }
         });
 

--- a/piv/src/main/java/com/yubico/yubikit/piv/jca/PivProvider.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/jca/PivProvider.java
@@ -88,13 +88,6 @@ public class PivProvider extends Provider {
             }
         });
 
-        putService(new Service(this, "Signature", "X25519", PivEcSignatureSpi.Prehashed.class.getName(), null, x25519Attributes) {
-            @Override
-            public Object newInstance(Object constructorParameter) {
-                return new PivEcSignatureSpi.Prehashed(sessionRequester);
-            }
-        });
-
         putService(new Service(this, "KeyAgreement", "X25519", PivKeyAgreementSpi.class.getName(), null, x25519Attributes) {
             @Override
             public Object newInstance(Object constructorParameter) {

--- a/piv/src/test/java/com/yubico/yubikit/piv/PivProviderTest.java
+++ b/piv/src/test/java/com/yubico/yubikit/piv/PivProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022,2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ public class PivProviderTest {
     public void testStandardAlgorithms() throws Exception {
         PivTestUtils.rsaTests();
         PivTestUtils.ecTests();
+        PivTestUtils.cv25519Tests();
     }
 
     @Test
@@ -38,5 +39,6 @@ public class PivProviderTest {
 
         PivTestUtils.rsaTests();
         PivTestUtils.ecTests();
+        PivTestUtils.cv25519Tests();
     }
 }

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/piv/PivJcaProviderTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/piv/PivJcaProviderTests.java
@@ -32,6 +32,11 @@ public class PivJcaProviderTests extends PivInstrumentedTests {
     }
 
     @Test
+    public void testGenerateKeysPreferBC() throws Throwable {
+        withPivSession(PivJcaDeviceTests::testGenerateKeysPreferBC);
+    }
+
+    @Test
     public void testImportKeys() throws Throwable {
         withPivSession(PivJcaDeviceTests::testImportKeys);
     }

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/piv/PivTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/piv/PivTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,11 @@ public class PivTests extends PivInstrumentedTests {
     @Test
     public void testManagementKey() throws Throwable {
         withPivSession(PivDeviceTests::testManagementKey);
+    }
+
+    @Test
+    public void testManagementKeyType() throws Throwable {
+        withPivSession(PivDeviceTests::testManagementKeyType);
     }
 
     @Test

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivCertificateTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivCertificateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import static com.yubico.yubikit.testing.piv.PivTestConstants.DEFAULT_MANAGEMENT
 import com.yubico.yubikit.core.application.BadResponseException;
 import com.yubico.yubikit.core.smartcard.ApduException;
 import com.yubico.yubikit.piv.KeyType;
-import com.yubico.yubikit.piv.ManagementKeyType;
 import com.yubico.yubikit.piv.PivSession;
 import com.yubico.yubikit.piv.Slot;
 
@@ -48,7 +47,7 @@ public class PivCertificateTests {
 
     private static void putCertificate(PivSession piv, boolean compressed) throws IOException, ApduException, CertificateException, BadResponseException {
 
-        piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(DEFAULT_MANAGEMENT_KEY);
 
         for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.RSA1024, KeyType.RSA2048)) {
             Slot slot = Slot.SIGNATURE;

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivDeviceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Yubico.
+ * Copyright (C) 2020-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package com.yubico.yubikit.testing.piv;
 
+import static com.yubico.yubikit.piv.PivSession.FEATURE_AES_KEY;
 import static com.yubico.yubikit.testing.piv.PivTestConstants.DEFAULT_MANAGEMENT_KEY;
 import static com.yubico.yubikit.testing.piv.PivTestConstants.DEFAULT_PIN;
 import static com.yubico.yubikit.testing.piv.PivTestConstants.DEFAULT_PUK;
@@ -30,13 +31,12 @@ import org.bouncycastle.util.encoders.Hex;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
-
+import org.junit.Assume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-@SuppressWarnings("deprecation")
 public class PivDeviceTests {
 
     private static final Logger logger = LoggerFactory.getLogger(PivDeviceTests.class);
@@ -44,34 +44,59 @@ public class PivDeviceTests {
     public static void testManagementKey(PivSession piv) throws BadResponseException, IOException, ApduException {
         byte[] key2 = Hex.decode("010203040102030401020304010203040102030401020304");
 
+        ManagementKeyType managementKeyType = piv.getManagementKeyType();
+
         logger.debug("Authenticate with the wrong key");
         try {
-            piv.authenticate(ManagementKeyType.TDES, key2);
+            piv.authenticate(key2);
             Assert.fail("Authenticated with wrong key");
         } catch (ApduException e) {
             Assert.assertEquals(SW.SECURITY_CONDITION_NOT_SATISFIED, e.getSw());
         }
 
         logger.debug("Change management key");
-        piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
-        piv.setManagementKey(ManagementKeyType.TDES, key2, false);
+        piv.authenticate(DEFAULT_MANAGEMENT_KEY);
+        piv.setManagementKey(managementKeyType, key2, false);
 
         logger.debug("Authenticate with the old key");
         try {
-            piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
+            piv.authenticate(DEFAULT_MANAGEMENT_KEY);
             Assert.fail("Authenticated with wrong key");
         } catch (ApduException e) {
             Assert.assertEquals(SW.SECURITY_CONDITION_NOT_SATISFIED, e.getSw());
         }
 
         logger.debug("Change management key");
-        piv.authenticate(ManagementKeyType.TDES, key2);
-        piv.setManagementKey(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY, false);
+        piv.authenticate(key2);
+        piv.setManagementKey(managementKeyType, DEFAULT_MANAGEMENT_KEY, false);
+    }
+
+    public static void testManagementKeyType(PivSession piv) throws BadResponseException, IOException, ApduException {
+        Assume.assumeTrue("No AES key support", piv.supports(FEATURE_AES_KEY));
+
+        ManagementKeyType managementKeyType = piv.getManagementKeyType();
+        byte[] aes128Key = Hex.decode("01020304010203040102030401020304");
+
+        logger.debug("Change management key type");
+        piv.authenticate(DEFAULT_MANAGEMENT_KEY);
+        piv.setManagementKey(ManagementKeyType.AES128, aes128Key, false);
+        Assert.assertEquals(ManagementKeyType.AES128, piv.getManagementKeyType());
+
+        try {
+            piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
+            Assert.fail("Authenticated with wrong key type");
+        } catch (IllegalArgumentException e) {
+            // ignored
+        }
+
+        // set original management key type
+        piv.authenticate(aes128Key);
+        piv.setManagementKey(managementKeyType, DEFAULT_MANAGEMENT_KEY, false);
     }
 
     public static void testPin(PivSession piv) throws ApduException, InvalidPinException, IOException, BadResponseException {
         // Ensure we only try this if the default management key is set.
-        piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(DEFAULT_MANAGEMENT_KEY);
 
         logger.debug("Verify PIN");
         char[] pin2 = "123123".toCharArray();
@@ -115,7 +140,7 @@ public class PivDeviceTests {
 
     public static void testPuk(PivSession piv) throws ApduException, InvalidPinException, IOException, BadResponseException {
         // Ensure we only try this if the default management key is set.
-        piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(DEFAULT_MANAGEMENT_KEY);
 
         // Change PUK
         char[] puk2 = "12341234".toCharArray();

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDecryptTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDecryptTests.java
@@ -69,7 +69,7 @@ public class PivJcaDecryptTests {
             throw new IllegalArgumentException("Unsupported");
         }
 
-        piv.authenticate(piv.getManagementKeyType(), DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(DEFAULT_MANAGEMENT_KEY);
         logger.debug("Generate key: {}", keyType);
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("YKPivRSA");
         kpg.initialize(new PivAlgorithmParameterSpec(Slot.KEY_MANAGEMENT, keyType, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, DEFAULT_PIN));

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDecryptTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDecryptTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import com.yubico.yubikit.core.application.BadResponseException;
 import com.yubico.yubikit.core.smartcard.ApduException;
 import com.yubico.yubikit.core.util.StringUtils;
 import com.yubico.yubikit.piv.KeyType;
-import com.yubico.yubikit.piv.ManagementKeyType;
 import com.yubico.yubikit.piv.PinPolicy;
 import com.yubico.yubikit.piv.PivSession;
 import com.yubico.yubikit.piv.Slot;
@@ -70,7 +69,7 @@ public class PivJcaDecryptTests {
             throw new IllegalArgumentException("Unsupported");
         }
 
-        piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(PivTestUtils.getManagementKeyType(piv), DEFAULT_MANAGEMENT_KEY);
         logger.debug("Generate key: {}", keyType);
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("YKPivRSA");
         kpg.initialize(new PivAlgorithmParameterSpec(Slot.KEY_MANAGEMENT, keyType, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, DEFAULT_PIN));

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDecryptTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDecryptTests.java
@@ -69,7 +69,7 @@ public class PivJcaDecryptTests {
             throw new IllegalArgumentException("Unsupported");
         }
 
-        piv.authenticate(PivTestUtils.getManagementKeyType(piv), DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(piv.getManagementKeyType(), DEFAULT_MANAGEMENT_KEY);
         logger.debug("Generate key: {}", keyType);
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("YKPivRSA");
         kpg.initialize(new PivAlgorithmParameterSpec(Slot.KEY_MANAGEMENT, keyType, PinPolicy.DEFAULT, TouchPolicy.DEFAULT, DEFAULT_PIN));

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDeviceTests.java
@@ -47,7 +47,7 @@ public class PivJcaDeviceTests {
     @SuppressWarnings("NewApi") // casting to Destroyable is supported from API 26
     public static void testImportKeys(PivSession piv) throws Exception {
         setupJca(piv);
-        piv.authenticate(PivTestUtils.getManagementKeyType(piv), DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(piv.getManagementKeyType(), DEFAULT_MANAGEMENT_KEY);
 
         KeyStore keyStore = KeyStore.getInstance("YKPiv");
         keyStore.load(null);
@@ -115,7 +115,7 @@ public class PivJcaDeviceTests {
 
     public static void testGenerateKeys(PivSession piv) throws Exception {
         setupJca(piv);
-        piv.authenticate(PivTestUtils.getManagementKeyType(piv), DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(piv.getManagementKeyType(), DEFAULT_MANAGEMENT_KEY);
 
         KeyPairGenerator ecGen = KeyPairGenerator.getInstance("YKPivEC");
         for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.ED25519, KeyType.X25519)) {

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDeviceTests.java
@@ -47,7 +47,7 @@ public class PivJcaDeviceTests {
     @SuppressWarnings("NewApi") // casting to Destroyable is supported from API 26
     public static void testImportKeys(PivSession piv) throws Exception {
         setupJca(piv);
-        piv.authenticate(piv.getManagementKeyType(), DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(DEFAULT_MANAGEMENT_KEY);
 
         KeyStore keyStore = KeyStore.getInstance("YKPiv");
         keyStore.load(null);
@@ -115,7 +115,7 @@ public class PivJcaDeviceTests {
 
     public static void testGenerateKeys(PivSession piv) throws Exception {
         setupJca(piv);
-        piv.authenticate(piv.getManagementKeyType(), DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(DEFAULT_MANAGEMENT_KEY);
 
         KeyPairGenerator ecGen = KeyPairGenerator.getInstance("YKPivEC");
         for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.ED25519, KeyType.X25519)) {

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
@@ -76,7 +76,7 @@ public class PivJcaSigningTests {
             logger.debug("Ignoring keyType: {}", keyType);
             return;
         }
-        piv.authenticate(piv.getManagementKeyType(), DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(DEFAULT_MANAGEMENT_KEY);
         logger.debug("Generate key: {}", keyType);
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("YKPiv" + keyType.params.algorithm.name());

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
@@ -76,7 +76,7 @@ public class PivJcaSigningTests {
             logger.debug("Ignoring keyType: {}", keyType);
             return;
         }
-        piv.authenticate(PivTestUtils.getManagementKeyType(piv), DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(piv.getManagementKeyType(), DEFAULT_MANAGEMENT_KEY);
         logger.debug("Generate key: {}", keyType);
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("YKPiv" + keyType.params.algorithm.name());

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
@@ -85,7 +85,6 @@ public class PivJcaSigningTests {
 
         signatureAlgorithmsWithPss = getAllSignatureAlgorithmsWithPSS();
 
-
         switch (keyType.params.algorithm) {
             case EC:
                 if (keyType != KeyType.ED25519) {

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import static com.yubico.yubikit.testing.piv.PivTestConstants.DEFAULT_PIN;
 import com.yubico.yubikit.core.application.BadResponseException;
 import com.yubico.yubikit.core.smartcard.ApduException;
 import com.yubico.yubikit.piv.KeyType;
-import com.yubico.yubikit.piv.ManagementKeyType;
 import com.yubico.yubikit.piv.PinPolicy;
 import com.yubico.yubikit.piv.PivSession;
 import com.yubico.yubikit.piv.Slot;
@@ -68,7 +67,11 @@ public class PivJcaSigningTests {
     }
 
     public static void testSign(PivSession piv, KeyType keyType) throws NoSuchAlgorithmException, IOException, ApduException, InvalidKeyException, BadResponseException, InvalidAlgorithmParameterException, SignatureException {
-        piv.authenticate(ManagementKeyType.TDES, DEFAULT_MANAGEMENT_KEY);
+        if (keyType == KeyType.X25519) {
+            logger.debug("Ignoring keyType: {}", keyType);
+            return;
+        }
+        piv.authenticate(PivTestUtils.getManagementKeyType(piv), DEFAULT_MANAGEMENT_KEY);
         logger.debug("Generate key: {}", keyType);
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("YKPiv" + keyType.params.algorithm.name());
@@ -77,13 +80,18 @@ public class PivJcaSigningTests {
 
         signatureAlgorithmsWithPss = getAllSignatureAlgorithmsWithPSS();
 
+
         switch (keyType.params.algorithm) {
             case EC:
-                testSign(keyPair, "SHA1withECDSA", null);
-                testSign(keyPair, "SHA256withECDSA", null);
-                //noinspection SpellCheckingInspection
-                testSign(keyPair, "NONEwithECDSA", null);
-                testSign(keyPair, "SHA3-256withECDSA", null);
+                if (keyType != KeyType.ED25519) {
+                    testSign(keyPair, "SHA1withECDSA", null);
+                    testSign(keyPair, "SHA256withECDSA", null);
+                    //noinspection SpellCheckingInspection
+                    testSign(keyPair, "NONEwithECDSA", null);
+                    testSign(keyPair, "SHA3-256withECDSA", null);
+                } else {
+                    testSign(keyPair, "ED25519", null);
+                }
                 break;
             case RSA:
                 testSign(keyPair, "SHA1withRSA", null);
@@ -166,6 +174,7 @@ public class PivJcaSigningTests {
 
                 break;
         }
+
     }
 
     public static byte[] testSign(KeyPair keyPair, String signatureAlgorithm, AlgorithmParameterSpec param) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, SignatureException {

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
@@ -178,7 +178,6 @@ public class PivJcaSigningTests {
 
                 break;
         }
-
     }
 
     public static byte[] testSign(KeyPair keyPair, String signatureAlgorithm, AlgorithmParameterSpec param) throws NoSuchAlgorithmException, InvalidAlgorithmParameterException, InvalidKeyException, SignatureException {

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaSigningTests.java
@@ -16,6 +16,7 @@
 
 package com.yubico.yubikit.testing.piv;
 
+import static com.yubico.yubikit.piv.PivSession.FEATURE_CV25519;
 import static com.yubico.yubikit.testing.piv.PivJcaUtils.setupJca;
 import static com.yubico.yubikit.testing.piv.PivJcaUtils.tearDownJca;
 import static com.yubico.yubikit.testing.piv.PivTestConstants.DEFAULT_MANAGEMENT_KEY;
@@ -67,6 +68,10 @@ public class PivJcaSigningTests {
     }
 
     public static void testSign(PivSession piv, KeyType keyType) throws NoSuchAlgorithmException, IOException, ApduException, InvalidKeyException, BadResponseException, InvalidAlgorithmParameterException, SignatureException {
+        if (!piv.supports(FEATURE_CV25519) && (keyType == KeyType.ED25519 || keyType == KeyType.X25519)) {
+            return;
+        }
+
         if (keyType == KeyType.X25519) {
             logger.debug("Ignoring keyType: {}", keyType);
             return;

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaUtils.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaUtils.java
@@ -33,7 +33,7 @@ public class PivJcaUtils {
 
     public static void setupJca(PivSession piv) {
         Security.removeProvider("BC");
-        Security.addProvider(new BouncyCastleProvider());
+        Security.insertProviderAt(new BouncyCastleProvider(), 1);
         Security.insertProviderAt(new PivProvider(piv), 1);
         listJcaProviders();
     }

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaUtils.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaUtils.java
@@ -33,7 +33,7 @@ public class PivJcaUtils {
 
     public static void setupJca(PivSession piv) {
         Security.removeProvider("BC");
-        Security.insertProviderAt(new BouncyCastleProvider(), 1);
+        Security.addProvider(new BouncyCastleProvider());
         Security.insertProviderAt(new PivProvider(piv), 1);
         listJcaProviders();
     }

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivMoveKeyTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivMoveKeyTests.java
@@ -61,7 +61,7 @@ public class PivMoveKeyTests {
         Slot srcSlot = Slot.RETIRED1;
         Slot dstSlot = Slot.RETIRED2;
 
-        piv.authenticate(piv.getManagementKeyType(), DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(DEFAULT_MANAGEMENT_KEY);
 
         for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.RSA1024, KeyType.RSA2048, KeyType.ED25519, KeyType.X25519)) {
 

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivMoveKeyTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivMoveKeyTests.java
@@ -28,7 +28,6 @@ import com.yubico.yubikit.core.application.BadResponseException;
 import com.yubico.yubikit.core.keys.PrivateKeyValues;
 import com.yubico.yubikit.core.smartcard.ApduException;
 import com.yubico.yubikit.piv.KeyType;
-import com.yubico.yubikit.piv.ManagementKeyType;
 import com.yubico.yubikit.piv.PinPolicy;
 import com.yubico.yubikit.piv.PivSession;
 import com.yubico.yubikit.piv.Slot;
@@ -58,9 +57,9 @@ public class PivMoveKeyTests {
         Slot srcSlot = Slot.RETIRED1;
         Slot dstSlot = Slot.RETIRED2;
 
-        piv.authenticate(ManagementKeyType.AES192, DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(PivTestUtils.getManagementKeyType(piv), DEFAULT_MANAGEMENT_KEY);
 
-        for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.RSA1024, KeyType.RSA2048)) {
+        for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.RSA1024, KeyType.RSA2048, KeyType.ED25519)) {
 
             KeyPair keyPair = PivTestUtils.loadKey(keyType);
             PrivateKeyValues privateKeyValues = PrivateKeyValues.fromPrivateKey(keyPair.getPrivate());
@@ -82,7 +81,7 @@ public class PivMoveKeyTests {
                 KeyPair signingKeyPair = new KeyPair(publicKey, privateKey);
 
                 testSign(signingKeyPair, keyType.params.algorithm == EC
-                        ? "SHA256withECDSA"
+                        ? keyType == KeyType.ED25519 ? "ED25519" : "SHA256withECDSA"
                         : "SHA256withRSA", null);
 
             } catch (KeyStoreException | UnrecoverableKeyException |

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivMoveKeyTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivMoveKeyTests.java
@@ -63,9 +63,9 @@ public class PivMoveKeyTests {
 
         piv.authenticate(PivTestUtils.getManagementKeyType(piv), DEFAULT_MANAGEMENT_KEY);
 
-        for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.RSA1024, KeyType.RSA2048, KeyType.ED25519)) {
+        for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.RSA1024, KeyType.RSA2048, KeyType.ED25519, KeyType.X25519)) {
 
-            if (!piv.supports(FEATURE_CV25519) && keyType == KeyType.ED25519) {
+            if (!piv.supports(FEATURE_CV25519) && (keyType == KeyType.ED25519 || keyType == KeyType.X25519)) {
                 continue;
             }
 
@@ -88,9 +88,11 @@ public class PivMoveKeyTests {
                 PrivateKey privateKey = (PrivateKey) keyStore.getKey(dstSlot.getStringAlias(), DEFAULT_PIN);
                 KeyPair signingKeyPair = new KeyPair(publicKey, privateKey);
 
-                testSign(signingKeyPair, keyType.params.algorithm == EC
-                        ? keyType == KeyType.ED25519 ? "ED25519" : "SHA256withECDSA"
-                        : "SHA256withRSA", null);
+                if (keyType != KeyType.X25519) {
+                    testSign(signingKeyPair, keyType.params.algorithm == EC
+                            ? keyType == KeyType.ED25519 ? "ED25519" : "SHA256withECDSA"
+                            : "SHA256withRSA", null);
+                }
 
             } catch (KeyStoreException | UnrecoverableKeyException |
                      InvalidAlgorithmParameterException | InvalidKeyException |

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivMoveKeyTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivMoveKeyTests.java
@@ -61,7 +61,7 @@ public class PivMoveKeyTests {
         Slot srcSlot = Slot.RETIRED1;
         Slot dstSlot = Slot.RETIRED2;
 
-        piv.authenticate(PivTestUtils.getManagementKeyType(piv), DEFAULT_MANAGEMENT_KEY);
+        piv.authenticate(piv.getManagementKeyType(), DEFAULT_MANAGEMENT_KEY);
 
         for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.RSA1024, KeyType.RSA2048, KeyType.ED25519, KeyType.X25519)) {
 

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivMoveKeyTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivMoveKeyTests.java
@@ -18,6 +18,8 @@ package com.yubico.yubikit.testing.piv;
 
 import static com.yubico.yubikit.core.smartcard.SW.REFERENCED_DATA_NOT_FOUND;
 import static com.yubico.yubikit.piv.KeyType.Algorithm.EC;
+import static com.yubico.yubikit.piv.PivSession.FEATURE_CV25519;
+import static com.yubico.yubikit.piv.PivSession.FEATURE_MOVE_KEY;
 import static com.yubico.yubikit.testing.piv.PivJcaSigningTests.testSign;
 import static com.yubico.yubikit.testing.piv.PivJcaUtils.setupJca;
 import static com.yubico.yubikit.testing.piv.PivJcaUtils.tearDownJca;
@@ -34,6 +36,7 @@ import com.yubico.yubikit.piv.Slot;
 import com.yubico.yubikit.piv.TouchPolicy;
 
 import org.junit.Assert;
+import org.junit.Assume;
 
 import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
@@ -53,6 +56,7 @@ public class PivMoveKeyTests {
 
     static void moveKey(PivSession piv)
             throws IOException, ApduException, BadResponseException, NoSuchAlgorithmException {
+        Assume.assumeTrue("Key does not support move instruction", piv.supports(FEATURE_MOVE_KEY));
         setupJca(piv);
         Slot srcSlot = Slot.RETIRED1;
         Slot dstSlot = Slot.RETIRED2;
@@ -60,6 +64,10 @@ public class PivMoveKeyTests {
         piv.authenticate(PivTestUtils.getManagementKeyType(piv), DEFAULT_MANAGEMENT_KEY);
 
         for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.RSA1024, KeyType.RSA2048, KeyType.ED25519)) {
+
+            if (!piv.supports(FEATURE_CV25519) && keyType == KeyType.ED25519) {
+                continue;
+            }
 
             KeyPair keyPair = PivTestUtils.loadKey(keyType);
             PrivateKeyValues privateKeyValues = PrivateKeyValues.fromPrivateKey(keyPair.getPrivate());

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivTestUtils.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivTestUtils.java
@@ -20,7 +20,11 @@ import com.yubico.yubikit.core.smartcard.ApduException;
 import com.yubico.yubikit.piv.KeyType;
 import com.yubico.yubikit.piv.ManagementKeyMetadata;
 import com.yubico.yubikit.piv.ManagementKeyType;
+import com.yubico.yubikit.piv.PinPolicy;
 import com.yubico.yubikit.piv.PivSession;
+import com.yubico.yubikit.piv.TouchPolicy;
+import com.yubico.yubikit.piv.jca.PivAlgorithmParameterSpec;
+import com.yubico.yubikit.piv.jca.PivPrivateKey;
 
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -52,6 +56,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECKey;
+import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -129,6 +134,10 @@ public class PivTestUtils {
         ED25519(
                 KeyType.ED25519, "MC4CAQAwBQYDK2VwBCIEIO_yEBZ291rK6lY8BH3RVtO61LnzLv78VxVxBZDj3uvi",
                 "MCowBQYDK2VwAyEA7m2UD-6mR8vVSpGFFYCnsDgXTuFRT5_M7yVOMM_7uHw="
+        ),
+        X25519(
+                KeyType.X25519, "MC4CAQAwBQYDK2VuBCIEIJjvGxF_sesDPC6uoIanoMQU-O4HGMpCqyBssnhc8yBS",
+                "MCowBQYDK2VuAyEAq6Ws-klOFZ_Kbnf4TPqR45T9szGWeKz-5udDURxOeS4"
         );
 
         private final KeyType keyType;
@@ -143,7 +152,10 @@ public class PivTestUtils {
 
         private KeyPair getKeyPair() {
             try {
-                KeyFactory kf = KeyFactory.getInstance(keyType == KeyType.ED25519 ? keyType.name() : keyType.params.algorithm.name());
+                KeyFactory kf = KeyFactory.getInstance(
+                        (keyType == KeyType.ED25519 || keyType == KeyType.X25519)
+                                ? keyType.name()
+                                : keyType.params.algorithm.name());
                 return new KeyPair(
                         kf.generatePublic(new X509EncodedKeySpec(Base64.fromUrlSafeString(publicKey))),
                         kf.generatePrivate(new PKCS8EncodedKeySpec(Base64.fromUrlSafeString(privateKey)))
@@ -226,7 +238,9 @@ public class PivTestUtils {
         KeyType keyType = KeyType.fromKey(keyPair.getPrivate());
         switch (keyType.params.algorithm) {
             case EC:
-                algorithm = keyType == KeyType.ED25519 ? "ED25519" : "SHA256WithECDSA";
+                algorithm = keyType == KeyType.ED25519
+                        ? "ED25519"
+                        : "SHA256WithECDSA";
                 break;
             case RSA:
                 algorithm = "SHA256WithRSA";
@@ -235,7 +249,24 @@ public class PivTestUtils {
                 throw new IllegalStateException();
         }
         try {
-            ContentSigner contentSigner = new JcaContentSignerBuilder(algorithm).build(keyPair.getPrivate());
+
+            // for X25519 we sign with a temporary key
+            PrivateKey pk = null;
+            if (keyType == KeyType.X25519) {
+                try {
+                    KeyPairGenerator kpg = KeyPairGenerator.getInstance("ED25519");
+                    kpg.initialize(255);
+                    KeyPair tempKeyPair = kpg.generateKeyPair();
+                    pk = tempKeyPair.getPrivate();
+                    algorithm = "ED25519";
+                } catch (Exception e) {
+                    // ignored
+                }
+            } else {
+                pk = keyPair.getPrivate();
+            }
+
+            ContentSigner contentSigner = new JcaContentSignerBuilder(algorithm).build(pk);
             X509CertificateHolder holder = serverCertGen.build(contentSigner);
 
             InputStream stream = new ByteArrayInputStream(holder.getEncoded());
@@ -337,6 +368,26 @@ public class PivTestUtils {
 
         Assert.assertArrayEquals("Secret mismatch", secret, peerSecret);
     }
+    public static void x25519KeyAgreement(PrivateKey privateKey, PublicKey publicKey) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("X25519");
+        kpg.initialize(255);
+
+        KeyPair peerPair = kpg.generateKeyPair();
+
+        KeyAgreement ka = KeyAgreement.getInstance("X25519");
+
+        ka.init(privateKey);
+        ka.doPhase(peerPair.getPublic(), true);
+        byte[] secret = ka.generateSecret();
+
+        ka = KeyAgreement.getInstance("X25519");
+        ka.init(peerPair.getPrivate());
+        ka.doPhase(publicKey, true);
+        byte[] peerSecret = ka.generateSecret();
+
+        Assert.assertArrayEquals("Secret mismatch", secret, peerSecret);
+    }
+
 
     static ManagementKeyType getManagementKeyType(PivSession session) {
         try {

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivTestUtils.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivTestUtils.java
@@ -387,14 +387,4 @@ public class PivTestUtils {
 
         Assert.assertArrayEquals("Secret mismatch", secret, peerSecret);
     }
-
-
-    static ManagementKeyType getManagementKeyType(PivSession session) {
-        try {
-            ManagementKeyMetadata metadata = session.getManagementKeyMetadata();
-            return metadata.getKeyType();
-        } catch (IOException | ApduException exception) {
-            return ManagementKeyType.TDES;
-        }
-    }
 }


### PR DESCRIPTION
- Generate/import Ed25519 and X25519 keys directly through `PivSession` or with the use of our YKPiv JCA Provider. 
- Digital signature with Ed25519 through YKPiv JCA Provider.
- Key agreement with X25519 through YKPiv JCA Provider.
- Both new types can be stored in all of the PIV slots.
- All operations on the new key types are guarded by `FEATURE_CV25519` feature.
- New tests for the key types, including different order of JCA providers.

Other changes:
- Cache management key type in the PivSession object for simpler coding, use `PivSession.getManagementKeyType()` to get the value.
- Deprecated `PivSession.authenticate(ManagementKeyType,byte[])` and added `PivSession.authenticate(byte[])` - this new method uses the cached key directly.
- Updated DemoApplication so that one can generate the new keys interactively.


Note: PIV curve 25519 key types are supported since YubiKey firmware version 5.7