### PR TITLE
Propagate exceptions 

### DIFF
--- a/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Yubico.
+ * Copyright (C) 2019-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcYubiKeyDevice.java
@@ -150,7 +150,8 @@ public class NfcYubiKeyDevice implements YubiKeyDevice {
                           "openConnection("
                               + connectionType.getSimpleName()
                               + ") exception: "
-                              + exception.getMessage())));
+                              + exception.getMessage(),
+                          exception)));
             }
           });
   }

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyDevice.java
@@ -133,6 +133,14 @@ public class UsbYubiKeyDevice implements YubiKeyDevice, Closeable {
               callback.invoke(Result.success(connection));
             } catch (IOException e) {
               callback.invoke(Result.failure(e));
+            } catch (Exception exception) {
+              callback.invoke(
+                  Result.failure(
+                      new IOException(
+                          "openConnection("
+                              + connectionType.getSimpleName()
+                              + ") exception: "
+                              + exception.getMessage())));
             }
           });
     }
@@ -197,6 +205,11 @@ public class UsbYubiKeyDevice implements YubiKeyDevice, Closeable {
               }
             } catch (IOException e) {
               callback.invoke(Result.failure(e));
+            } catch (Exception exception) {
+              callback.invoke(
+                  Result.failure(
+                      new IOException(
+                          "openConnection(OtpConnection) exception: " + exception.getMessage())));
             }
           });
     }

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyDevice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2023 Yubico.
+ * Copyright (C) 2019-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyDevice.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbYubiKeyDevice.java
@@ -140,7 +140,8 @@ public class UsbYubiKeyDevice implements YubiKeyDevice, Closeable {
                           "openConnection("
                               + connectionType.getSimpleName()
                               + ") exception: "
-                              + exception.getMessage())));
+                              + exception.getMessage(),
+                          exception)));
             }
           });
     }
@@ -209,7 +210,8 @@ public class UsbYubiKeyDevice implements YubiKeyDevice, Closeable {
               callback.invoke(
                   Result.failure(
                       new IOException(
-                          "openConnection(OtpConnection) exception: " + exception.getMessage())));
+                          "openConnection(OtpConnection) exception: " + exception.getMessage(),
+                          exception)));
             }
           });
     }


### PR DESCRIPTION
Fixes #158 

This unifies exception handling during `UsbYubiKeyDevice.requestConnection`. As the linked issue points out, any `Exception` which is not an `IOException` in not propagate throughout the `Result` to the caller.

The behavior has been updated to be same as in NfcYubiKeyDevice.