### PR TITLE
[FIDO] Add device test to verify PIN fallback after UV_BLOCKED

### DIFF
--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2BioEnrollmentInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2BioEnrollmentInstrumentedTests.java
@@ -32,6 +32,6 @@ public class Ctap2BioEnrollmentInstrumentedTests extends FidoInstrumentedTests {
   @Test
   @Category(AlwaysManualTest.class)
   public void testPinRequiredAfterUvBlocked() throws Throwable {
-    withDevice(Ctap2BioUVTests::testPinRequiredAfterUvBlocked);
+    withDevice(Ctap2BioUvTests::testPinRequiredAfterUvBlocked);
   }
 }

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2BioEnrollmentInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2BioEnrollmentInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,21 @@
 package com.yubico.yubikit.testing.fido;
 
 import androidx.test.filters.LargeTest;
+import com.yubico.yubikit.testing.AlwaysManualTest;
 import com.yubico.yubikit.testing.framework.FidoInstrumentedTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 @LargeTest
 public class Ctap2BioEnrollmentInstrumentedTests extends FidoInstrumentedTests {
   @Test
   public void testFingerprintEnrollment() throws Throwable {
     withCtap2Session(Ctap2BioEnrollmentTests::testFingerprintEnrollment);
+  }
+
+  @Test
+  @Category(AlwaysManualTest.class)
+  public void testPinRequiredAfterUvBlocked() throws Throwable {
+    withDevice(Ctap2BioUVTests::testPinRequiredAfterUvBlocked);
   }
 }

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/FidoTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/FidoTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.junit.runners.Suite;
   UvDiscouragedInstrumentedTests.class,
   Ctap2ConfigInstrumentedTests.class,
   Ctap2BioEnrollmentInstrumentedTests.class,
+  Ctap2BioUvTests.class,
   Ctap2SessionResetInstrumentedTests.class,
   ExtensionsInstrumentedTests.class,
 })

--- a/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/Ctap2BioEnrollmentInstrumentedTests.java
+++ b/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/Ctap2BioEnrollmentInstrumentedTests.java
@@ -18,7 +18,7 @@ package com.yubico.yubikit.testing.desktop.fido;
 import com.yubico.yubikit.testing.desktop.AlwaysManualTest;
 import com.yubico.yubikit.testing.desktop.framework.FidoInstrumentedTests;
 import com.yubico.yubikit.testing.fido.Ctap2BioEnrollmentTests;
-import com.yubico.yubikit.testing.fido.Ctap2BioUVTests;
+import com.yubico.yubikit.testing.fido.Ctap2BioUvTests;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -31,6 +31,6 @@ public class Ctap2BioEnrollmentInstrumentedTests extends FidoInstrumentedTests {
   @Test
   @Category(AlwaysManualTest.class)
   public void testPinRequiredAfterUvBlocked() throws Throwable {
-    withDevice(Ctap2BioUVTests::testPinRequiredAfterUvBlocked);
+    withDevice(Ctap2BioUvTests::testPinRequiredAfterUvBlocked);
   }
 }

--- a/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/Ctap2BioEnrollmentInstrumentedTests.java
+++ b/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/Ctap2BioEnrollmentInstrumentedTests.java
@@ -15,13 +15,22 @@
  */
 package com.yubico.yubikit.testing.desktop.fido;
 
+import com.yubico.yubikit.testing.desktop.AlwaysManualTest;
 import com.yubico.yubikit.testing.desktop.framework.FidoInstrumentedTests;
 import com.yubico.yubikit.testing.fido.Ctap2BioEnrollmentTests;
+import com.yubico.yubikit.testing.fido.Ctap2BioUVTests;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public class Ctap2BioEnrollmentInstrumentedTests extends FidoInstrumentedTests {
   @Test
   public void testFingerprintEnrollment() throws Throwable {
     withCtap2Session(Ctap2BioEnrollmentTests::testFingerprintEnrollment);
+  }
+
+  @Test
+  @Category(AlwaysManualTest.class)
+  public void testPinRequiredAfterUvBlocked() throws Throwable {
+    withDevice(Ctap2BioUVTests::testPinRequiredAfterUvBlocked);
   }
 }

--- a/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/FidoTests.java
+++ b/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/FidoTests.java
@@ -17,6 +17,7 @@ package com.yubico.yubikit.testing.desktop.fido;
 
 import com.yubico.yubikit.testing.desktop.AlwaysManualTest;
 import com.yubico.yubikit.testing.desktop.fido.extensions.SignExtensionInstrumentedTests;
