### PR TITLE
Improve functionality for legacy devices

### DIFF
--- a/core/src/main/java/com/yubico/yubikit/core/UsbInterface.java
+++ b/core/src/main/java/com/yubico/yubikit/core/UsbInterface.java
@@ -57,5 +57,15 @@ public final class UsbInterface {
       }
       throw new IllegalArgumentException("Invalid interfaces for Mode");
     }
+
+    public static Mode fromCode(int code) {
+      for (Mode mode : Mode.values()) {
+        // Mode is determined from the lowest 3 bits
+        if (mode.value == (code & 0b00000111)) {
+          return mode;
+        }
+      }
+      throw new IllegalArgumentException("Invalid mode code");
+    }
   }
 }

--- a/core/src/main/java/com/yubico/yubikit/core/fido/FidoProtocol.java
+++ b/core/src/main/java/com/yubico/yubikit/core/fido/FidoProtocol.java
@@ -43,11 +43,24 @@ public class FidoProtocol implements Closeable {
   private static final byte CTAPHID_ERROR = TYPE_INIT | 0x3f;
   private static final byte CTAPHID_KEEPALIVE = TYPE_INIT | 0x3b;
 
+  /**
+   * Protocol capabilities
+   *
+   * @see <a
+   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#usb-hid-init">CTAPHID_INIT</a>
+   */
+  public static class Capability {
+    public static final byte WINK = 0x01;
+    public static final byte CBOR = 0x04;
+    public static final byte NMSG = 0x08;
+  }
+
   private final CommandState defaultState = new CommandState();
 
   private final FidoConnection connection;
 
   private final Version version;
+  private final int capabilities;
   private int channelId;
 
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(FidoProtocol.class);
@@ -71,7 +84,7 @@ public class FidoProtocol implements Closeable {
     byte[] versionBytes = new byte[3];
     buffer.get(versionBytes);
     version = Version.fromBytes(versionBytes);
-    buffer.get(); // Capabilities
+    capabilities = buffer.get();
     Logger.debug(
         logger, "FIDO connection set up with channel ID: {}", String.format("0x%08x", channelId));
   }
@@ -146,6 +159,10 @@ public class FidoProtocol implements Closeable {
 
   public Version getVersion() {
     return version;
+  }
+
+  public boolean supports(int capability) {
+    return (capabilities & capability) == capability;
   }
 
   @Override

--- a/management/src/main/java/com/yubico/yubikit/management/ManagementSession.java
+++ b/management/src/main/java/com/yubico/yubikit/management/ManagementSession.java
@@ -260,7 +260,14 @@ public class ManagementSession extends ApplicationSession<ManagementSession> {
    */
   public ManagementSession(FidoConnection connection) throws IOException {
     FidoProtocol protocol = new FidoProtocol(connection);
-    version = protocol.getVersion();
+    Version protocolVersion = protocol.getVersion();
+    if (protocolVersion.major < 4) {
+      // Prior to YK4 this was not firmware version
+      if (!(protocolVersion.major == 0 && protocol.supports(FidoProtocol.Capability.CBOR))) {
+        protocolVersion = new Version(3, 0, 0);
+      }
+    }
+    version = protocolVersion;
     backend =
         new Backend<FidoProtocol>(protocol) {
           @Override


### PR DESCRIPTION
This PR adds additional handling of devices with FW < 4. 

With these improvements, such devices will get:
- Correct ManagementSession version over FidoConnection.
- Correct USB interfaces value (OTP, FIDO, CCID) during NFC connections.

The changes has been tested with YubiKey Neo.