### PR TITLE
[FIDO] fix largeBlobKey authenticator inputs

### DIFF
--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
@@ -64,7 +64,8 @@ public class LargeBlobExtension extends Extension {
 
   @Override
   protected boolean isSupported(Ctap2Session ctap) {
-    return super.isSupported(ctap) && ctap.getCachedInfo().getOptions().containsKey(LARGE_BLOBS);
+    return super.isSupported(ctap)
+        && Boolean.TRUE.equals(ctap.getCachedInfo().getOptions().get(LARGE_BLOBS));
   }
 
   @Nullable
@@ -82,7 +83,7 @@ public class LargeBlobExtension extends Extension {
         throw new IllegalArgumentException("Authenticator does not support large blob storage");
       }
       return new RegistrationProcessor(
-          pinToken -> Collections.singletonMap(LARGE_BLOB, true),
+          pinToken -> Collections.singletonMap(LARGE_BLOB_KEY, true),
           (attestationObject, pinToken) ->
               serializationType ->
                   Collections.singletonMap(
@@ -106,11 +107,11 @@ public class LargeBlobExtension extends Extension {
     }
     if (Boolean.TRUE.equals(inputs.read)) {
       return new AuthenticationProcessor(
-          (selected, pinToken) -> Collections.singletonMap(LARGE_BLOB, true),
+          (selected, pinToken) -> Collections.singletonMap(LARGE_BLOB_KEY, true),
           (assertionData, pinToken) -> read(assertionData, ctap));
     } else if (inputs.write != null) {
       return new AuthenticationProcessor(
-          (selected, pinToken) -> Collections.singletonMap(LARGE_BLOB, true),
+          (selected, pinToken) -> Collections.singletonMap(LARGE_BLOB_KEY, true),
           (assertionData, pinToken) ->
               write(
                   assertionData,


### PR DESCRIPTION
- Fixes issue when the SDK was using wrong property name for authenticator inputs. `largeBlob` instead of `largeBlobKey`.
- Fixes support detection

See https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#sctn-largeBlobKey-extension

Testing: Integration tests pass on devices supporting largeBlobKey 