### PR TITLE
Improve legacy key support

### DIFF
--- a/core/src/main/java/com/yubico/yubikit/core/application/Feature.java
+++ b/core/src/main/java/com/yubico/yubikit/core/application/Feature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022, 2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package com.yubico.yubikit.core.application;
+
+import static com.yubico.yubikit.core.application.SessionVersionOverride.overrideOf;
 
 import com.yubico.yubikit.core.Version;
 
@@ -71,7 +73,7 @@ public abstract class Feature<T extends ApplicationSession<T>> {
 
         @Override
         public boolean isSupportedBy(Version version) {
-            return version.compareTo(requiredVersion) >= 0;
+            return overrideOf(version).compareTo(requiredVersion) >= 0;
         }
     }
 }

--- a/core/src/main/java/com/yubico/yubikit/core/application/Feature.java
+++ b/core/src/main/java/com/yubico/yubikit/core/application/Feature.java
@@ -71,7 +71,7 @@ public abstract class Feature<T extends ApplicationSession<T>> {
 
         @Override
         public boolean isSupportedBy(Version version) {
-            return version.major == 0 || version.compareTo(requiredVersion) >= 0;
+            return version.compareTo(requiredVersion) >= 0;
         }
     }
 }

--- a/core/src/main/java/com/yubico/yubikit/core/application/SessionVersionOverride.java
+++ b/core/src/main/java/com/yubico/yubikit/core/application/SessionVersionOverride.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.core.application;
+
+import com.yubico.yubikit.core.Version;
+
+import javax.annotation.Nullable;
+
+/**
+ * Adds support for overriding YubiKey session version number.
+ * <p>
+ * Internal use only.
+ */
+public class SessionVersionOverride {
+
+    @Nullable
+    private static Version versionOverride = null;
+
+    /**
+     * Internal use only.
+     * <p>
+     * Override version of connected YubiKey with the specified version.
+     *
+     * @param version version to use instead of YubiKey version. Only applies if the major version
+     *                of the YubiKey is 0.
+     */
+    public static void set(@Nullable Version version) {
+        versionOverride = version;
+    }
+
+    /**
+     * Returns an applicable override of version.
+     *
+     * @param version The version which might be overridden.
+     * @return Version to use.
+     */
+    static Version overrideOf(Version version) {
+        return (versionOverride != null && version.major == 0)
+                ? versionOverride
+                : version;
+    }
+}

--- a/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
+++ b/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
@@ -30,7 +30,6 @@ import com.yubico.yubikit.core.otp.OtpConnection;
 import com.yubico.yubikit.core.smartcard.AppId;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
 import com.yubico.yubikit.core.smartcard.SmartCardProtocol;
-import com.yubico.yubikit.core.smartcard.scp.ScpKeyParams;
 import com.yubico.yubikit.management.Capability;
 import com.yubico.yubikit.management.DeviceConfig;
 import com.yubico.yubikit.management.DeviceInfo;
@@ -78,17 +77,14 @@ public class DeviceUtil {
         return new OtpData(otpSession.getVersion(), serialNumber);
     }
 
