### PR TITLE
CTAP 2.2

### DIFF
--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import com.yubico.yubikit.core.util.StringUtils;
 import com.yubico.yubikit.fido.ctap.ClientPin;
 import com.yubico.yubikit.fido.ctap.Ctap2Session;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
-import com.yubico.yubikit.fido.webauthn.AttestationObject;
 import com.yubico.yubikit.fido.webauthn.AuthenticatorData;
 import com.yubico.yubikit.fido.webauthn.Extensions;
 import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialCreationOptions;
@@ -49,56 +48,115 @@ import javax.annotation.Nullable;
 import org.slf4j.LoggerFactory;
 
 /**
- * Implements the Pseudo-random function (prf) and the hmac-secret CTAP2 extensions.
+ * Implements the Pseudo-random function (prf) and the hmac-secret and hmac-secret-mc CTAP2
+ * extensions.
  *
- * <p>The hmac-secret extension is not directly available to clients by default, instead the prf
- * extension is used.
+ * <p>The hmac-secret and hmac-secret-mc extensions are not directly available to clients by
+ * default, instead the prf extension is used.
  *
  * @see <a href="https://www.w3.org/TR/webauthn-3/#prf-extension">PRF extension</a>
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.1-rd-20201208/fido-client-to-authenticator-protocol-v2.1-rd-20201208.html#sctn-hmac-secret-extension">HMAC
- *     secret extension</a>
+ *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#sctn-hmac-secret-extension">HMAC
+ *     secret extension (hmac-secret)</a>
+ * @see <a
+ *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#sctn-hmac-secret-make-cred-extension">HMAC
+ *     Secret MakeCredential Extension (hmac-secret-mc)</a>
  */
 public class HmacSecretExtension extends Extension {
   private final boolean allowHmacSecret;
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(HmacSecretExtension.class);
   private static final int SALT_LEN = 32;
 
+  private static final String PRF = "prf";
+  private static final String HMAC_GET_SECRET = "hmacGetSecret";
+  private static final String HMAC_CREATE_SECRET = "hmacCreateSecret";
+  private static final String FIRST = "first";
+  private static final String SECOND = "second";
+  private static final String OUTPUT_1 = "output1";
+  private static final String OUTPUT_2 = "output2";
+  private static final String SALT_1 = "salt1";
+  private static final String SALT_2 = "salt2";
+  private static final String ENABLED = "enabled";
+  private static final String RESULTS = "results";
+  private static final String EVAL_BY_CREDENTIAL = "evalByCredential";
+  private static final String EVAL = "eval";
+  private static final byte[] WEBAUTHN_PRF_BYTES =
+      "WebAuthn PRF".getBytes(StandardCharsets.US_ASCII);
+  private static final String NAME = "hmac-secret";
+  private static final String NAME_MC = "hmac-secret-mc";
+
   public HmacSecretExtension() {
     this(false);
   }
 
   /**
-   * @param allowHmacSecret Set to True to allow hmac-secret, in addition to prf
+   * @param allowHmacSecret Set to True to allow hmac-secret and hmac-secret-mc, in addition to prf
    */
   public HmacSecretExtension(boolean allowHmacSecret) {
-    super("hmac-secret");
+    super(NAME);
     this.allowHmacSecret = allowHmacSecret;
   }
 
+  @Nullable
   @Override
   public RegistrationProcessor makeCredential(
       Ctap2Session ctap2,
       PublicKeyCredentialCreationOptions options,
       PinUvAuthProtocol pinUvAuthProtocol) {
     Extensions extensions = options.getExtensions();
-    if (extensions == null) {
+    if (extensions == null || !isSupported(ctap2)) {
       return null;
     }
-    if (allowHmacSecret && Boolean.TRUE.equals(extensions.get("hmacCreateSecret"))) {
-      return new RegistrationProcessor(
-          pinToken -> Collections.singletonMap(name, true),
-          (attestationObject, pinToken) ->
-              serializationType -> registrationOutput(attestationObject, false));
-    } else if (extensions.has("prf")) {
-      return new RegistrationProcessor(
-          pinToken -> Collections.singletonMap(name, true),
-          (attestationObject, pinToken) ->
-              serializationType -> registrationOutput(attestationObject, true));
+
+    boolean prf = extensions.has(PRF);
+    boolean hmac = allowHmacSecret && Boolean.TRUE.equals(extensions.get(HMAC_CREATE_SECRET));
+
+    if (!prf && !hmac) {
+      return null;
     }
-    return null;
+
+    // get inputs
+    Map<String, Object> extensionInputs = new HashMap<>();
+    extensionInputs.put(name, true);
+
+    PinUvAuthHelper pinUvAuthHelper = new PinUvAuthHelper(ctap2, pinUvAuthProtocol);
+
+    if (ctap2.getCachedInfo().getExtensions().contains(NAME_MC)
+        && pinUvAuthHelper.keyAgreement != null) {
+      Inputs inputs = Inputs.fromExtensions(extensions);
+      Salts salts = prepareSalts(null, null, inputs);
+
+      if (salts != null) {
+        byte[] saltEnc = pinUvAuthHelper.encrypt(salts.concat());
+        byte[] saltAuth = pinUvAuthHelper.authenticate(saltEnc);
+
+        final Map<Integer, Object> hmacCreateSecretInput = new HashMap<>();
+        hmacCreateSecretInput.put(1, pinUvAuthHelper.keyAgreement.first);
+        hmacCreateSecretInput.put(2, saltEnc);
+        hmacCreateSecretInput.put(3, saltAuth);
+        hmacCreateSecretInput.put(4, pinUvAuthHelper.clientPin.getPinUvAuth().getVersion());
+        extensionInputs.put(NAME_MC, hmacCreateSecretInput);
+      }
+    } // hmac-secret-mc processing
+
+    return new RegistrationProcessor(
+        pinToken -> extensionInputs,
+        (attestationObject, pinToken) ->
+            serializationType -> {
+              Map<String, ?> extResult =
+                  (attestationObject.getAuthenticatorData().getExtensions() != null)
+                      ? attestationObject.getAuthenticatorData().getExtensions()
+                      : Collections.emptyMap();
+              boolean enabled = Boolean.TRUE.equals(extResult.get(name));
+              return formatOutputs(
+                  serializationType,
+                  enabled,
+                  pinUvAuthHelper.decrypt((byte[]) extResult.get(NAME_MC)),
+                  prf);
+            });
   }
 
+  @Nullable
   @Override
   public AuthenticationProcessor getAssertion(
       Ctap2Session ctap,
@@ -108,12 +166,8 @@ public class HmacSecretExtension extends Extension {
       return null;
     }
 
-    final ClientPin clientPin = new ClientPin(ctap, pinUvAuthProtocol);
-    Pair<Map<Integer, ?>, byte[]> keyAgreement;
-    try {
-      keyAgreement = clientPin.getSharedSecret();
-    } catch (IOException | CommandException e) {
-      Logger.error(logger, "Failed to get shared secret: ", e);
+    final PinUvAuthHelper pinUvAuthHelper = new PinUvAuthHelper(ctap, pinUvAuthProtocol);
+    if (pinUvAuthHelper.keyAgreement == null) {
       return null;
     }
 
@@ -123,103 +177,21 @@ public class HmacSecretExtension extends Extension {
     }
     final AuthenticationInput prepareInput =
         (selected, pinToken) -> {
-          Salts salts;
-          if (inputs.prf != null) {
-            Map<String, Object> secrets = inputs.prf.eval;
-            Map<String, Object> evalByCredential = inputs.prf.evalByCredential;
+          Salts salts = prepareSalts(options.getAllowCredentials(), selected, inputs);
 
-            if (evalByCredential != null) {
-              List<PublicKeyCredentialDescriptor> allowCredentials = options.getAllowCredentials();
-
-              if (allowCredentials.isEmpty()) {
-                throw new IllegalArgumentException("evalByCredential needs allow list");
-              }
-
-              Set<String> ids = new HashSet<>();
-              for (PublicKeyCredentialDescriptor descriptor : allowCredentials) {
-                ids.add(toUrlSafeString(descriptor.getId()));
-              }
-
-              if (!ids.containsAll(evalByCredential.keySet())) {
-                throw new IllegalArgumentException("evalByCredentials contains invalid key");
-              }
-
-              if (selected != null) {
-                String key = toUrlSafeString(selected.getId());
-                if (evalByCredential.containsKey(key)) {
-                  secrets = inputs.evalByCredential(key);
-                }
-              }
-            }
-
-            if (secrets == null) {
-              return null;
-            }
-
-            Logger.debug(logger, "PRF inputs: {}, {}", secrets.get("first"), secrets.get("second"));
-
-            String firstInput = (String) secrets.get("first");
-            if (firstInput == null) {
-              return null;
-            }
-
-            byte[] first = prfSalt(fromUrlSafeString(firstInput));
-            byte[] second =
-                secrets.containsKey("second")
-                    ? prfSalt(fromUrlSafeString((String) secrets.get("second")))
-                    : null;
-
-            salts = new Salts(first, second);
-          } else {
-            if (inputs.hmac == null) {
-              return null;
-            }
-
-            Logger.debug(
-                logger,
-                "hmacGetSecret inputs: {}, {}",
-                inputs.hmac.salt1 != null ? inputs.hmac.salt1 : "none",
-                inputs.hmac.salt2 != null ? inputs.hmac.salt2 : "none");
-
-            if (inputs.hmac.salt1 == null) {
-              return null;
-            }
-
-            byte[] salt1 = prfSalt(fromUrlSafeString(inputs.hmac.salt1));
-            byte[] salt2 =
-                inputs.hmac.salt2 != null ? prfSalt(fromUrlSafeString(inputs.hmac.salt2)) : null;
-
-            salts = new Salts(salt1, salt2);
+          if (salts == null) {
+            return null;
           }
 
-          Logger.debug(
-              logger,
-              "Salts: {}, {}",
-              StringUtils.bytesToHex(salts.salt1),
-              StringUtils.bytesToHex(salts.salt2));
-          if (!(salts.salt1.length == SALT_LEN
-              && (salts.salt2.length == 0 || salts.salt2.length == SALT_LEN))) {
-            throw new IllegalArgumentException("Invalid salt length");
-          }
-
-          byte[] saltEnc =
-              clientPin
-                  .getPinUvAuth()
-                  .encrypt(
-                      keyAgreement.second,
-                      ByteBuffer.allocate(salts.salt1.length + salts.salt2.length)
-                          .put(salts.salt1)
-                          .put(salts.salt2)
-                          .array());
-
-          byte[] saltAuth = clientPin.getPinUvAuth().authenticate(keyAgreement.second, saltEnc);
+          byte[] saltEnc = pinUvAuthHelper.encrypt(salts.concat());
+          byte[] saltAuth = pinUvAuthHelper.authenticate(saltEnc);
 
           final Map<Integer, Object> hmacGetSecretInput = new HashMap<>();
-          hmacGetSecretInput.put(1, keyAgreement.first);
+          hmacGetSecretInput.put(1, pinUvAuthHelper.keyAgreement.first);
           hmacGetSecretInput.put(2, saltEnc);
           hmacGetSecretInput.put(3, saltAuth);
-          hmacGetSecretInput.put(4, clientPin.getPinUvAuth().getVersion());
-          return Collections.singletonMap(name, hmacGetSecretInput);
+          hmacGetSecretInput.put(4, pinUvAuthHelper.clientPin.getPinUvAuth().getVersion());
+          return Collections.singletonMap(NAME, hmacGetSecretInput);
         };
 
     final AuthenticationOutput prepareOutput =
@@ -237,7 +209,10 @@ public class HmacSecretExtension extends Extension {
             return null;
           }
 
-          byte[] decrypted = clientPin.getPinUvAuth().decrypt(keyAgreement.second, value);
+          byte[] decrypted = pinUvAuthHelper.decrypt(value);
+          if (decrypted == null) {
+            return null;
+          }
 
           byte[] output1 = Arrays.copyOf(decrypted, SALT_LEN);
           byte[] output2 =
@@ -256,30 +231,30 @@ public class HmacSecretExtension extends Extension {
           if (inputs.prf != null) {
             return serializationType -> {
               results.put(
-                  "first",
+                  FIRST,
                   serializationType == SerializationType.JSON ? toUrlSafeString(output1) : output1);
               if (output2.length > 0) {
                 results.put(
-                    "second",
+                    SECOND,
                     serializationType == SerializationType.JSON
                         ? toUrlSafeString(output2)
                         : output2);
               }
-              return Collections.singletonMap("prf", Collections.singletonMap("results", results));
+              return Collections.singletonMap(PRF, Collections.singletonMap(RESULTS, results));
             };
           } else {
             return serializationType -> {
               results.put(
-                  "output1",
+                  OUTPUT_1,
                   serializationType == SerializationType.JSON ? toUrlSafeString(output1) : output1);
               if (output2.length > 0) {
                 results.put(
-                    "output2",
+                    OUTPUT_2,
                     serializationType == SerializationType.JSON
                         ? toUrlSafeString(output2)
                         : output2);
               }
-              return Collections.singletonMap("hmacGetSecret", results);
+              return Collections.singletonMap(HMAC_GET_SECRET, results);
             };
           }
         };
@@ -287,13 +262,141 @@ public class HmacSecretExtension extends Extension {
     return new AuthenticationProcessor(prepareInput, prepareOutput);
   }
 
-  Map<String, Object> registrationOutput(AttestationObject attestationObject, boolean isPrf) {
-    Map<String, ?> extensions = attestationObject.getAuthenticatorData().getExtensions();
+  @SuppressWarnings("unchecked")
+  @Nullable
+  private Salts prepareSalts(
+      @Nullable List<PublicKeyCredentialDescriptor> allowCredentials,
+      @Nullable PublicKeyCredentialDescriptor selected,
+      Inputs inputs) {
 
-    boolean enabled = extensions != null && Boolean.TRUE.equals(extensions.get(name));
-    return isPrf
-        ? Collections.singletonMap("prf", Collections.singletonMap("enabled", enabled))
-        : Collections.singletonMap("hmacCreateSecret", enabled);
+    Salts salts;
+    if (inputs.prf != null) {
+      Map<String, Object> secrets = inputs.prf.eval;
+      Map<String, Object> evalByCredential = inputs.prf.evalByCredential;
+
+      if (evalByCredential != null) {
+        if (allowCredentials == null || allowCredentials.isEmpty()) {
+          throw new IllegalArgumentException("evalByCredential needs allow list");
+        }
+
+        Set<String> ids = new HashSet<>();
+        for (PublicKeyCredentialDescriptor descriptor : allowCredentials) {
+          ids.add(toUrlSafeString(descriptor.getId()));
+        }
+
+        if (!ids.containsAll(evalByCredential.keySet())) {
+          throw new IllegalArgumentException("evalByCredentials contains invalid key");
+        }
+
+        if (selected != null) {
+          String key = toUrlSafeString(selected.getId());
+          if (evalByCredential.containsKey(key)) {
+            secrets = (Map<String, Object>) inputs.prf.evalByCredential.get(key);
+          }
+        }
+      }
+
+      if (secrets == null) {
+        return null;
+      }
+
+      Logger.debug(logger, "PRF inputs: {}, {}", secrets.get(FIRST), secrets.get(SECOND));
+
+      String firstInput = (String) secrets.get(FIRST);
+      if (firstInput == null) {
+        return null;
+      }
+
+      byte[] first = prfSalt(fromUrlSafeString(firstInput));
+      byte[] second =
+          secrets.containsKey(SECOND)
+              ? prfSalt(fromUrlSafeString((String) secrets.get(SECOND)))
+              : null;
+
+      salts = new Salts(first, second);
+    } else {
+      if (inputs.hmac == null) {
+        return null;
+      }
+
+      Logger.debug(
+          logger,
+          "hmacGetSecret inputs: {}, {}",
+          inputs.hmac.salt1 != null ? inputs.hmac.salt1 : "none",
+          inputs.hmac.salt2 != null ? inputs.hmac.salt2 : "none");
+
+      if (inputs.hmac.salt1 == null) {
+        return null;
+      }
+
+      byte[] salt1 = prfSalt(fromUrlSafeString(inputs.hmac.salt1));
+      byte[] salt2 =
+          inputs.hmac.salt2 != null ? prfSalt(fromUrlSafeString(inputs.hmac.salt2)) : null;
+
+      salts = new Salts(salt1, salt2);
+    }
+
+    Logger.debug(
+        logger,
+        "Salts: {}, {}",
+        StringUtils.bytesToHex(salts.salt1),
+        StringUtils.bytesToHex(salts.salt2));
+    if (!(salts.salt1.length == SALT_LEN
+        && (salts.salt2.length == 0 || salts.salt2.length == SALT_LEN))) {
+      throw new IllegalArgumentException("Invalid salt length");
+    }
+
+    return salts;
+  }
+
+  private Map<String, Object> formatOutputs(
+      SerializationType serializationType,
+      @Nullable Boolean enabled,
+      @Nullable byte[] decrypted,
+      boolean prf) {
+    byte[] output1 = decrypted != null ? Arrays.copyOfRange(decrypted, 0, SALT_LEN) : null;
+    byte[] output2 =
+        decrypted != null ? Arrays.copyOfRange(decrypted, SALT_LEN, decrypted.length) : null;
+
+    Map<String, Object> result = new HashMap<>();
+    if (prf) {
+      result.put(ENABLED, enabled);
+      Map<String, Object> results = new HashMap<>();
+      if (output1 != null) {
+        results.put(
+            FIRST,
+            serializationType == SerializationType.JSON ? toUrlSafeString(output1) : output1);
+      }
+      if (output2 != null && output2.length > 0) {
+        results.put(
+            SECOND,
+            serializationType == SerializationType.JSON ? toUrlSafeString(output2) : output2);
+      }
+      if (!results.isEmpty()) {
+        result.put(RESULTS, results);
+      }
+      return enabled != null ? Collections.singletonMap(PRF, result) : Collections.emptyMap();
+
+    } else {
+      if (output1 != null) {
+        result.put(
+            OUTPUT_1,
+            serializationType == SerializationType.JSON ? toUrlSafeString(output1) : output1);
+      }
+      if (output2 != null && output2.length > 0) {
+        result.put(
+            OUTPUT_2,
+            serializationType == SerializationType.JSON ? toUrlSafeString(output2) : output2);
+      }
+      Map<String, Object> hmacSecretResults = new HashMap<>();
+      if (enabled != null) {
+        hmacSecretResults.put(HMAC_CREATE_SECRET, enabled);
+      }
+      if (output1 != null) {
+        hmacSecretResults.put(HMAC_GET_SECRET, result);
+      }
+      return hmacSecretResults;
+    }
   }
 
   private static class Salts {
@@ -304,6 +407,12 @@ public class HmacSecretExtension extends Extension {
       this.salt1 = salt1;
       this.salt2 = salt2 != null ? salt2 : new byte[0];
     }
+
+    byte[] concat() {
+      ByteBuffer buffer = ByteBuffer.allocate(salt1.length + salt2.length);
+      buffer.put(salt1).put(salt2);
+      return buffer.array();
+    }
   }
 
   private byte[] prfSalt(byte[] secret) {
@@ -311,7 +420,7 @@ public class HmacSecretExtension extends Extension {
       return MessageDigest.getInstance("SHA-256")
           .digest(
               ByteBuffer.allocate(13 + secret.length)
-                  .put("WebAuthn PRF".getBytes(StandardCharsets.US_ASCII))
+                  .put(WEBAUTHN_PRF_BYTES)
                   .put((byte) 0x00)
                   .put(secret)
                   .array());
@@ -337,7 +446,7 @@ public class HmacSecretExtension extends Extension {
       }
 
       return new PrfInputs(
-          (Map<String, Object>) map.get("eval"), (Map<String, Object>) map.get("evalByCredential"));
+          (Map<String, Object>) map.get(EVAL), (Map<String, Object>) map.get(EVAL_BY_CREDENTIAL));
     }
   }
 
@@ -356,7 +465,7 @@ public class HmacSecretExtension extends Extension {
         return null;
       }
 
-      return new HmacInputs((String) map.get("salt1"), (String) map.get("salt2"));
+      return new HmacInputs((String) map.get(SALT_1), (String) map.get(SALT_2));
     }
   }
 
@@ -371,23 +480,57 @@ public class HmacSecretExtension extends Extension {
     }
 
     @Nullable
-    Map<String, Object> evalByCredential(String key) {
-      if (prf == null || prf.evalByCredential == null) {
-        return null;
-      }
-
-      return (Map<String, Object>) prf.evalByCredential.get(key);
-    }
-
-    @Nullable
     public static Inputs fromExtensions(@Nullable Extensions extensions) {
       if (extensions == null) {
         return null;
       }
 
       return new Inputs(
-          (Map<String, Object>) extensions.get("prf"),
-          (Map<String, Object>) extensions.get("hmacGetSecret"));
+          (Map<String, Object>) extensions.get(PRF),
+          (Map<String, Object>) extensions.get(HMAC_GET_SECRET));
+    }
+  }
+
+  private static class PinUvAuthHelper {
+    private final PinUvAuthProtocol pinUvAuthProtocol;
+    private final ClientPin clientPin;
+
+    @Nullable private final Pair<Map<Integer, ?>, byte[]> keyAgreement;
+
+    PinUvAuthHelper(Ctap2Session session, PinUvAuthProtocol pinUvAuthProtocol) {
+      this.pinUvAuthProtocol = pinUvAuthProtocol;
+      this.clientPin = new ClientPin(session, pinUvAuthProtocol);
+      Pair<Map<Integer, ?>, byte[]> keyAgreement = null;
+      try {
+        keyAgreement = clientPin.getSharedSecret();
+      } catch (IOException | CommandException e) {
+        Logger.error(logger, "Failed to get shared secret: ", e);
+      }
+      this.keyAgreement = keyAgreement;
+    }
+
+    @Nullable
+    byte[] encrypt(byte[] data) {
+      if (keyAgreement == null) {
+        return null;
+      }
+      return clientPin.getPinUvAuth().encrypt(keyAgreement.second, data);
+    }
+
+    @Nullable
+    byte[] decrypt(@Nullable byte[] data) {
+      if (keyAgreement == null || data == null) {
+        return null;
+      }
+      return pinUvAuthProtocol.decrypt(keyAgreement.second, data);
+    }
+
+    @Nullable
+    byte[] authenticate(@Nullable byte[] data) {
+      if (keyAgreement == null || data == null) {
+        return null;
+      }
+      return clientPin.getPinUvAuth().authenticate(keyAgreement.second, data);
     }
   }
 }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtension.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import com.yubico.yubikit.fido.ctap.Ctap2Session;
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import com.yubico.yubikit.fido.webauthn.Extensions;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialCreationOptions;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialRequestOptions;
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Implements the Third-party payment authentication (thirdPartyPayment) CTAP2 extension.
+ *
+ * <p>This extension allows a Relying Party to indicate that a credential can be used for Payment
+ * authentication initiated by a party (website or native application) that is not the Relying
+ * Party.
+ *
+ * <p>Note that most of the processing for the WebAuthn extension needs to be done by the client.
+ * Therefore this extension is not included in the default extensions list, and should not be used
+ * without a client that supports the WebAuthn payment extension.
+ *
+ * @see <a
+ *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#sctn-thirdPartyPayment-extension">Third-Party
+ *     Payment authentication (thirdPartyPayment)</a>
+ * @see <a href="https://www.w3.org/TR/secure-payment-confirmation">Secure Payment Confirmation</a>
+ */
+public class ThirdPartyPaymentExtension extends Extension {
+
+  private static final String THIRD_PARTY_PAYMENT = "thirdPartyPayment";
+  private static final String PAYMENT = "payment";
+  private static final String IS_PAYMENT = "isPayment";
+
+  public ThirdPartyPaymentExtension() {
+    super(THIRD_PARTY_PAYMENT);
+  }
+
+  @Nullable
+  @Override
+  public RegistrationProcessor makeCredential(
+      Ctap2Session ctap,
+      PublicKeyCredentialCreationOptions options,
+      PinUvAuthProtocol pinUvAuthProtocol) {
+
+    if (!isSupported(ctap)) {
+      return null;
+    }
+
+    Boolean isPayment = getIsPayment(options.getExtensions());
+    if (isPayment == null) {
+      return null;
+    }
+
+    return new RegistrationProcessor(
+        (pinToken) ->
+            Collections.singletonMap(THIRD_PARTY_PAYMENT, Boolean.TRUE.equals(isPayment)));
+  }
+
+  @Nullable
+  @Override
+  public AuthenticationProcessor getAssertion(
+      Ctap2Session ctap,
+      PublicKeyCredentialRequestOptions options,
+      PinUvAuthProtocol pinUvAuthProtocol) {
+
+    if (!isSupported(ctap)) {
+      return null;
+    }
+
+    Boolean isPayment = getIsPayment(options.getExtensions());
+    if (isPayment == null) {
+      return null;
+    }
+
+    final AuthenticationInput prepareInput =
+        (selected, pinToken) ->
+            Collections.singletonMap(THIRD_PARTY_PAYMENT, Boolean.TRUE.equals(isPayment));
+
+    return new AuthenticationProcessor(prepareInput);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Nullable
+  private Boolean getIsPayment(@Nullable Extensions extensions) {
+    if (extensions == null) {
+      return null;
+    }
+
+    Map<String, ?> payment = (Map<String, ?>) extensions.get(PAYMENT);
+    if (payment == null) {
+      return null;
+    }
+
+    return (Boolean) payment.get(IS_PAYMENT);
+  }
+}

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/ClientPin.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/ClientPin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Yubico.
+ * Copyright (C) 2020-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ public class ClientPin {
   public static final int PIN_PERMISSION_BE = 0x08;
   public static final int PIN_PERMISSION_LBW = 0x10;
   public static final int PIN_PERMISSION_ACFG = 0x20;
+  public static final int PIN_PERMISSION_PCMR = 0x40;
 
   private final Ctap2Session ctap;
   private final PinUvAuthProtocol pinUvAuth;

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/CredentialManagement.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/CredentialManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Yubico.
+ * Copyright (C) 2020-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,10 @@ public class CredentialManagement {
 
   public static boolean isSupported(Ctap2Session.InfoData info) {
     return supportsCredMgmt(info) || supportsCredentialMgmtPreview(info);
+  }
+
+  public static boolean isReadonlySupported(Ctap2Session.InfoData info) {
+    return Boolean.TRUE.equals(info.getOptions().get("perCredMgmtRO"));
   }
 
   private static boolean supportsCredMgmt(Ctap2Session.InfoData info) {

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/Ctap2Session.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/Ctap2Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Yubico.
+ * Copyright (C) 2020-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,10 +50,10 @@ import javax.annotation.Nullable;
 import org.slf4j.LoggerFactory;
 
 /**
- * Implements CTAP 2.1
+ * Implements CTAP 2.2
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html">Client
+ *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html">Client
  *     to Authenticator Protocol (CTAP)</a>
  */
 public class Ctap2Session extends ApplicationSession<Ctap2Session> {
@@ -235,7 +235,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorMakeCredential">authenticatorMakeCredential</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorMakeCredential">authenticatorMakeCredential</a>
    */
   public CredentialData makeCredential(
       byte[] clientDataHash,
@@ -305,9 +305,9 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorGetAssertion">authenticatorGetAssertion</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorGetAssertion">authenticatorGetAssertion</a>
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorGetNextAssertion">authenticatorGetNextAssertion</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorGetNextAssertion">authenticatorGetNextAssertion</a>
    */
   public List<AssertionData> getAssertions(
       String rpId,
@@ -366,7 +366,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorGetInfo">authenticatorGetInfo</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorGetInfo">authenticatorGetInfo</a>
    */
   public InfoData getInfo() throws IOException, CommandException {
     final Map<Integer, ?> infoData = sendCbor(CMD_GET_INFO, null, null);
@@ -391,7 +391,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorClientPIN">authenticatorClientPIN</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorClientPIN">authenticatorClientPIN</a>
    */
   Map<Integer, ?> clientPin(
       @Nullable Integer pinUvAuthProtocol,
@@ -443,7 +443,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorReset">authenticatorReset</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorReset">authenticatorReset</a>
    */
   public void reset(@Nullable CommandState state) throws IOException, CommandException {
     sendCbor(CMD_RESET, null, state);
@@ -463,7 +463,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorBioEnrollment">authenticatorBioEnrollment</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorBioEnrollment">authenticatorBioEnrollment</a>
    */
   Map<Integer, ?> bioEnrollment(
       @Nullable Integer modality,
@@ -494,7 +494,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorCredentialManagement">authenticatorCredentialManagement</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorCredentialManagement">authenticatorCredentialManagement</a>
    */
   Map<Integer, ?> credentialManagement(
       int subCommand,
@@ -518,7 +518,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorSelection">authenticatorSelection</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorSelection">authenticatorSelection</a>
    */
   public void selection(@Nullable CommandState state) throws IOException, CommandException {
     sendCbor(CMD_SELECTION, null, state);
@@ -538,7 +538,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorLargeBlobs">authenticatorLargeBlobs</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorLargeBlobs">authenticatorLargeBlobs</a>
    */
   public Map<Integer, ?> largeBlobs(
       int offset,
@@ -574,7 +574,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorConfig">authenticatorConfig</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorConfig">authenticatorConfig</a>
    */
   public Map<Integer, ?> config(
       byte subCommand,
@@ -626,7 +626,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * Data object containing the information readable form a YubiKey using the getInfo command.
    *
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorGetInfo">authenticatorGetInfo</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorGetInfo">authenticatorGetInfo</a>
    */
   public static class InfoData {
     private static final int RESULT_VERSIONS = 0x01;
@@ -650,6 +650,14 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
     private static final int RESULT_CERTIFICATIONS = 0x13;
     private static final int RESULT_REMAINING_DISCOVERABLE_CREDENTIALS = 0x14;
     private static final int RESULT_VENDOR_PROTOTYPE_CONFIG_COMMANDS = 0x15;
+    private static final int RESULT_ATTESTATION_FORMATS = 0x16;
+    private static final int RESULT_UV_COUNT_SINCE_LAST_PIN_ENTRY = 0x17;
+    private static final int RESULT_LONG_TOUCH_FOR_RESET = 0x18;
+    private static final int RESULT_ENC_IDENTIFIER = 0x19;
+    private static final int RESULT_TRANSPORTS_FOR_RESET = 0x1A;
+    private static final int RESULT_PIN_COMPLEXITY_POLICY = 0x1B;
+    private static final int RESULT_PIN_COMPLEXITY_POLICY_URL = 0x1C;
+    private static final int RESULT_MAX_PIN_LENGTH = 0x1D;
 
     private final List<String> versions;
     private final List<String> extensions;
@@ -672,6 +680,14 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
     private final Map<String, Object> certifications;
     @Nullable private final Integer remainingDiscoverableCredentials;
     @Nullable private final List<Integer> vendorPrototypeConfigCommands;
+    @Nullable private final List<String> attestationFormats;
+    @Nullable private final Integer uvCountSinceLastPinEntry;
+    @Nullable private final Boolean longTouchForReset;
+    @Nullable private final byte[] encIdentifier;
+    @Nullable private final List<String> transportsForReset;
+    @Nullable private final Boolean pinComplexityPolicy;
+    @Nullable private final byte[] pinComplexityPolicyURL;
+    @Nullable private final Integer maxPINLength;
 
     private InfoData(
         List<String> versions,
@@ -694,7 +710,15 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
         int uvModality,
         Map<String, Object> certifications,
         @Nullable Integer remainingDiscoverableCredentials,
-        @Nullable List<Integer> vendorPrototypeConfigCommands) {
+        @Nullable List<Integer> vendorPrototypeConfigCommands,
+        @Nullable List<String> attestationFormats,
+        @Nullable Integer uvCountSinceLastPinEntry,
+        @Nullable Boolean longTouchForReset,
+        @Nullable byte[] encIdentifier,
+        @Nullable List<String> transportsForReset,
+        @Nullable Boolean pinComplexityPolicy,
+        @Nullable byte[] pinComplexityPolicyURL,
+        @Nullable Integer maxPINLength) {
       this.versions = versions;
       this.extensions = extensions;
       this.aaguid = aaguid;
@@ -716,6 +740,14 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
       this.certifications = certifications;
       this.remainingDiscoverableCredentials = remainingDiscoverableCredentials;
       this.vendorPrototypeConfigCommands = vendorPrototypeConfigCommands;
+      this.attestationFormats = attestationFormats;
+      this.uvCountSinceLastPinEntry = uvCountSinceLastPinEntry;
+      this.longTouchForReset = longTouchForReset;
+      this.encIdentifier = encIdentifier;
+      this.transportsForReset = transportsForReset;
+      this.pinComplexityPolicy = pinComplexityPolicy;
+      this.pinComplexityPolicyURL = pinComplexityPolicyURL;
+      this.maxPINLength = maxPINLength;
     }
 
     @SuppressWarnings("unchecked")
@@ -763,15 +795,23 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
               ? (Map<String, Object>) data.get(RESULT_CERTIFICATIONS)
               : Collections.emptyMap(),
           (Integer) data.get(RESULT_REMAINING_DISCOVERABLE_CREDENTIALS),
-          (List<Integer>) data.get(RESULT_VENDOR_PROTOTYPE_CONFIG_COMMANDS));
+          (List<Integer>) data.get(RESULT_VENDOR_PROTOTYPE_CONFIG_COMMANDS),
+          (List<String>) data.get(RESULT_ATTESTATION_FORMATS),
+          (Integer) data.get(RESULT_UV_COUNT_SINCE_LAST_PIN_ENTRY),
+          (Boolean) data.get(RESULT_LONG_TOUCH_FOR_RESET),
+          (byte[]) data.get(RESULT_ENC_IDENTIFIER),
+          (List<String>) data.get(RESULT_TRANSPORTS_FOR_RESET),
+          (Boolean) data.get(RESULT_PIN_COMPLEXITY_POLICY),
+          (byte[]) data.get(RESULT_PIN_COMPLEXITY_POLICY_URL),
+          (Integer) data.get(RESULT_MAX_PIN_LENGTH));
     }
 
     /**
      * List of supported versions.
      *
-     * <p>Supported versions are: {@code FIDO_2_0}, {@code FIDO_2_1_PRE}, and {@code FIDO_2_1} for
-     * CTAP2 / FIDO2 / Web Authentication authenticators and {@code U2F_V2} for CTAP1/U2F
-     * authenticators.
+     * <p>Supported versions are: {@code FIDO_2_0}, {@code FIDO_2_1_PRE}, {@code FIDO_2_1} and
+     * {@code FIDO_2_2} for CTAP2 / FIDO2 / Web Authentication authenticators and {@code U2F_V2} for
+     * CTAP1/U2F authenticators.
      *
      * @return list of supported versions
      */
@@ -821,7 +861,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *
      * @return a list of supported protocol versions
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#getinfo-pinuvauthprotocols">pinUvAuthProtocols</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-pinuvauthprotocols">pinUvAuthProtocols</a>
      */
     public List<Integer> getPinUvAuthProtocols() {
       return pinUvAuthProtocols;
@@ -881,7 +921,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      * @return maximum size of serialized large-blob array the authenticator can store if {@code
      *     authenticatorLargeBlobs} command is supported by the authenticator, 0 otherwise
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorLargeBlobs">authenticatorLargeBlobs</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-maxserializedlargeblobarray">authenticatorLargeBlobs</a>
      */
     public int getMaxSerializedLargeBlobArray() {
       return maxSerializedLargeBlobArray;
@@ -892,7 +932,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *
      * @return force PIN Change requirement
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#changingExistingPin">PIN
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-forcepinchange">PIN
      *     Change</a>
      */
     public boolean getForcePinChange() {
@@ -908,7 +948,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *
      * @return current minimum PIN length
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#getinfo-minpinlength">Minimum
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-minpinlength">Minimum
      *     PIN length</a>
      */
     public int getMinPinLength() {
@@ -931,8 +971,8 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      * @return maximum credBlob length if the authenticator supports {@code credBlob} extension, 0
      *     otherwise
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#getinfo-maxcredbloblength">Maximum
-     *     credBlob lenght</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-maxcredbloblength">Maximum
+     *     credBlob length</a>
      */
     public int getMaxCredBlobLength() {
       return maxCredBlobLength;
@@ -945,7 +985,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *
      * @return the maximum number of RP IDs
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#setMinPINLength">Setting
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-maxrpidsforsetminpinlength">Setting
      *     a minimum PIN Length</a>
      */
     public int getMaxRPIDsForSetMinPinLength() {
@@ -959,7 +999,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *
      * @return the preferred number of {@code getPinUvAuthTokenUsingUvWithPermissions} invocations
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#getinfo-preferredplatformuvattempts">Preferred
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-preferredplatformuvattempts">Preferred
      *     platfrom UV attempts</a>
      */
     @Nullable
@@ -973,7 +1013,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *
      * @return the user verification modality
      * @see <a
-     *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.1-ps-20191217.html#user-verification-methods">User
+     *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#user-verification-methods">User
      *     Verification Methods</a>
      */
     public int getUvModality() {
@@ -986,7 +1026,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *
      * @return certifications in the form key-value pairs with string IDs and integer values
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#sctn-feature-descriptions-certifications">Authenticator
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#sctn-feature-descriptions-certifications">Authenticator
      *     Certifications</a>
      */
     public final Map<String, Object> getCertifications() {
@@ -1008,12 +1048,114 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *
      * @return list of vendor command id's
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#getinfo-vendorprototypeconfigcommands">Vendor
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-vendorprototypeconfigcommands">Vendor
      *     prototype config commands</a>
      */
     @Nullable
     public List<Integer> getVendorPrototypeConfigCommands() {
       return vendorPrototypeConfigCommands;
+    }
+
+    /**
+     * Get the list of attestation formats supported by the authenticator.
+     *
+     * @return list of supported attestation formats
+     * @see <a
+     *     href="https://www.iana.org/assignments/webauthn/webauthn.xhtml#webauthn-attestation-statement-format-ids">WebAuthn
+     *     attestation statement format IDs</a>
+     */
+    @Nullable
+    public List<String> getAttestationFormats() {
+      return attestationFormats;
+    }
+
+    /**
+     * Get the count of User Verification operations since the last PIN entry including all failed
+     * attempts..
+     *
+     * @return the count of UV attempts since the last PIN entry
+     * @see <a
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-uvcountsincelastpinentry">uvCountSinceLastPinEntry</a>
+     */
+    @Nullable
+    public Integer getUvCountSinceLastPinEntry() {
+      return uvCountSinceLastPinEntry;
+    }
+
+    /**
+     * If present the authenticator requires a 10 second touch for reset.
+     *
+     * @return true if the authenticator requires a 10 second touch for reset
+     */
+    @Nullable
+    public Boolean getLongTouchForReset() {
+      return longTouchForReset;
+    }
+
+    /**
+     * Get the encrypted identifier for the authenticator.
+     *
+     * @return the encrypted identifier
+     * @see <a
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-encidentifier">encIdentifier</a>
+     */
+    @Nullable
+    public byte[] getEncIdentifier() {
+      return encIdentifier;
+    }
+
+    /**
+     * Get the list of transports that support the reset command.
+     *
+     * @return list of transports that support the reset command
+     * @see <a
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorReset">authenticatorReset</a>
+     * @see <a href="https://www.w3.org/TR/webauthn/#enumdef-authenticatortransport">WebAuthn
+     *     Authenticator Transport Enumeration</a>
+     */
+    @Nullable
+    public List<String> getTransportsForReset() {
+      return transportsForReset;
+    }
+
+    /**
+     * If present, returns whether the authenticator is enforcing an additional current PIN
+     * complexity policy beyond {@code minPINLength}. PIN complexity policies for authenticators are
+     * listed in the FIDO MDS. The authenticator may have a pre-configured PIN complexity policy
+     * value that is applied after a reset.
+     *
+     * @return true if whether the authenticator is enforcing an additional current PIN complexity
+     *     policy
+     * @see <a
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-pincomplexitypolicy">pinComplexityPolicy</a>
+     */
+    @Nullable
+    public Boolean getPinComplexityPolicy() {
+      return pinComplexityPolicy;
+    }
+
+    /**
+     * Get the URL that the platform can use to provide the user more information about the enforced
+     * PIN policy.
+     *
+     * @return the URL providing more information about the enforced PIN policy
+     */
+    @Nullable
+    public byte[] getPinComplexityPolicyURL() {
+      return pinComplexityPolicyURL;
+    }
+
+    /**
+     * Specifies the maximum PIN length, in Unicode code points, the authenticator enforces for
+     * ClientPIN.
+     *
+     * @return the maximum PIN length
+     * @see <a
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-maxpinlength">maxPinLength</a>
+     */
+    @Nullable
+    public Integer getMaxPINLength() {
+      return maxPINLength;
     }
 
     @Override
@@ -1061,6 +1203,22 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
           + remainingDiscoverableCredentials
           + ", vendorPrototypeConfigCommands="
           + vendorPrototypeConfigCommands
+          + ", attestationFormats="
+          + attestationFormats
+          + ", uvCountSinceLastPinEntry="
+          + uvCountSinceLastPinEntry
+          + ", longTouchForReset="
+          + longTouchForReset
+          + ", encIdentifier="
+          + (encIdentifier != null ? StringUtils.bytesToHex(encIdentifier) : null)
+          + ", transportsForReset="
+          + transportsForReset
+          + ", pinComplexityPolicy="
+          + pinComplexityPolicy
+          + ", pinComplexityPolicyURL="
+          + (pinComplexityPolicyURL != null ? StringUtils.bytesToHex(pinComplexityPolicyURL) : null)
+          + ", maxPINLength="
+          + maxPINLength
           + '}';
     }
   }
@@ -1155,7 +1313,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
    * Data class holding the result of getAssertion.
    *
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
+   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
    *     response structure</a>.
    */
   public static class AssertionData {
@@ -1252,7 +1410,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *
      * @return Total number of account credentials for the RP.
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
      *     response structure</a>.
      */
     @Nullable
@@ -1273,7 +1431,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      * @return True if the credential was selected by the user via interaction directly with the
      *     authenticator.
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
      *     response structure</a>.
      */
     @Nullable
@@ -1287,10 +1445,10 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *
      * @return The contents of the associated largeBlobKey.
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
      *     response structure</a>.
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#sctn-largeBlobKey-extension">Large
+     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#sctn-largeBlobKey-extension">Large
      *     Blob Key Extension</a>.
      */
     @Nullable

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2CredentialManagementInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2CredentialManagementInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,11 @@ public class Ctap2CredentialManagementInstrumentedTests {
     @Category(SmokeTest.class)
     public void testUpdateUserInformation() throws Throwable {
       withCtap2Session(Ctap2CredentialManagementTests::testUpdateUserInformation);
+    }
+
+    @Test
+    public void testReadOnlyManagement() throws Throwable {
+      withDevice(Ctap2CredentialManagementTests::testReadOnlyManagement);
     }
   }
 

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/ExtensionsInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/ExtensionsInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import com.yubico.yubikit.testing.fido.extensions.HmacSecretExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.LargeBlobExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.MinPinLengthExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.PrfExtensionTests;
+import com.yubico.yubikit.testing.fido.extensions.ThirdPartyPaymentExtensionTests;
 import com.yubico.yubikit.testing.framework.FidoInstrumentedTests;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -92,6 +93,11 @@ public class ExtensionsInstrumentedTests {
     @Test
     public void testMinPinLengthExtension() throws Throwable {
       withDevice(MinPinLengthExtensionTests::test);
+    }
+
+    @Test
+    public void testThirdPartyPaymentExtension() throws Throwable {
+      withDevice(ThirdPartyPaymentExtensionTests::test);
     }
   }
 

--- a/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/Ctap2CredentialManagementInstrumentedTests.java
+++ b/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/Ctap2CredentialManagementInstrumentedTests.java
@@ -45,9 +45,8 @@ public class Ctap2CredentialManagementInstrumentedTests {
     }
 
     @Test
-    @Category(SmokeTest.class)
-    public void testUpdateUserInformation() throws Throwable {
-      withCtap2Session(Ctap2CredentialManagementTests::testUpdateUserInformation);
+    public void testReadOnlyManagement() throws Throwable {
+      withDevice(Ctap2CredentialManagementTests::testReadOnlyManagement);
     }
   }
 

--- a/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/ExtensionsInstrumentedTests.java
+++ b/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/ExtensionsInstrumentedTests.java
@@ -27,6 +27,7 @@ import com.yubico.yubikit.testing.fido.extensions.HmacSecretExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.LargeBlobExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.MinPinLengthExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.PrfExtensionTests;
+import com.yubico.yubikit.testing.fido.extensions.ThirdPartyPaymentExtensionTests;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -92,6 +93,11 @@ public class ExtensionsInstrumentedTests {
     @Test
     public void testMinPinLengthExtension() throws Throwable {
       withDevice(MinPinLengthExtensionTests::test);
+    }
+
+    @Test
+    public void testThirdPartyPaymentExtension() throws Throwable {
+      withDevice(ThirdPartyPaymentExtensionTests::test);
     }
   }
 

--- a/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/ExtensionsInstrumentedTests.java
+++ b/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/ExtensionsInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.yubico.yubikit.testing.fido;
+package com.yubico.yubikit.testing.desktop.fido;
 
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocolV1;
-import com.yubico.yubikit.testing.PinUvAuthProtocolV1Test;
+import com.yubico.yubikit.testing.desktop.PinUvAuthProtocolV1Test;
+import com.yubico.yubikit.testing.desktop.framework.FidoInstrumentedTests;
 import com.yubico.yubikit.testing.fido.extensions.CredBlobExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.CredPropsExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.CredProtectExtensionTests;
@@ -26,7 +27,6 @@ import com.yubico.yubikit.testing.fido.extensions.HmacSecretExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.LargeBlobExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.MinPinLengthExtensionTests;
 import com.yubico.yubikit.testing.fido.extensions.PrfExtensionTests;
-import com.yubico.yubikit.testing.framework.FidoInstrumentedTests;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/extensions/ThirdPartyPaymentExtensionTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/extensions/ThirdPartyPaymentExtensionTests.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.testing.fido.extensions;
+
+import com.yubico.yubikit.fido.client.extensions.Extension;
+import com.yubico.yubikit.fido.client.extensions.ThirdPartyPaymentExtension;
+import com.yubico.yubikit.fido.webauthn.AuthenticatorAssertionResponse;
+import com.yubico.yubikit.fido.webauthn.AuthenticatorData;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredential;
+import com.yubico.yubikit.testing.fido.FidoTestState;
+import com.yubico.yubikit.testing.fido.utils.ClientHelper;
+import com.yubico.yubikit.testing.fido.utils.CreationOptionsBuilder;
+import com.yubico.yubikit.testing.fido.utils.RequestOptionsBuilder;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Assume;
+
+public class ThirdPartyPaymentExtensionTests {
+  private static final String THIRD_PARTY_PAYMENT = "thirdPartyPayment";
+  private static final String PAYMENT = "payment";
+  private static final String IS_PAYMENT = "isPayment";
+
+  private static final List<Extension> extensions =
+      Collections.singletonList(new ThirdPartyPaymentExtension());
+
+  public static void test(FidoTestState state) throws Throwable {
+    ThirdPartyPaymentExtensionTests extTest = new ThirdPartyPaymentExtensionTests();
+    extTest.runTest(state, false);
+    extTest.runTest(state, true);
+  }
+
+  private ThirdPartyPaymentExtensionTests() {}
+
+  private void runTest(FidoTestState state, boolean rk) throws Throwable {
+
+    {
+      // create a new credential without the payment extension
+      PublicKeyCredential publicKeyCredential =
+          state.withCtap2(
+              session -> {
+                Assume.assumeTrue(
+                    "thirdPartyPayment not supported",
+                    session.getCachedInfo().getExtensions().contains(THIRD_PARTY_PAYMENT));
+                return new ClientHelper(session, extensions)
+                    .makeCredential(new CreationOptionsBuilder().residentKey(rk).build());
+              });
+
+      // check that the credential has the expected value
+      // input:  { payment: { isPayment: true } }
+      // authenticator extensions output: { thirdPartyPayment: false }
+      state.withCtap2(
+          session -> {
+            RequestOptionsBuilder requestOptionsBuilder =
+                new RequestOptionsBuilder()
+                    .extensions(
+                        Collections.singletonMap(
+                            PAYMENT, Collections.singletonMap(IS_PAYMENT, true)));
+
+            if (!rk) {
+              requestOptionsBuilder.allowedCredentials(publicKeyCredential);
+            }
+
+            final ClientHelper client = new ClientHelper(session, extensions);
+            PublicKeyCredential credential = client.getAssertions(requestOptionsBuilder.build());
+            Assert.assertEquals(Boolean.FALSE, getThirdPartyPaymentValue(credential));
+
+            if (rk) {
+              client.deleteCredentials(publicKeyCredential);
+            }
+          });
+    }
+
+    // test with client input
+    {
+      // input:  { payment: { isPayment: true } }
+      // output: {  }
+      PublicKeyCredential publicKeyCredential =
+          state.withCtap2(
+              session -> {
+                return new ClientHelper(session, extensions)
+                    .makeCredential(
+                        new CreationOptionsBuilder()
+                            .residentKey(rk)
+                            .extensions(
+                                Collections.singletonMap(
+                                    PAYMENT, Collections.singletonMap(IS_PAYMENT, true)))
+                            .build());
+              });
+
+      // check that the credential has the expected value
+      // input:  { payment: { isPayment: true } }
+      // authenticator extensions output: { thirdPartyPayment: true }
+      state.withCtap2(
+          session -> {
+            RequestOptionsBuilder requestOptionsBuilder =
+                new RequestOptionsBuilder()
+                    .extensions(
+                        Collections.singletonMap(
+                            PAYMENT, Collections.singletonMap(IS_PAYMENT, true)));
+
+            if (!rk) {
+              requestOptionsBuilder.allowedCredentials(publicKeyCredential);
+            }
+
+            final ClientHelper client = new ClientHelper(session, extensions);
+            PublicKeyCredential credential = client.getAssertions(requestOptionsBuilder.build());
+            Assert.assertEquals(Boolean.TRUE, getThirdPartyPaymentValue(credential));
+
+            if (rk) {
+              client.deleteCredentials(publicKeyCredential);
+            }
+          });
+    }
+  }
+
+  // get the value of thirdPartyPayment extension from the authenticator data
+  private static Boolean getThirdPartyPaymentValue(PublicKeyCredential credential) {
+    AuthenticatorAssertionResponse response =
+        (AuthenticatorAssertionResponse) credential.getResponse();
+
+    AuthenticatorData authenticatorData =
+        AuthenticatorData.parseFrom(ByteBuffer.wrap(response.getAuthenticatorData()));
+
+    Map<String, ?> extensions = authenticatorData.getExtensions();
+    Assert.assertNotNull("Extensions missing", extensions);
+    return (Boolean) extensions.get(THIRD_PARTY_PAYMENT);
+  }
+}


### PR DESCRIPTION
Adds support for new [CTAP2.2](https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html) features

- exposes new deviceInfo fields
- implements support for PPUAT and encIdentifier
- implements hmac-secret-mc extension processing
- implements thirdPartyPayment extension processing 