### PR TITLE
Fix CredentialData URI parser

### DIFF
--- a/oath/src/test/java/com/yubico/yubikit/oath/CredentialDataTest.java
+++ b/oath/src/test/java/com/yubico/yubikit/oath/CredentialDataTest.java
@@ -45,20 +45,27 @@ public class CredentialDataTest {
   }
 
   @Test
-  public void testParseIssuer() throws ParseUriException, URISyntaxException {
+  public void testParse() throws ParseUriException, URISyntaxException {
     CredentialData noIssuer =
         CredentialData.parseUri(new URI("otpauth://totp/account?secret=abba"));
     Assert.assertNull(noIssuer.getIssuer());
+    Assert.assertEquals("account", noIssuer.getAccountName());
+
     CredentialData usingParam =
-        CredentialData.parseUri(new URI("otpauth://totp/account?secret=abba&issuer=Issuer"));
-    Assert.assertEquals(usingParam.getIssuer(), "Issuer");
+        CredentialData.parseUri(new URI("otpauth://totp/account?secret=abba&issuer=Issuer%26Amp"));
+    Assert.assertEquals("Issuer&Amp", usingParam.getIssuer());
+    Assert.assertEquals("account", usingParam.getAccountName());
+
     CredentialData usingSeparator =
-        CredentialData.parseUri(new URI("otpauth://totp/Issuer:account?secret=abba"));
-    Assert.assertEquals(usingSeparator.getIssuer(), "Issuer");
+        CredentialData.parseUri(new URI("otpauth://totp/Issuer%26Amp:account?secret=abba"));
+    Assert.assertEquals("Issuer&Amp", usingSeparator.getIssuer());
+    Assert.assertEquals("account", noIssuer.getAccountName());
+
     CredentialData usingBoth =
         CredentialData.parseUri(
-            new URI("otpauth://totp/IssuerA:account?secret=abba&issuer=IssuerB"));
-    Assert.assertEquals(usingBoth.getIssuer(), "IssuerA");
+            new URI("otpauth://totp/Issuer%26Amp:account?secret=abba&issuer=IssuerB"));
+    Assert.assertEquals("Issuer&Amp", usingBoth.getIssuer());
+    Assert.assertEquals("account", noIssuer.getAccountName());
   }
 
   @Test(expected = ParseUriException.class)
@@ -85,5 +92,10 @@ public class CredentialDataTest {
   @Test(expected = ParseUriException.class)
   public void testParseMissingAlgorithm() throws ParseUriException, URISyntaxException {
     CredentialData.parseUri(new URI("otpauth:///foo:mallory@example.com?secret=kaka"));
+  }
+
+  @Test(expected = ParseUriException.class)
+  public void testParseInvalidIssuerQuery() throws ParseUriException, URISyntaxException {
+    CredentialData.parseUri(new URI("otpauth:///foo:mallory@example.com?secret=kaka&issuer"));
   }
 }


### PR DESCRIPTION
This pull request enhances the robustness and correctness of the `CredentialData` URI parsing logic and improves the test coverage for edge cases. The most important changes include stricter validation of URI query parameters, decoding URL-encoded values, and adding new test cases to ensure proper behavior.

### Improvements to URI Parsing Logic:

* Added validation to ensure the query string is not null or empty, throwing a `ParseUriException` if it is. (`oath/src/main/java/com/yubico/yubikit/oath/CredentialData.java`, [oath/src/main/java/com/yubico/yubikit/oath/CredentialData.javaL72-R94](diffhunk://#diff-04ffceee9ab2818173da5d6014e983c68169e803b177ab04b4577304b3234764L72-R94))
* Introduced decoding for URL-encoded query parameter values using `URLDecoder`, with error handling for unsupported encoding or invalid URL encoding. (`oath/src/main/java/com/yubico/yubikit/oath/CredentialData.java`, [oath/src/main/java/com/yubico/yubikit/oath/CredentialData.javaL72-R94](diffhunk://#diff-04ffceee9ab2818173da5d6014e983c68169e803b177ab04b4577304b3234764L72-R94))
* Added validation to ensure the `secret` parameter is present and non-empty, throwing a `ParseUriException` if it is missing or invalid. (`oath/src/main/java/com/yubico/yubikit/oath/CredentialData.java`, [oath/src/main/java/com/yubico/yubikit/oath/CredentialData.javaL98-R122](diffhunk://#diff-04ffceee9ab2818173da5d6014e983c68169e803b177ab04b4577304b3234764L98-R122))

### Test Coverage Enhancements:

* Updated the `testParseUriGood` test to include cases with URL-encoded `issuer` and `accountName`, ensuring proper decoding and validation. (`oath/src/test/java/com/yubico/yubikit/oath/CredentialDataTest.java`, [oath/src/test/java/com/yubico/yubikit/oath/CredentialDataTest.javaL48-R68](diffhunk://#diff-43360648f63d6dafe978bf66fef45124293150e94bdbaf75fdbeaf1461a1b712L48-R68))
* Added a new test case, `testParseInvalidIssuerQuery`, to verify that an invalid `issuer` query parameter without a value throws a `ParseUriException`. (`oath/src/test/java/com/yubico/yubikit/oath/CredentialDataTest.java`, [oath/src/test/java/com/yubico/yubikit/oath/CredentialDataTest.javaR96-R100](diffhunk://#diff-43360648f63d6dafe978bf66fef45124293150e94bdbaf75fdbeaf1461a1b712R96-R100))