### PR TITLE
Update Spotbugs GitHub action

### DIFF
--- a/.github/workflows/spotbugs-scan.yml
+++ b/.github/workflows/spotbugs-scan.yml
@@ -18,7 +18,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      security-events: write
 
     strategy:
       fail-fast: false
@@ -78,14 +77,19 @@ jobs:
           name: sarif-files
 
       - run: |
-          jq '.runs |= map( if .taxonomies == [null] then .taxonomies = [] else . end)' < spotbugs-${{ matrix.module }}.sarif |
-          jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uri |= \"$module/src/main/java/\" + ." |
+          MODULE=${{ matrix.module }}
+          BASE_NAME=spotbugs-${MODULE}
+          INPUT=${BASE_NAME}.sarif
+          OUTPUT=${BASE_NAME}.json
+          jq '.runs |= map( if .taxonomies == [null] then .taxonomies = [] else . end)' < ${INPUT} |
+          jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uri |= \"${MODULE}/src/main/java/\" + ." |
           jq ".runs[].results[].locations[].physicalLocation.artifactLocation.uriBaseId |= \"%SRC_ROOT%\" " |
           jq '.runs[].tool.driver.rules |= map( . += { fullDescription: { text: .shortDescription.text } } )' |
           jq '.runs[].tool.driver.rules |= map( . += { name: ("SpotBugs_" + .id | ascii_downcase | sub("(^|_)(?<x>[a-z])";"\(.x|ascii_upcase)";"g")) } )' |
           jq '.runs[].tool.driver.rules |= map( . += { help: { text: .helpUri } } )' |
+          jq '.runs[].invocations |= map( . += { executionSuccessful: true } )' |
           jq 'del(.runs[].originalUriBaseIds)' |
-          jq -c '.' > spotbugs-${{ matrix.module }}.json
+          jq -c '.' > ${OUTPUT}
 
       - name: Upload SARIF for ${{ matrix.module }}
         uses: github/codeql-action/upload-sarif@v3

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,6 +9,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.16'
+    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.18'
     implementation 'com.android.tools.build:gradle:8.4.2'
 }

--- a/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
+++ b/buildSrc/src/main/groovy/project-convention-spotbugs.gradle
@@ -6,11 +6,11 @@ plugins {
 }
 
 dependencies {
-    spotbugs 'com.github.spotbugs:spotbugs:4.8.5'
+    spotbugs 'com.github.spotbugs:spotbugs:4.8.6'
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.13.0'
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.5'
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.8.6'
 
     testImplementation 'com.google.code.findbugs:jsr305:3.0.2'
 }


### PR DESCRIPTION
1. Bumps the versions of spotbugs and spotbugs gradle plugin to most recent.

2. Forces `true` result for the spotbugs invocations (in the sarif files this is a property in `runs[].invocations` called `executionSuccessful`). The reason is that there is a bug in find-sec-bugs which causes warnings/errors similar to

   ```
   The following classes needed for analysis were missing:
   call
   invoke
   ```

   and makes the invocation to fail (with exit code 3 and execution successful `false`). 
   Github is reading the value of `executionSuccessful` and reports it as 

   ![image](https://github.com/Yubico/yubikit-android/assets/1954891/07d1d4bc-2b4f-4623-8281-a8481122bccd)

   Forcing execution successful to true removes the error status and we can still browse all the reports in the security scanning view.

