### PR TITLE
Fix ShortApduFormatter

### DIFF
--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/ShortApduFormatter.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/ShortApduFormatter.java
@@ -32,7 +32,12 @@ class ShortApduFormatter implements ApduFormatter {
     }
 
     ByteBuffer buf =
-        ByteBuffer.allocate(4 + (length > 0 ? 1 : 0) + length + (le > 0 ? 1 : 0))
+        ByteBuffer.allocate(
+                4
+                    + (length > 0 ? 1 : 0)
+                    + length
+                    + (le > 0 ? 1 : 0)
+                    + (length == 0 && le == 0 ? 1 : 0))
             .put(cla)
             .put(ins)
             .put(p1)
@@ -42,6 +47,8 @@ class ShortApduFormatter implements ApduFormatter {
     }
     if (le > 0) {
       buf.put((byte) le);
+    } else if (length == 0) {
+      buf.put((byte) 0);
     }
     return buf.array();
   }


### PR DESCRIPTION
This PR fixes issue where HW security keys would not accept an APDU, resulting in `0x67 0x00` response (WRONG LENGTH). 

The change is similar to what we already do in [yubikey-manager](https://github.com/Yubico/yubikey-manager/blob/5.7.2/yubikit/core/smartcard/__init__.py#L163-L165) and libfido2.
