### PR TITLE
Categorize sarif files

### DIFF
--- a/.github/workflows/spotbugs-scan.yml
+++ b/.github/workflows/spotbugs-scan.yml
@@ -78,17 +78,17 @@ jobs:
           name: sarif-files
 
       - run: |
-          jq '.runs |= map( if .taxonomies == [null] then .taxonomies = [] else . end)' < $SARIF |
+          jq '.runs |= map( if .taxonomies == [null] then .taxonomies = [] else . end)' < spotbugs-${{ matrix.module }}.sarif |
           jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uri |= \"$module/src/main/java/\" + ." |
           jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uriBaseId |= \"%SRC_ROOT%\" " |
           jq '.runs[].tool.driver.rules |= map( . += { fullDescription: { text: .shortDescription.text } } )' |
           jq '.runs[].tool.driver.rules |= map( . += { name: ("SpotBugs_" + .id | ascii_downcase | sub("(^|_)(?<x>[a-z])";"\(.x|ascii_upcase)";"g")) } )' |
           jq '.runs[].tool.driver.rules |= map( . += { help: { text: .helpUri } } )' |
           jq 'del(.runs[].originalUriBaseIds)' |
-          jq -c '.' > spotbugs-${{ matrix.module }}.sarif
+          jq -c '.' > spotbugs-${{ matrix.module }}.json
 
       - name: Upload SARIF for ${{ matrix.module }}
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: spotbugs-${{ matrix.module }}.sarif
+          sarif_file: spotbugs-${{ matrix.module }}.json
           category: spotbugs-analysis-${{ matrix.module }}

--- a/.github/workflows/spotbugs-scan.yml
+++ b/.github/workflows/spotbugs-scan.yml
@@ -77,10 +77,7 @@ jobs:
         with:
           name: sarif-files
 
-      - name: Fix SARIF of module ${{ matrix.module }}
-        run: >-
-          module=${{ matrix.module }}
-          SARIF=spotbugs-$module.sarif
+      - run: |
           jq '.runs |= map( if .taxonomies == [null] then .taxonomies = [] else . end)' < $SARIF |
           jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uri |= \"$module/src/main/java/\" + ." |
           jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uriBaseId |= \"%SRC_ROOT%\" " |
@@ -88,8 +85,7 @@ jobs:
           jq '.runs[].tool.driver.rules |= map( . += { name: ("SpotBugs_" + .id | ascii_downcase | sub("(^|_)(?<x>[a-z])";"\(.x|ascii_upcase)";"g")) } )' |
           jq '.runs[].tool.driver.rules |= map( . += { help: { text: .helpUri } } )' |
           jq 'del(.runs[].originalUriBaseIds)' |
-          jq -c '.' > $SARIF.json
-          mv $SARIF.json $SARIF
+          jq -c '.' > spotbugs-${{ matrix.module }}.sarif
 
       - name: Upload SARIF for ${{ matrix.module }}
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/spotbugs-scan.yml
+++ b/.github/workflows/spotbugs-scan.yml
@@ -2,7 +2,7 @@ name: "SpotBugs"
 
 on:
   push:
-    branches: [ main, adamve/multiple_sarif_files ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]

--- a/.github/workflows/spotbugs-scan.yml
+++ b/.github/workflows/spotbugs-scan.yml
@@ -2,7 +2,7 @@ name: "SpotBugs"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, adamve/multiple_sarif_files ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["java"]
+        language: [ "java" ]
 
     steps:
       - name: Checkout repository
@@ -38,35 +38,61 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew spotbugsRelease spotbugsMain
 
-      - name: Fix SARIF
-        run: >-
-          for module in \
-            "android" \
-            "AndroidDemo" \
-            "core" \
-            "fido" \
-            "management" \
-            "oath" \
-            "openpgp" \
-            "piv" \
-            "support" \
-            "testing" \
-            "yubiotp";
-          do
-            SARIF="./build/spotbugs/spotbugs-$module.sarif"
-            jq '.runs |= map( if .taxonomies == [null] then .taxonomies = [] else . end)' < $SARIF |
-            jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uri |= \"$module/src/main/java/\" + ." |
-            jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uriBaseId |= \"%SRC_ROOT%\" " |
-            jq '.runs[].tool.driver.rules |= map( . += { fullDescription: { text: .shortDescription.text } } )' |
-            jq '.runs[].tool.driver.rules |= map( . += { name: ("SpotBugs_" + .id | ascii_downcase | sub("(^|_)(?<x>[a-z])";"\(.x|ascii_upcase)";"g")) } )' |
-            jq '.runs[].tool.driver.rules |= map( . += { help: { text: .helpUri } } )' |
-            jq 'del(.runs[].originalUriBaseIds)' |
-            jq -c '.' > $SARIF.json
-            mv $SARIF.json $SARIF
-          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sarif-files
+          path: ./build/spotbugs/*.sarif
+          retention-days: 1
 
-      - name: upload SARIF
+  upload:
+    name: Upload SARIF
+    needs: analyze
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          [
+            "android",
+            "AndroidDemo",
+            "core",
+            "fido",
+            "management",
+            "oath",
+            "openpgp",
+            "piv",
+            "support",
+            "testing",
+            "yubiotp",
+          ]
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sarif-files
+
+      - name: Fix SARIF of module ${{ matrix.module }}
+        run: >-
+          module=${{ matrix.module }}
+          SARIF=spotbugs-$module.sarif
+          jq '.runs |= map( if .taxonomies == [null] then .taxonomies = [] else . end)' < $SARIF |
+          jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uri |= \"$module/src/main/java/\" + ." |
+          jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uriBaseId |= \"%SRC_ROOT%\" " |
+          jq '.runs[].tool.driver.rules |= map( . += { fullDescription: { text: .shortDescription.text } } )' |
+          jq '.runs[].tool.driver.rules |= map( . += { name: ("SpotBugs_" + .id | ascii_downcase | sub("(^|_)(?<x>[a-z])";"\(.x|ascii_upcase)";"g")) } )' |
+          jq '.runs[].tool.driver.rules |= map( . += { help: { text: .helpUri } } )' |
+          jq 'del(.runs[].originalUriBaseIds)' |
+          jq -c '.' > $SARIF.json
+          mv $SARIF.json $SARIF
+
+      - name: Upload SARIF for ${{ matrix.module }}
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: build/spotbugs/
-          category: spotbugs-analysis
+          sarif_file: spotbugs-${{ matrix.module }}.sarif
+          category: spotbugs-analysis-${{ matrix.module }}


### PR DESCRIPTION
Uploads each sarif file with its own category and fixes the following warning: 

```
Uploading multiple SARIF runs with the same category is deprecated and will be removed on June 4, 2025. Please update your workflow to upload a single run per category.
```

More info: https://github.blog/changelog/2024-05-06-code-scanning-will-stop-combining-runs-from-a-single-upload