+import com.yubico.yubikit.testing.fido.Ctap2BioUvTests;
 import org.junit.experimental.categories.Categories;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -39,6 +40,7 @@ import org.junit.runners.Suite;
   UvDiscouragedInstrumentedTests.class,
   Ctap2ConfigInstrumentedTests.class,
   Ctap2BioEnrollmentInstrumentedTests.class,
+  Ctap2BioUvTests.class,
   Ctap2SessionResetInstrumentedTests.class,
   SignExtensionInstrumentedTests.class
 })

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/Ctap2BioUVTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/Ctap2BioUVTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.testing.fido;
+
+import static com.yubico.yubikit.testing.fido.utils.BioEnrollment.enrollFingerprint;
+import static com.yubico.yubikit.testing.fido.utils.BioEnrollment.fpBioEnrollment;
+import static com.yubico.yubikit.testing.fido.utils.BioEnrollment.removeAllFingerprints;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+import com.yubico.yubikit.core.fido.CtapException;
+import com.yubico.yubikit.fido.client.ClientError;
+import com.yubico.yubikit.fido.ctap.BioEnrollment;
+import com.yubico.yubikit.fido.ctap.FingerprintBioEnrollment;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredential;
+import com.yubico.yubikit.fido.webauthn.UserVerificationRequirement;
+import com.yubico.yubikit.testing.fido.utils.ClientHelper;
+import com.yubico.yubikit.testing.fido.utils.CreationOptionsBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Ctap2BioUVTests {
+
+  private static final Logger logger = LoggerFactory.getLogger(Ctap2BioUVTests.class);
+
+  /**
+   * Needs to be ran manually with a Bio device.
+   *
+   * <p>Verifies that after blocking Bio UV by three failed matches, PIN can be used to perform UV.
+   * See logger.info output for instructions:
+   *
+   * <p>The test does following:
+   *
+   * <ol>
+   *   <li>resets the device, sets default PIN
+   *   <li>asks for fingerprint enrollments -> touch the fp sensor 5x with finger 1
+   *   <li>calls make credential 3x -> touch the fp sensor 3x with finger 2 (UV_INVALID)
+   *   <li>calls make credential with PIN -> touch the sensor
+   *   <li>removes new credential and created fingerprint
+   * </ol>
+   *
+   * @param state test state
+   * @throws Throwable on any test error
+   */
+  public static void testPinRequiredAfterUvBlocked(FidoTestState state) throws Throwable {
+
+    final byte[] templateId =
+        state.withCtap2(
+            session -> {
+              assumeTrue(
+                  "Bio enrollment not supported",
+                  BioEnrollment.isSupported(session.getCachedInfo()));
+
+              final FingerprintBioEnrollment fingerprintBioEnrollment =
+                  fpBioEnrollment(session, state);
+
+              removeAllFingerprints(fingerprintBioEnrollment);
+
+              return enrollFingerprint(fingerprintBioEnrollment);
+            });
+
+    // MC with fingerprint
+    for (int i = 0; i < 4; i++) {
+      final int innerI = i;
+      state.withCtap2(
+          session -> {
+            try {
+              logger.info("Use wrong fingerprint");
+              new ClientHelper(session)
+                  .withPin(null)
+                  .makeCredential(
+                      new CreationOptionsBuilder()
+                          .userEntity("Bio User")
+                          .residentKey(true)
+                          .userVerification(UserVerificationRequirement.REQUIRED)
+                          .build());
+
+            } catch (ClientError e) {
+              if (e.getErrorCode() == ClientError.Code.BAD_REQUEST) {
+                if (e.getCause() instanceof CtapException) {
+                  CtapException ctapException = (CtapException) e.getCause();
+                  if (innerI < 3) {
+                    // first three wrong matches
+                    assertEquals(CtapException.ERR_UV_INVALID, ctapException.getCtapError());
+                    logger.info("Received UV Invalid");
+                  } else {
+                    // three wrong matches block UV
+                    assertEquals(CtapException.ERR_UV_BLOCKED, ctapException.getCtapError());
+                    logger.info("Received UV Blocked");
+                  }
+                }
+              }
+            }
+          });
+    }
+
+    PublicKeyCredential cred =
+        state.withCtap2(
+            session -> {
+              logger.info("Touch the sensor (no fingerprint scan)");
+
+              return new ClientHelper(session)
+                  .makeCredential(
+                      new CreationOptionsBuilder()
+                          .userEntity("Bio User")
+                          .residentKey(true)
+                          // even when UV is required, PIN will be used
+                          .userVerification(UserVerificationRequirement.REQUIRED)
+                          .build());
+            });
+
+    state.withCtap2(
+        session -> {
+          final FingerprintBioEnrollment fingerprintBioEnrollment = fpBioEnrollment(session, state);
+          fingerprintBioEnrollment.removeEnrollment(templateId);
+          new ClientHelper(session).deleteCredentials(cred);
+        });
+  }
+}

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/Ctap2BioUvTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/Ctap2BioUvTests.java
@@ -33,9 +33,9 @@ import com.yubico.yubikit.testing.fido.utils.CreationOptionsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Ctap2BioUVTests {
+public class Ctap2BioUvTests {
 
-  private static final Logger logger = LoggerFactory.getLogger(Ctap2BioUVTests.class);
+  private static final Logger logger = LoggerFactory.getLogger(Ctap2BioUvTests.class);
 
   /**
    * Needs to be ran manually with a Bio device.

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/utils/BioEnrollment.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/utils/BioEnrollment.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.testing.fido.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.yubico.yubikit.core.fido.CtapException;
+import com.yubico.yubikit.fido.ctap.ClientPin;
+import com.yubico.yubikit.fido.ctap.Ctap2Session;
+import com.yubico.yubikit.fido.ctap.FingerprintBioEnrollment;
+import com.yubico.yubikit.testing.fido.FidoTestState;
+import java.util.Arrays;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BioEnrollment {
+  private static final Logger logger = LoggerFactory.getLogger(BioEnrollment.class);
+
+  public static byte[] enrollFingerprint(FingerprintBioEnrollment bioEnrollment) {
+
+    final FingerprintBioEnrollment.Context context = bioEnrollment.enroll(null);
+
+    byte[] templateId = null;
+    while (templateId == null) {
+      logger.info("Touch the fingerprint");
+      try {
+        templateId = context.capture(null);
+      } catch (FingerprintBioEnrollment.CaptureError captureError) {
+        // capture errors are expected
+        logger.info("Received capture error: ", captureError);
+      } catch (CtapException ctapException) {
+        assertThat(
+            "Received CTAP2_ERR_FP_DATABASE_FULL exception - "
+                + "remove fingerprints before running this test",
+            ctapException.getCtapError() != CtapException.ERR_FP_DATABASE_FULL);
+        fail("Received unexpected CTAP2 exception " + ctapException.getCtapError());
+      } catch (Throwable exception) {
+        fail("Received unexpected exception " + exception.getMessage());
+      }
+    }
+
+    logger.info("Enrolled: {}", templateId);
+
+    return templateId;
+  }
+
+  public static FingerprintBioEnrollment fpBioEnrollment(Ctap2Session session, FidoTestState state)
+      throws Throwable {
+
+    final ClientPin pin = new ClientPin(session, state.getPinUvAuthProtocol());
+    final byte[] pinToken = pin.getPinToken(TestData.PIN, ClientPin.PIN_PERMISSION_BE, "localhost");
+
+    return new FingerprintBioEnrollment(session, state.getPinUvAuthProtocol(), pinToken);
+  }
+
+  public static void renameFingerprint(
+      FingerprintBioEnrollment fingerprintBioEnrollment, byte[] templateId, int newNameLen)
+      throws Throwable {
+
+    char[] charArray = new char[newNameLen];
+    Arrays.fill(charArray, 'A');
+    String newName = new String(charArray);
+
+    fingerprintBioEnrollment.setName(templateId, newName);
+    Map<byte[], String> enrollments = fingerprintBioEnrollment.enumerateEnrollments();
+    assertEquals(newName, getName(templateId, enrollments));
+  }
+
+  public static void removeAllFingerprints(FingerprintBioEnrollment fingerprintBioEnrollment)
+      throws Throwable {
+    Map<byte[], String> enrollments = fingerprintBioEnrollment.enumerateEnrollments();
+
+    for (byte[] templateId : enrollments.keySet()) {
+      fingerprintBioEnrollment.removeEnrollment(templateId);
+    }
+
+    enrollments = fingerprintBioEnrollment.enumerateEnrollments();
+    assertThat("Fingerprints still exists after removal", enrollments.isEmpty());
+  }
+
+  public static boolean isEnrolled(byte[] templateId, Map<byte[], String> enrollments) {
+    for (byte[] enrolledTemplateId : enrollments.keySet()) {
+      if (Arrays.equals(templateId, enrolledTemplateId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static String getName(byte[] templateId, Map<byte[], String> enrollments) {
+    for (Map.Entry<byte[], String> enrollment : enrollments.entrySet()) {
+      if (Arrays.equals(templateId, enrollment.getKey())) {
+        return enrollments.get(enrollment.getKey());
+      }
+    }
+    return null;
+  }
+}

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/utils/ClientHelper.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/utils/ClientHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/utils/ClientHelper.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/utils/ClientHelper.java
@@ -16,6 +16,8 @@
 
 package com.yubico.yubikit.testing.fido.utils;
 
+import static org.junit.Assert.assertNotNull;
+
 import com.yubico.yubikit.core.application.CommandException;
 import com.yubico.yubikit.fido.client.BasicWebAuthnClient;
 import com.yubico.yubikit.fido.client.ClientError;
@@ -31,16 +33,20 @@ import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 public class ClientHelper {
   final BasicWebAuthnClient client;
+  @Nullable private char[] pin;
 
   public ClientHelper(Ctap2Session ctap) throws IOException, CommandException {
+    this.pin = TestData.PIN;
     this.client = new BasicWebAuthnClient(ctap);
   }
 
   public ClientHelper(Ctap2Session ctap, List<Extension> extensions)
       throws IOException, CommandException {
+    this.pin = TestData.PIN;
     this.client = new BasicWebAuthnClient(ctap, extensions);
   }
 
@@ -51,19 +57,19 @@ public class ClientHelper {
   public PublicKeyCredential makeCredential(PublicKeyCredentialCreationOptions options)
       throws IOException, CommandException, ClientError {
     return client.makeCredential(
-        TestData.CLIENT_DATA_JSON_CREATE, options, TestData.RP_ID, TestData.PIN, null, null);
+        TestData.CLIENT_DATA_JSON_CREATE, options, TestData.RP_ID, pin, null, null);
   }
 
   public PublicKeyCredential getAssertions(PublicKeyCredentialRequestOptions options)
       throws IOException, CommandException, ClientError, MultipleAssertionsAvailable {
-    return client.getAssertion(
-        TestData.CLIENT_DATA_JSON_GET, options, TestData.RP_ID, TestData.PIN, null);
+    return client.getAssertion(TestData.CLIENT_DATA_JSON_GET, options, TestData.RP_ID, pin, null);
   }
 
   public void deleteCredentialsByIds(List<byte[]> credIds)
       throws IOException, CommandException, ClientError {
     try {
-      CredentialManager credentialManager = client.getCredentialManager(TestData.PIN);
+      assertNotNull("Pin cannot be null for delete credential", pin);
+      CredentialManager credentialManager = client.getCredentialManager(pin);
       for (byte[] credId : credIds) {
         credentialManager.deleteCredential(
             new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, credId, null));
@@ -89,5 +95,10 @@ public class ClientHelper {
       credIds.add(credential.getRawId());
     }
     deleteCredentialsByIds(credIds);
+  }
+
+  public ClientHelper withPin(@Nullable char[] pin) {
+    this.pin = pin;
+    return this;
   }
 }

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/utils/CreationOptionsBuilder.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/utils/CreationOptionsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/utils/CreationOptionsBuilder.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/utils/CreationOptionsBuilder.java
@@ -39,6 +39,7 @@ public class CreationOptionsBuilder {
   @Nullable Extensions extensions = null;
   @Nullable PublicKeyCredentialUserEntity userEntity = null;
   @Nullable List<PublicKeyCredentialDescriptor> excludeCredentials = null;
+  @Nullable String userVerification = null;
 
   public CreationOptionsBuilder residentKey(boolean residentKey) {
     this.residentKey = residentKey;
@@ -95,13 +96,18 @@ public class CreationOptionsBuilder {
     return this;
   }
 
+  public CreationOptionsBuilder userVerification(@Nullable String userVerification) {
+    this.userVerification = userVerification;
+    return this;
+  }
+
   public PublicKeyCredentialCreationOptions build() {
     PublicKeyCredentialRpEntity rp = TestData.RP;
     AuthenticatorSelectionCriteria criteria =
         new AuthenticatorSelectionCriteria(
             null,
             residentKey ? ResidentKeyRequirement.REQUIRED : ResidentKeyRequirement.DISCOURAGED,
-            null);
+            userVerification);
     return new PublicKeyCredentialCreationOptions(
         rp,
         userEntity != null ? userEntity : TestData.USER,


### PR DESCRIPTION
This pull request introduces a new manual test to verify PIN fallback after biometric user verification (UV) is blocked, refactors fingerprint enrollment helper methods into a new utility class, and improves test code maintainability and clarity. The changes affect both Android and desktop test suites, as well as core test utilities.
