### PR TITLE
Use BouncyCastleProvider in Kdf if available

### DIFF
--- a/openpgp/src/main/java/com/yubico/yubikit/openpgp/Kdf.java
+++ b/openpgp/src/main/java/com/yubico/yubikit/openpgp/Kdf.java
@@ -25,6 +25,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -82,6 +83,12 @@ public abstract class Kdf {
       }
 
       private MessageDigest getMessageDigest() {
+        try {
+          return MessageDigest.getInstance(name(), "BC");
+        } catch (NoSuchAlgorithmException | NoSuchProviderException ignored) {
+          // noop
+        }
+
         try {
           return MessageDigest.getInstance(name());
         } catch (NoSuchAlgorithmException e) {


### PR DESCRIPTION
Android already seem to include some stripped-downed version of BouncyCastle, so it's not possible to check if the provider is present or not (it always is, but it doesn't mean that it has the expected algorithm).

So I just try to get the instance using BouncyCastle, and if that fails, I fallback to the default implementation.

In my app (outside Yubikit), I call this to register the BouncyCastleProvider (I need to first remove the embedded BouncyCastle and then add the full one):

```kotlin
val provider = Security.getProvider(BouncyCastleProvider.PROVIDER_NAME)
if (provider == null || provider.javaClass != BouncyCastleProvider::class.java) {
    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
    Security.addProvider(BouncyCastleProvider())
}
```

What do you think?

Resolves #200.