-    static DeviceInfo readInfoCcid(
-            SmartCardConnection connection,
-            int interfaces,
-            @Nullable ScpKeyParams scpKeyParams)
+    static DeviceInfo readInfoCcid(SmartCardConnection connection, int interfaces)
             throws IOException {
 
         boolean managementAvailable = true;
         Version version = null;
 
         try {
-            ManagementSession managementSession = new ManagementSession(connection, scpKeyParams);
+            ManagementSession managementSession = new ManagementSession(connection);
             version = managementSession.getVersion();
             try {
                 return managementSession.getDeviceInfo();
@@ -279,20 +275,16 @@ public class DeviceUtil {
      * The <code>pid</code> parameter must be provided whenever the YubiKey is connected via USB,
      * </p>
      *
-     * @param connection   {@link SmartCardConnection}, {@link OtpConnection} or
-     *                     {@link FidoConnection} connection to the YubiKey
-     * @param pid          USB product ID of the YubiKey, can be null if unknown
-     * @param scpKeyParams SCP key parameters to establish a secure smartcard connection
+     * @param connection {@link SmartCardConnection}, {@link OtpConnection} or
+     *                   {@link FidoConnection} connection to the YubiKey
+     * @param pid        USB product ID of the YubiKey, can be null if unknown
      * @throws IOException              in case of connection error
      * @throws IllegalArgumentException in case of <code>pid</code> is null for USB connection
      * @throws IllegalArgumentException in case of connection is not {@link SmartCardConnection},
      *                                  {@link OtpConnection} or {@link FidoConnection}
      * @throws IllegalArgumentException when the hardware key could not be identified
      */
-    public static DeviceInfo readInfo(
-            YubiKeyConnection connection,
-            @Nullable UsbPid pid,
-            @Nullable ScpKeyParams scpKeyParams)
+    public static DeviceInfo readInfo(YubiKeyConnection connection, @Nullable UsbPid pid)
             throws IOException, IllegalArgumentException {
 
         YubiKeyType keyType = null;
@@ -308,7 +300,7 @@ public class DeviceUtil {
 
         DeviceInfo info;
         if (connection instanceof SmartCardConnection) {
-            info = readInfoCcid((SmartCardConnection) connection, interfaces, scpKeyParams);
+            info = readInfoCcid((SmartCardConnection) connection, interfaces);
         } else if (connection instanceof OtpConnection) {
             info = readInfoOtp((OtpConnection) connection, keyType, interfaces);
         } else if (connection instanceof FidoConnection) {
@@ -319,33 +311,6 @@ public class DeviceUtil {
 
         Logger.debug(logger, "Read info {}", info);
         return adjustDeviceInfo(info, keyType, interfaces);
-    }
-
-    /**
-     * Reads out DeviceInfo from a YubiKey, or attempts to synthesize the data.
-     * <p>
-     * Reading DeviceInfo from a ManagementSession is only supported for newer YubiKeys.
-     * This function attempts to read that information, but will fall back to gathering the
-     * data using other mechanisms if needed. It will also make adjustments to the data if
-     * required, for example to "fix" known bad values.
-     * </p>
-     * <p>
-     * The <code>pid</code> parameter must be provided whenever the YubiKey is connected via USB,
-     * </p>
-     *
-     * @param connection {@link SmartCardConnection}, {@link OtpConnection} or
-     *                   {@link FidoConnection} connection to the YubiKey
-     * @param pid        USB product ID of the YubiKey, can be null if unknown
-     * @throws IOException              in case of connection error
-     * @throws IllegalArgumentException in case of <code>pid</code> is null for USB connection
-     * @throws IllegalArgumentException in case of connection is not {@link SmartCardConnection},
-     *                                  {@link OtpConnection} or {@link FidoConnection}
-     * @throws IllegalArgumentException when the hardware key could not be identified
-     */
-    public static DeviceInfo readInfo(
-            YubiKeyConnection connection,
-            @Nullable UsbPid pid) throws IOException {
-        return readInfo(connection, pid, null);
     }
 
     /**

--- a/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
+++ b/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
@@ -16,7 +16,6 @@
 
 package com.yubico.yubikit.support;
 
-import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.UsbInterface;
 import com.yubico.yubikit.core.UsbPid;
@@ -26,6 +25,7 @@ import com.yubico.yubikit.core.YubiKeyType;
 import com.yubico.yubikit.core.application.ApplicationNotAvailableException;
 import com.yubico.yubikit.core.application.CommandException;
 import com.yubico.yubikit.core.fido.FidoConnection;
+import com.yubico.yubikit.core.internal.Logger;
 import com.yubico.yubikit.core.otp.OtpConnection;
 import com.yubico.yubikit.core.smartcard.AppId;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
@@ -153,10 +153,7 @@ public class DeviceUtil {
                 .build();
     }
 
-    static DeviceInfo readInfoOtp(
-            OtpConnection connection,
-            YubiKeyType keyType,
-            int interfaces)
+    static DeviceInfo readInfoOtp(OtpConnection connection, YubiKeyType keyType, int interfaces)
             throws IOException {
 
         ManagementSession managementSession = null;
@@ -534,11 +531,10 @@ public class DeviceUtil {
             }
 
             StringBuilder builder = new StringBuilder();
-            for (int partCount = 0; partCount < namePartsList.size(); partCount++)
-            {
+            for (int partCount = 0; partCount < namePartsList.size(); partCount++) {
                 String s = namePartsList.get(partCount);
                 builder.append(s);
-                if (partCount<namePartsList.size() - 1) {
+                if (partCount < namePartsList.size() - 1) {
                     builder.append(" ");
                 }
             }

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/oath/OathTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/oath/OathTests.java
@@ -50,6 +50,11 @@ public class OathTests {
         public void testAccountManagement() throws Throwable {
             withOathSession(OathDeviceTests::testAccountManagement);
         }
+
+        @Test
+        public void testRenameAccount() throws Throwable {
+            withOathSession(OathDeviceTests::testRenameAccount);
+        }
     }
 
     public static class Scp11bTests extends NoScpTests {

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/FidoInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/FidoInstrumentedTests.java
@@ -18,6 +18,7 @@ package com.yubico.yubikit.testing.framework;
 
 import androidx.annotation.Nullable;
 
+import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.smartcard.scp.ScpKid;
 import com.yubico.yubikit.fido.ctap.Ctap2Session;
@@ -33,7 +34,7 @@ public class FidoInstrumentedTests extends YKInstrumentedTests {
     }
 
     protected void withDevice(boolean setPin, TestState.StatefulDeviceCallback<FidoTestState> callback) throws Throwable {
-        FidoTestState state = new FidoTestState.Builder(device, getPinUvAuthProtocol())
+        FidoTestState state = new FidoTestState.Builder(device, usbPid, getPinUvAuthProtocol())
                 .scpKid(getScpKid())
                 .reconnectDeviceCallback(this::reconnectDevice)
                 .setPin(setPin)
@@ -43,7 +44,7 @@ public class FidoInstrumentedTests extends YKInstrumentedTests {
     }
 
     protected void withCtap2Session(TestState.StatefulSessionCallback<Ctap2Session, FidoTestState> callback) throws Throwable {
-        FidoTestState state = new FidoTestState.Builder(device, getPinUvAuthProtocol())
+        FidoTestState state = new FidoTestState.Builder(device, usbPid, getPinUvAuthProtocol())
                 .scpKid(getScpKid())
                 .reconnectDeviceCallback(this::reconnectDevice)
                 .setPin(true)

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/MpeInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/MpeInstrumentedTests.java
@@ -24,12 +24,16 @@ import com.yubico.yubikit.testing.mpe.MpeTestState;
 public class MpeInstrumentedTests extends YKInstrumentedTests {
 
     protected void withPivSession(TestState.StatefulSessionCallback<PivSession, MpeTestState> callback) throws Throwable {
-        final MpeTestState state = new MpeTestState.Builder(device).scpKid(getScpKid()).build();
+        final MpeTestState state = new MpeTestState.Builder(device, usbPid)
+                .scpKid(getScpKid())
+                .build();
         state.withPiv(callback);
     }
 
     protected void withCtap2Session(TestState.StatefulSessionCallback<Ctap2Session, MpeTestState> callback) throws Throwable {
-        final MpeTestState state = new MpeTestState.Builder(device).scpKid(getScpKid()).build();
+        final MpeTestState state = new MpeTestState.Builder(device, usbPid)
+                .scpKid(getScpKid())
+                .build();
         state.withCtap2(callback);
     }
 }

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/OathInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/OathInstrumentedTests.java
@@ -23,7 +23,7 @@ import com.yubico.yubikit.testing.oath.OathTestState;
 public class OathInstrumentedTests extends YKInstrumentedTests {
 
     protected void withDevice(TestState.StatefulDeviceCallback<OathTestState> callback) throws Throwable {
-        final OathTestState state = new OathTestState.Builder(device)
+        final OathTestState state = new OathTestState.Builder(device, usbPid)
                 .scpKid(getScpKid())
                 .reconnectDeviceCallback(this::reconnectDevice)
                 .build();
@@ -32,7 +32,9 @@ public class OathInstrumentedTests extends YKInstrumentedTests {
     }
 
     protected void withOathSession(TestState.StatefulSessionCallback<OathSession, OathTestState> callback) throws Throwable {
-        final OathTestState state = new OathTestState.Builder(device).scpKid(getScpKid()).build();
+        final OathTestState state = new OathTestState.Builder(device, usbPid)
+                .scpKid(getScpKid())
+                .build();
         state.withOath(callback);
     }
 }

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/OpenPgpInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/OpenPgpInstrumentedTests.java
@@ -22,7 +22,9 @@ import com.yubico.yubikit.testing.openpgp.OpenPgpTestState;
 
 public class OpenPgpInstrumentedTests extends YKInstrumentedTests {
     protected void withOpenPgpSession(TestState.StatefulSessionCallback<OpenPgpSession, OpenPgpTestState> callback) throws Throwable {
-        final OpenPgpTestState state = new OpenPgpTestState.Builder(device).scpKid(getScpKid()).build();
+        final OpenPgpTestState state = new OpenPgpTestState.Builder(device, usbPid)
+                .scpKid(getScpKid())
+                .build();
         state.withOpenPgp(callback);
     }
 }

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/PivInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/PivInstrumentedTests.java
@@ -22,7 +22,9 @@ import com.yubico.yubikit.testing.piv.PivTestState;
 
 public class PivInstrumentedTests extends YKInstrumentedTests {
     protected void withPivSession(TestState.StatefulSessionCallback<PivSession, PivTestState> callback) throws Throwable {
-        final PivTestState state = new PivTestState.Builder(device).scpKid(getScpKid()).build();
+        final PivTestState state = new PivTestState.Builder(device, usbPid)
+                .scpKid(getScpKid())
+                .build();
         state.withPiv(callback);
     }
 }

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/SecurityDomainInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/SecurityDomainInstrumentedTests.java
@@ -16,13 +16,14 @@
 
 package com.yubico.yubikit.testing.framework;
 
+import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.sd.SecurityDomainTestState;
 
 public class SecurityDomainInstrumentedTests extends YKInstrumentedTests {
 
     protected void withState(TestState.StatefulDeviceCallback<SecurityDomainTestState> callback) throws Throwable {
-        final SecurityDomainTestState state = new SecurityDomainTestState.Builder(device)
+        final SecurityDomainTestState state = new SecurityDomainTestState.Builder(device, usbPid)
                 .reconnectDeviceCallback(this::reconnectDevice)
                 .build();
 

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
@@ -21,13 +21,20 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.UsbPid;
+import com.yubico.yubikit.core.Version;
 import com.yubico.yubikit.core.YubiKeyDevice;
+import com.yubico.yubikit.core.application.SessionVersionOverride;
+import com.yubico.yubikit.core.smartcard.SmartCardConnection;
+import com.yubico.yubikit.management.DeviceInfo;
+import com.yubico.yubikit.support.DeviceUtil;
 import com.yubico.yubikit.testing.TestActivity;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+
+import java.io.IOException;
 
 import javax.annotation.Nullable;
 
@@ -50,6 +57,17 @@ public class YKInstrumentedTests {
         usbPid = device instanceof UsbYubiKeyDevice
                 ? ((UsbYubiKeyDevice) device).getPid()
                 : null;
+
+        // use this version for devices which have major 0
+        SessionVersionOverride.set(new Version(5, 7, 2));
+        try (SmartCardConnection connection = device.openConnection(SmartCardConnection.class)) {
+            final DeviceInfo deviceInfo = DeviceUtil.readInfo(connection, usbPid);
+            if (deviceInfo.getVersion().major == 3) {
+                // for NEO remove the override
+                SessionVersionOverride.set(null);
+            }
+        } catch (IOException ignored) {
+        }
     }
 
     @After

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
@@ -58,13 +58,10 @@ public class YKInstrumentedTests {
                 ? ((UsbYubiKeyDevice) device).getPid()
                 : null;
 
-        // use this version for devices which have major 0
-        SessionVersionOverride.set(new Version(5, 7, 2));
         try (SmartCardConnection connection = device.openConnection(SmartCardConnection.class)) {
             final DeviceInfo deviceInfo = DeviceUtil.readInfo(connection, usbPid);
-            if (deviceInfo.getVersion().major == 3) {
-                // for NEO remove the override
-                SessionVersionOverride.set(null);
+            if (deviceInfo.getVersion().major == 0) {
+                SessionVersionOverride.set(new Version(5, 7, 2));
             }
         } catch (IOException ignored) {
         }

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
@@ -18,7 +18,9 @@ package com.yubico.yubikit.testing.framework;
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 
+import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice;
 import com.yubico.yubikit.core.Transport;
+import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.testing.TestActivity;
 
@@ -33,6 +35,7 @@ public class YKInstrumentedTests {
 
     private TestActivity activity;
     protected YubiKeyDevice device = null;
+    protected UsbPid usbPid = null;
 
     @Rule
     public final TestName name = new TestName();
@@ -44,6 +47,9 @@ public class YKInstrumentedTests {
     public void getYubiKey() throws InterruptedException {
         scenarioRule.getScenario().onActivity((TestActivity activity) -> this.activity = activity);
         device = activity.awaitSession(getClass().getSimpleName(), name.getMethodName());
+        usbPid = device instanceof UsbYubiKeyDevice
+                ? ((UsbYubiKeyDevice) device).getPid()
+                : null;
     }
 
     @After
@@ -55,6 +61,7 @@ public class YKInstrumentedTests {
         activity.returnSession(device);
         device = null;
         activity = null;
+        usbPid = null;
     }
 
     protected YubiKeyDevice reconnectDevice() {

--- a/testing/src/main/java/com/yubico/yubikit/testing/TestState.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/TestState.java
@@ -92,7 +92,7 @@ public class TestState {
 
     private void setupJca() {
         Security.removeProvider("BC");
-        Security.addProvider(new BouncyCastleProvider());
+        Security.insertProviderAt(new BouncyCastleProvider(), 1);
     }
 
     public boolean isUsbTransport() {

--- a/testing/src/main/java/com/yubico/yubikit/testing/TestState.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/TestState.java
@@ -16,8 +16,6 @@
 
 package com.yubico.yubikit.testing;
 
-import static com.yubico.yubikit.support.DeviceUtil.readInfo;
-
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyConnection;
@@ -166,7 +164,7 @@ public class TestState {
     public DeviceInfo getDeviceInfo() {
         DeviceInfo deviceInfo = null;
         try (YubiKeyConnection connection = openConnection()) {
-            deviceInfo = DeviceUtil.readInfo(connection, usbPid, scpParameters.getKeyParams());
+            deviceInfo = DeviceUtil.readInfo(connection, usbPid);
         } catch (IOException | UnsupportedOperationException ignoredException) {
         }
 

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/FidoTestState.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/FidoTestState.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
+import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyConnection;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.core.application.CommandException;
@@ -60,8 +61,8 @@ public class FidoTestState extends TestState {
         private final PinUvAuthProtocol pinUvAuthProtocol;
         private boolean setPin = false;
 
-        public Builder(YubiKeyDevice device, PinUvAuthProtocol pinUvAuthProtocol) {
-            super(device);
+        public Builder(YubiKeyDevice device, UsbPid usbPid, PinUvAuthProtocol pinUvAuthProtocol) {
+            super(device, usbPid);
             this.pinUvAuthProtocol = pinUvAuthProtocol;
         }
 
@@ -245,12 +246,16 @@ public class FidoTestState extends TestState {
     }
 
     @Nullable
-    public static Ctap2Session getCtap2Session(YubiKeyConnection connection)
-            throws IOException, CommandException {
-        return (connection instanceof FidoConnection)
-                ? new Ctap2Session((FidoConnection) connection)
-                : connection instanceof SmartCardConnection
-                ? new Ctap2Session((SmartCardConnection) connection)
-                : null;
+    public static Ctap2Session getCtap2Session(YubiKeyConnection connection) {
+        try {
+            return (connection instanceof FidoConnection)
+                    ? new Ctap2Session((FidoConnection) connection)
+                    : connection instanceof SmartCardConnection
+                    ? new Ctap2Session((SmartCardConnection) connection)
+                    : null;
+        } catch (IOException | CommandException ignored) {
+            // device does not provide CTAP2
+            return null;
+        }
     }
 }

--- a/testing/src/main/java/com/yubico/yubikit/testing/mpe/MpeTestState.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/mpe/MpeTestState.java
@@ -19,6 +19,7 @@ package com.yubico.yubikit.testing.mpe;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeTrue;
 
+import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyConnection;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
@@ -34,8 +35,8 @@ import com.yubico.yubikit.testing.piv.PivTestState;
 public class MpeTestState extends TestState {
     public static class Builder extends TestState.Builder<MpeTestState.Builder> {
 
-        public Builder(YubiKeyDevice device) {
-            super(device);
+        public Builder(YubiKeyDevice device, UsbPid usbPid) {
+            super(device, usbPid);
         }
 
         @Override

--- a/testing/src/main/java/com/yubico/yubikit/testing/oath/OathDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/oath/OathDeviceTests.java
@@ -16,6 +16,7 @@
 
 package com.yubico.yubikit.testing.oath;
 
+import static com.yubico.yubikit.oath.OathSession.FEATURE_RENAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -27,6 +28,8 @@ import com.yubico.yubikit.core.smartcard.SW;
 import com.yubico.yubikit.oath.Credential;
 import com.yubico.yubikit.oath.CredentialData;
 import com.yubico.yubikit.oath.OathSession;
+
+import org.junit.Assume;
 
 import java.net.URI;
 import java.util.List;
@@ -84,6 +87,24 @@ public class OathDeviceTests {
         assertEquals("bob@example.com", credential.getAccountName());
         assertEquals("foobar", credential.getIssuer());
 
+        oath.deleteCredential(credential.getId());
+        credentials = oath.getCredentials();
+        assertEquals(0, credentials.size());
+    }
+
+    public static void testRenameAccount(OathSession oath, OathTestState state) throws Exception {
+        Assume.assumeTrue(oath.supports(FEATURE_RENAME));
+        assertTrue(oath.unlock(state.password));
+        List<Credential> credentials = oath.getCredentials();
+        assertEquals(0, credentials.size());
+        final String uri = "otpauth://totp/foobar:bob@example.com?secret=abba";
+        CredentialData credentialData = CredentialData.parseUri(new URI(uri));
+        oath.putCredential(credentialData, false);
+
+        credentials = oath.getCredentials();
+        assertEquals(1,  credentials.size());
+
+        Credential credential = credentials.get(0);
         credential = oath.renameCredential(credential, "ann@example.com", null);
         assertEquals("ann@example.com", credential.getAccountName());
         assertNull(credential.getIssuer());

--- a/testing/src/main/java/com/yubico/yubikit/testing/oath/OathTestState.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/oath/OathTestState.java
@@ -19,6 +19,7 @@ package com.yubico.yubikit.testing.oath;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.core.application.ApplicationNotAvailableException;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
@@ -37,8 +38,8 @@ public class OathTestState extends TestState {
 
     public static class Builder extends TestState.Builder<OathTestState.Builder> {
 
-        public Builder(YubiKeyDevice device) {
-            super(device);
+        public Builder(YubiKeyDevice device, UsbPid usbPid) {
+            super(device, usbPid);
         }
 
         @Override

--- a/testing/src/main/java/com/yubico/yubikit/testing/openpgp/OpenPgpDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/openpgp/OpenPgpDeviceTests.java
@@ -204,8 +204,6 @@ public class OpenPgpDeviceTests {
     public static void testGenerateEcKeys(OpenPgpSession openpgp, OpenPgpTestState state) throws Exception {
         Assume.assumeTrue("EC support", openpgp.supports(OpenPgpSession.FEATURE_EC_KEYS));
 
-        Security.removeProvider("BC");
-        Security.insertProviderAt(new BouncyCastleProvider(), 1);
         openpgp.verifyAdminPin(state.defaultAdminPin);
 
         byte[] message = "hello".getBytes(StandardCharsets.UTF_8);
@@ -243,8 +241,6 @@ public class OpenPgpDeviceTests {
     public static void testGenerateEd25519(OpenPgpSession openpgp, OpenPgpTestState state) throws Exception {
         Assume.assumeTrue("EC support", openpgp.supports(OpenPgpSession.FEATURE_EC_KEYS));
 
-        Security.removeProvider("BC");
-        Security.insertProviderAt(new BouncyCastleProvider(), 1);
         openpgp.verifyAdminPin(state.defaultAdminPin);
 
         byte[] message = "hello".getBytes(StandardCharsets.UTF_8);
@@ -263,8 +259,6 @@ public class OpenPgpDeviceTests {
 
         Assume.assumeFalse("X25519 not supported in FIPS OpenPGP.", state.isFipsApproved);
 
-        Security.removeProvider("BC");
-        Security.insertProviderAt(new BouncyCastleProvider(), 1);
         openpgp.verifyAdminPin(state.defaultAdminPin);
 
         PublicKey publicKey = openpgp.generateEcKey(KeyRef.DEC, OpenPgpCurve.X25519).toPublicKey();
@@ -320,9 +314,6 @@ public class OpenPgpDeviceTests {
     public static void testImportEcDsaKeys(OpenPgpSession openpgp, OpenPgpTestState state) throws Exception {
         Assume.assumeTrue("EC support", openpgp.supports(OpenPgpSession.FEATURE_EC_KEYS));
 
-        Security.removeProvider("BC");
-        Security.insertProviderAt(new BouncyCastleProvider(), 1);
-
         openpgp.verifyAdminPin(state.defaultAdminPin);
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("ECDSA");
@@ -368,9 +359,6 @@ public class OpenPgpDeviceTests {
     public static void testImportEd25519(OpenPgpSession openpgp, OpenPgpTestState state) throws Exception {
         Assume.assumeTrue("EC support", openpgp.supports(OpenPgpSession.FEATURE_EC_KEYS));
 
-        Security.removeProvider("BC");
-        Security.insertProviderAt(new BouncyCastleProvider(), 1);
-
         openpgp.verifyAdminPin(state.defaultAdminPin);
 
         KeyPairGenerator kpg = KeyPairGenerator.getInstance("Ed25519");
@@ -393,9 +381,6 @@ public class OpenPgpDeviceTests {
     public static void testImportX25519(OpenPgpSession openpgp, OpenPgpTestState state) throws Exception {
         Assume.assumeTrue("EC support", openpgp.supports(OpenPgpSession.FEATURE_EC_KEYS));
         Assume.assumeFalse("X25519 not supported in FIPS OpenPGP.", state.isFipsApproved);
-
-        Security.removeProvider("BC");
-        Security.insertProviderAt(new BouncyCastleProvider(), 1);
 
         openpgp.verifyAdminPin(state.defaultAdminPin);
 

--- a/testing/src/main/java/com/yubico/yubikit/testing/openpgp/OpenPgpTestState.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/openpgp/OpenPgpTestState.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.core.application.ApplicationNotAvailableException;
 import com.yubico.yubikit.core.application.CommandException;
@@ -48,8 +49,8 @@ public class OpenPgpTestState extends TestState {
 
     public static class Builder extends TestState.Builder<OpenPgpTestState.Builder> {
 
-        public Builder(YubiKeyDevice device) {
-            super(device);
+        public Builder(YubiKeyDevice device, UsbPid usbPid) {
+            super(device, usbPid);
         }
 
         @Override

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivJcaDeviceTests.java
@@ -16,10 +16,12 @@
 package com.yubico.yubikit.testing.piv;
 
 import static com.yubico.yubikit.piv.PivSession.FEATURE_CV25519;
+import static com.yubico.yubikit.piv.PivSession.FEATURE_P384;
 import static com.yubico.yubikit.piv.PivSession.FEATURE_RSA3072_RSA4096;
 import static com.yubico.yubikit.testing.piv.PivJcaUtils.setupJca;
 import static com.yubico.yubikit.testing.piv.PivJcaUtils.tearDownJca;
 
+import com.yubico.yubikit.core.Version;
 import com.yubico.yubikit.piv.KeyType;
 import com.yubico.yubikit.piv.PinPolicy;
 import com.yubico.yubikit.piv.PivSession;
@@ -78,6 +80,11 @@ public class PivJcaDeviceTests {
         }
 
         for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384)) {
+
+            if (!piv.supports(FEATURE_P384) && keyType == KeyType.ECCP384) {
+                continue;
+            }
+
             String alias = Slot.SIGNATURE.getStringAlias();
 
             KeyPair keyPair = PivTestUtils.loadKey(keyType);
@@ -153,6 +160,10 @@ public class PivJcaDeviceTests {
         for (KeyType keyType : Arrays.asList(KeyType.ECCP256, KeyType.ECCP384, KeyType.ED25519, KeyType.X25519)) {
 
             if (state.isInvalidKeyType(keyType)) {
+                continue;
+            }
+
+            if (!piv.supports(FEATURE_P384) && keyType == KeyType.ECCP384) {
                 continue;
             }
 

--- a/testing/src/main/java/com/yubico/yubikit/testing/piv/PivTestState.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/piv/PivTestState.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
+import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.core.application.ApplicationNotAvailableException;
 import com.yubico.yubikit.core.smartcard.ApduException;
@@ -62,8 +63,8 @@ public class PivTestState extends TestState {
 
     public static class Builder extends TestState.Builder<PivTestState.Builder> {
 
-        public Builder(YubiKeyDevice device) {
-            super(device);
+        public Builder(YubiKeyDevice device, UsbPid usbPid) {
+            super(device, usbPid);
         }
 
         @Override

--- a/testing/src/main/java/com/yubico/yubikit/testing/sd/SecurityDomainTestState.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/sd/SecurityDomainTestState.java
@@ -19,6 +19,7 @@ package com.yubico.yubikit.testing.sd;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assume.assumeTrue;
 
+import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import com.yubico.yubikit.core.application.ApplicationNotAvailableException;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
@@ -26,10 +27,7 @@ import com.yubico.yubikit.core.smartcard.scp.ScpKeyParams;
 import com.yubico.yubikit.core.smartcard.scp.SecurityDomainSession;
 import com.yubico.yubikit.testing.TestState;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-
 import java.io.IOException;
-import java.security.Security;
 
 import javax.annotation.Nullable;
 
@@ -37,8 +35,8 @@ public class SecurityDomainTestState extends TestState {
 
     public static class Builder extends TestState.Builder<SecurityDomainTestState.Builder> {
 
-        public Builder(YubiKeyDevice device) {
-            super(device);
+        public Builder(YubiKeyDevice device, UsbPid usbPid) {
+            super(device, usbPid);
         }
 
         @Override
@@ -54,8 +52,6 @@ public class SecurityDomainTestState extends TestState {
     protected SecurityDomainTestState(Builder builder) throws Throwable {
         super(builder);
 
-        setupJca();
-
         try (SmartCardConnection connection = openSmartCardConnection()) {
             assumeTrue("Key does not support smart card connection", connection != null);
             SecurityDomainSession sd = getSecurityDomainSession(connection);
@@ -63,11 +59,6 @@ public class SecurityDomainTestState extends TestState {
             assertNull("These tests expect kid to be null", scpParameters.getKid());
         }
 
-    }
-
-    public static void setupJca() {
-        Security.removeProvider("BC");
-        Security.addProvider(new BouncyCastleProvider());
     }
 
     public void withDeviceCallback(StatefulDeviceCallback<SecurityDomainTestState> callback) throws Throwable {


### PR DESCRIPTION
Improves handling of legacy YubiKeys. Changes in SDK code:
- `Feature.isSupported` will no longer return true for major version 0.
- `DeviceUtil.readInfo` has a new override which accepts ScpKeyParameters to allow reading info over secure connections.


A big part of this PR are updates to device tests which discovered issues with NEO keys: 
- The test code was trying to open ManagementSession directly on any connection, which is not possible on NEO. Instead we need to use `DeviceUtil.readInfo` to synthesize the DeviceInfo without Management session and for some situations this session has to be opened in SCP mode. As a consequence of this, platform tests have to pass a UsbPid for USB connected YubiKeys to be able to call readInfo.
- NEO's applications use their own version numbers which are not related the the YubiKey firmware version. This caused issues when we were testing for feature in runtime.



