### PR TITLE
[FIDO2] Implement updateUserInformation sub command of authenticatorCredentialManagement

### DIFF
--- a/fido/src/main/java/com/yubico/yubikit/fido/client/CredentialManager.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/CredentialManager.java
@@ -128,4 +128,30 @@ public class CredentialManager {
             throw ClientError.wrapCtapException(e);
         }
     }
+
+    /**
+     * Update user information associated to a credential. Only name and displayName can be changed.
+     *
+     * @param credential A {@link PublicKeyCredentialDescriptor} which can be gotten from
+     *                   {@link #getCredentials(String)}.
+     * @param user       A {@link PublicKeyCredentialUserEntity} containing updated data.
+     * @throws IOException                   A communication error in the transport layer.
+     * @throws CommandException              A communication in the protocol layer.
+     * @throws ClientError                   A higher level error.
+     * @throws UnsupportedOperationException If the authenticator does not support updating user
+     *                                       information.
+     */
+    public void updateUserInformation(
+            PublicKeyCredentialDescriptor credential,
+            PublicKeyCredentialUserEntity user)
+            throws IOException, CommandException, ClientError, UnsupportedOperationException {
+        try {
+            credentialManagement.updateUserInformation(
+                    credential.toMap(SerializationType.CBOR),
+                    user.toMap(SerializationType.CBOR)
+            );
+        } catch (CtapException e) {
+            throw ClientError.wrapCtapException(e);
+        }
+    }
 }

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2CredentialManagementInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2CredentialManagementInstrumentedTests.java
@@ -44,6 +44,12 @@ public class Ctap2CredentialManagementInstrumentedTests {
         public void testManagement() throws Throwable {
             withCtap2Session(Ctap2CredentialManagementTests::testManagement);
         }
+
+        @Test
+        @Category(SmokeTest.class)
+        public void testUpdateUserInformation() throws Throwable {
+            withCtap2Session(Ctap2CredentialManagementTests::testUpdateUserInformation);
+        }
     }
 
     @Category(PinUvAuthProtocolV1Test.class)

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/BasicWebAuthnClientTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/BasicWebAuthnClientTests.java
@@ -711,6 +711,25 @@ public class BasicWebAuthnClientTests {
             assertThat(Objects.requireNonNull(credentials.get(key))
                     .getId(), equalTo(TestData.USER_ID));
 
+            try {
+                PublicKeyCredentialUserEntity updatedUser = new PublicKeyCredentialUserEntity(
+                        "New name", credentials.get(key).getId(), "New display name"
+                );
+                credentialManager.updateUserInformation(key, updatedUser);
+
+                // verify new information
+                Map<PublicKeyCredentialDescriptor, PublicKeyCredentialUserEntity> updatedCreds =
+                        credentialManager.getCredentials(TestData.RP_ID);
+                assertThat(updatedCreds.size(), equalTo(1));
+                PublicKeyCredentialDescriptor updatedKey = updatedCreds.keySet().iterator().next();
+                PublicKeyCredentialUserEntity updatedUserEntity = Objects.requireNonNull(updatedCreds.get(updatedKey));
+                assertThat(updatedUserEntity.getId(), equalTo(TestData.USER_ID));
+                assertThat(updatedUserEntity.getName(), equalTo("New name"));
+                assertThat(updatedUserEntity.getDisplayName(), equalTo("New display name"));
+            } catch (UnsupportedOperationException unsupportedOperationException) {
+                // ignored
+            }
+
             credentialManager.deleteCredential(key);
             assertThat(credentialManager.getCredentialCount(), equalTo(0));
             assertTrue(credentialManager.getCredentials(TestData.RP_ID).isEmpty());


### PR DESCRIPTION
See the [specification](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorCredentialManagement) 

This PR also adds tests of both the CTAP2 call and client call.
