### PR TITLE
Treat FUNCTION_NOT_SUPPORTED as ApplicationNotAvailableException

### DIFF
--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/SW.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/SW.java
@@ -27,6 +27,7 @@ public final class SW {
   public static final short CONDITIONS_NOT_SATISFIED = 0x6985;
   public static final short COMMAND_NOT_ALLOWED = 0x6986;
   public static final short INCORRECT_PARAMETERS = 0x6A80;
+  public static final short FUNCTION_NOT_SUPPORTED = 0x6A81;
   public static final short FILE_NOT_FOUND = 0x6A82;
   public static final short NO_SPACE = 0x6A84;
   public static final short REFERENCED_DATA_NOT_FOUND = 0x6A88;

--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/SW.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/SW.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022,2024 Yubico.
+ * Copyright (C) 2020-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/SmartCardProtocol.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/SmartCardProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2024 Yubico.
+ * Copyright (C) 2019-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/SmartCardProtocol.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/SmartCardProtocol.java
@@ -187,8 +187,12 @@ public class SmartCardProtocol implements Closeable {
     try {
       return sendAndReceive(new Apdu(0, INS_SELECT, P1_SELECT, P2_SELECT, aid));
     } catch (ApduException e) {
-      // NEO sometimes returns INVALID_INSTRUCTION instead of FILE_NOT_FOUND
-      if (e.getSw() == SW.FILE_NOT_FOUND || e.getSw() == SW.INVALID_INSTRUCTION) {
+      // FUNCTION_NOT_SUPPORTED or FILE_NOT_FOUND mean that it was not possible
+      // to select the AID.
+      // NEO sometimes returns INVALID_INSTRUCTION instead of these
+      if (e.getSw() == SW.FUNCTION_NOT_SUPPORTED
+          || e.getSw() == SW.FILE_NOT_FOUND
+          || e.getSw() == SW.INVALID_INSTRUCTION) {
         throw new ApplicationNotAvailableException("The application couldn't be selected", e);
       }
       throw new IOException("Unexpected SW", e);

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/neo/NeoTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/neo/NeoTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.testing.neo;
+
+import com.yubico.yubikit.testing.AlwaysManualTest;
+import com.yubico.yubikit.testing.framework.NeoInstrumentedTests;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class NeoTests extends NeoInstrumentedTests {
+
+  /**
+   * Test that the management session can be opened on NEO
+   *
+   * <p>Run this test with over USB and NFC
+   *
+   * <p>Will be marked as skipped if the device is not a NEO
+   */
+  @Test
+  @Category(AlwaysManualTest.class)
+  public void testOpenManagementSession() throws Throwable {
+    withConnection(NeoDeviceTests::testOpenManagementSession);
+  }
+}

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/NeoInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/NeoInstrumentedTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.testing.framework;
+
+import com.yubico.yubikit.core.smartcard.SmartCardConnection;
+
+public class NeoInstrumentedTests extends YKInstrumentedTests {
+
+  public interface SmartCardConnectionCallback {
+    void invoke(SmartCardConnection value) throws Throwable;
+  }
+
+  protected void withConnection(SmartCardConnectionCallback callback) throws Throwable {
+    try (SmartCardConnection connection = device.openConnection(SmartCardConnection.class)) {
+      callback.invoke(connection);
+    }
+  }
+
+  @Override
+  protected boolean shouldOverrideVersion() {
+    return false;
+  }
+}

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YKInstrumentedTests.java
@@ -52,12 +52,14 @@ public class YKInstrumentedTests {
     device = activity.awaitSession(getClass().getSimpleName(), name.getMethodName());
     usbPid = device instanceof UsbYubiKeyDevice ? ((UsbYubiKeyDevice) device).getPid() : null;
 
-    try (SmartCardConnection connection = device.openConnection(SmartCardConnection.class)) {
-      final DeviceInfo deviceInfo = DeviceUtil.readInfo(connection, usbPid);
-      if (deviceInfo.getVersion().major == 0) {
-        SessionVersionOverride.set(new Version(5, 7, 2));
+    if (shouldOverrideVersion()) {
+      try (SmartCardConnection connection = device.openConnection(SmartCardConnection.class)) {
+        final DeviceInfo deviceInfo = DeviceUtil.readInfo(connection, usbPid);
+        if (deviceInfo.getVersion().major == 0) {
+          SessionVersionOverride.set(new Version(5, 7, 2));
+        }
+      } catch (IOException | IllegalStateException | IllegalArgumentException ignored) {
       }
-    } catch (IOException | IllegalStateException | IllegalArgumentException ignored) {
     }
   }
 
@@ -88,5 +90,9 @@ public class YKInstrumentedTests {
   @Nullable
   protected Byte getScpKid() {
     return null;
+  }
+
+  protected boolean shouldOverrideVersion() {
+    return true;
   }
 }

--- a/testing/src/main/java/com/yubico/yubikit/testing/neo/NeoDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/neo/NeoDeviceTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.testing.neo;
+
+import static org.hamcrest.Matchers.is;
+
+import com.yubico.yubikit.core.smartcard.SmartCardConnection;
+import com.yubico.yubikit.management.ManagementSession;
+import org.junit.Assume;
+
+public class NeoDeviceTests {
+  public static void testOpenManagementSession(SmartCardConnection connection) throws Exception {
+    ManagementSession session = new ManagementSession(connection);
+    int major = session.getVersion().major;
+    Assume.assumeThat(3, is(major));
+  }
+}

--- a/testing/src/main/java/com/yubico/yubikit/testing/neo/NeoDeviceTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/neo/NeoDeviceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
All NEO's I tested return 0x6A81 (FUNCTION_NOT_SUPPORTED) when trying to select the management app. 

This PR makes this situation an ApplicationNotAvailableException.

Fixes #173 