### PR TITLE
Return proper name for Enhanced PIN devices.

### DIFF
--- a/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
+++ b/support/src/main/java/com/yubico/yubikit/support/DeviceUtil.java
@@ -545,6 +545,10 @@ public class DeviceUtil {
         namePartsList.add("- Enterprise Edition");
       }
 
+      if (info.getPinComplexity() && !(info.isSky() || info.isFips())) {
+        namePartsList.add("- Enhanced PIN");
+      }
+
       StringBuilder builder = new StringBuilder();
       for (int partCount = 0; partCount < namePartsList.size(); partCount++) {
         String s = namePartsList.get(partCount);

--- a/support/src/test/java/com/yubico/yubikit/support/GetNameTest.java
+++ b/support/src/test/java/com/yubico/yubikit/support/GetNameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -451,6 +451,35 @@ public class GetNameTest {
                   i.formFactor(USB_C_KEYCHAIN);
                   i.version(new Version(5, 4, 3));
                   i.isSky(true);
+                  i.supportedCapabilities(fidoCapabilities);
+                  i.serialNumber(65454545);
+                }),
+            YubiKeyType.YK4));
+  }
+
+  @Test
+  public void testEnhancedPin() {
+    assertEquals(
+        "YubiKey 5 NFC - Enhanced PIN",
+        DeviceUtil.getName(
+            info(
+                i -> {
+                  i.formFactor(USB_A_KEYCHAIN);
+                  i.version(new Version(5, 4, 3));
+                  i.pinComplexity(true);
+                  i.supportedCapabilities(fidoCapabilities);
+                  i.serialNumber(65454545);
+                }),
+            YubiKeyType.YK4));
+
+    assertEquals(
+        "YubiKey 5C NFC - Enhanced PIN",
+        DeviceUtil.getName(
+            info(
+                i -> {
+                  i.formFactor(USB_C_KEYCHAIN);
+                  i.version(new Version(5, 4, 3));
+                  i.pinComplexity(true);
                   i.supportedCapabilities(fidoCapabilities);
                   i.serialNumber(65454545);
                 }),


### PR DESCRIPTION
Adds support to `DeviceUtil.getName()` to return `- Enhanced PIN` postfix for appropriate devices.