### PR TITLE
[opgp] fix implementation of parseFingerprints

### DIFF
--- a/openpgp/src/main/java/com/yubico/yubikit/openpgp/DiscretionaryDataObjects.java
+++ b/openpgp/src/main/java/com/yubico/yubikit/openpgp/DiscretionaryDataObjects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,8 +151,8 @@ public class DiscretionaryDataObjects {
     KeyRef[] refs = KeyRef.values();
     Map<KeyRef, byte[]> fingerprints = new HashMap<>();
     ByteBuffer buf = ByteBuffer.wrap(encoded);
-    byte[] fingerprint = new byte[20];
     for (int i = 0; buf.remaining() > 0; i++) {
+      byte[] fingerprint = new byte[20];
       buf.get(fingerprint);
       fingerprints.put(refs[i], fingerprint);
     }

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/openpgp/OpenPgpTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/openpgp/OpenPgpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,11 @@ public class OpenPgpTests {
     @Test
     public void testGenerateEcKeys() throws Throwable {
       withOpenPgpSession(OpenPgpDeviceTests::testGenerateEcKeys);
+    }
+
+    @Test
+    public void testFingerprintOperations() throws Throwable {
+      withOpenPgpSession(OpenPgpDeviceTests::testFingerprintOperations);
     }
 
     @Test

--- a/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/openpgp/OpenPgpTests.java
+++ b/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/openpgp/OpenPgpTests.java
@@ -85,6 +85,11 @@ public class OpenPgpTests {
     }
 
     @Test
+    public void testFingerprintOperations() throws Throwable {
+      withOpenPgpSession(OpenPgpDeviceTests::testFingerprintOperations);
+    }
+
+    @Test
     public void testGenerateEd25519() throws Throwable {
       withOpenPgpSession(OpenPgpDeviceTests::testGenerateEd25519);
     }


### PR DESCRIPTION
Fixes a bug where all parsed fingerprints shared the same buffer:
* Moved the fingerprint buffer allocation inside the loop in `parseFingerprints` to ensure each fingerprint is a distinct byte array, preventing unintended overwriting.
* Added device tests

Fixes #220 
