### PR TITLE
[PIV] handle INVALID_INSTRUCTION

### DIFF
--- a/piv/src/main/java/com/yubico/yubikit/piv/PivSession.java
+++ b/piv/src/main/java/com/yubico/yubikit/piv/PivSession.java
@@ -707,7 +707,8 @@ public class PivSession extends ApplicationSession<PivSession> {
           data.get(TAG_METADATA_RETRIES)[0],
           data.get(TAG_METADATA_TEMPORARY_PIN)[0] == 1);
     } catch (ApduException apduException) {
-      if (apduException.getSw() == SW.REFERENCED_DATA_NOT_FOUND) {
+      short sw = apduException.getSw();
+      if (sw == SW.REFERENCED_DATA_NOT_FOUND || sw == SW.INVALID_INSTRUCTION) {
         throw new UnsupportedOperationException(
             "Biometric verification not supported by this YubiKey");
       }


### PR DESCRIPTION
YubiKey NEO returns INVALID_INSTRUCTION when metadata is queried. This PR handles the situation and treats it as that BioMetadata is not supported. 