### PR TITLE
Use version qualifier for all protocols

### DIFF
--- a/management/src/main/java/com/yubico/yubikit/management/ManagementSession.java
+++ b/management/src/main/java/com/yubico/yubikit/management/ManagementSession.java
@@ -521,18 +521,28 @@ public class ManagementSession extends ApplicationSession<ManagementSession> {
     return new byte[] {(byte) page};
   }
 
+  /**
+   * Retrieves the versionQualifier version of the YubiKey device.
+   *
+   * <p>If the provided version is identified as a development version, this method overrides it by
+   * with version from the versionQualifier.
+   *
+   * @param version the initial version of the YubiKey device.
+   * @return the version override.
+   * @throws IOException if reading the device information fails.
+   */
   private Version getQualifiedVersion(Version version) throws IOException {
-    Version result = version;
-    if (SessionVersionOverride.isDevelopmentVersion(version)) {
-      try {
-        logger.debug("Overriding development version...");
-        result = readDeviceInfo().getVersionQualifier().getVersion();
-        SessionVersionOverride.set(result);
-      } catch (CommandException e) {
-        // failed to read device info where it was expected
-        throw new IOException("Failed reading device info.", e);
-      }
+    if (!SessionVersionOverride.isDevelopmentVersion(version)) {
+      return version;
     }
-    return result;
+    try {
+      logger.debug("Overriding development version...");
+      Version result = readDeviceInfo().getVersionQualifier().getVersion();
+      SessionVersionOverride.set(result);
+      return result;
+    } catch (CommandException e) {
+      // failed to read device info where it was expected
+      throw new IOException("Failed reading device info.", e);
+    }
   }
 }


### PR DESCRIPTION
Improves handling of versionQualifier when constructing ManagementSession by using the qualifier version also for FIDO and OTP connections, where previously this was only handled during SmartCard connections.

This has been tested with integration tests over USB and NFC, on Android 8.1.0 and Android 16 and YubiKeys 3 to latest.