### PR TITLE
Unify use of abbreviations in identifiers

### DIFF
--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/Ctap2Session.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/Ctap2Session.java
@@ -749,7 +749,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
     private final int minPinLength;
     @Nullable private final Integer firmwareVersion;
     private final int maxCredBlobLength;
-    private final int maxRPIDsForSetMinPinLength;
+    private final int maxRpidsForSetMinPinLength;
     @Nullable private final Integer preferredPlatformUvAttempts;
     private final int uvModality;
     private final Map<String, Object> certifications;
@@ -761,7 +761,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
     @Nullable private final byte[] encIdentifier;
     private final List<String> transportsForReset;
     @Nullable private final Boolean pinComplexityPolicy;
-    @Nullable private final byte[] pinComplexityPolicyURL;
+    @Nullable private final byte[] pinComplexityPolicyUrl;
     private final int maxPinLength;
 
     private InfoData(
@@ -780,7 +780,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
         int minPinLength,
         @Nullable Integer firmwareVersion,
         int maxCredBlobLength,
-        int maxRPIDsForSetMinPinLength,
+        int maxRpidsForSetMinPinLength,
         @Nullable Integer preferredPlatformUvAttempts,
         int uvModality,
         Map<String, Object> certifications,
@@ -792,7 +792,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
         @Nullable byte[] encIdentifier,
         List<String> transportsForReset,
         @Nullable Boolean pinComplexityPolicy,
-        @Nullable byte[] pinComplexityPolicyURL,
+        @Nullable byte[] pinComplexityPolicyUrl,
         int maxPinLength) {
       this.versions = versions;
       this.extensions = extensions;
@@ -809,7 +809,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
       this.minPinLength = minPinLength;
       this.firmwareVersion = firmwareVersion;
       this.maxCredBlobLength = maxCredBlobLength;
-      this.maxRPIDsForSetMinPinLength = maxRPIDsForSetMinPinLength;
+      this.maxRpidsForSetMinPinLength = maxRpidsForSetMinPinLength;
       this.preferredPlatformUvAttempts = preferredPlatformUvAttempts;
       this.uvModality = uvModality;
       this.certifications = certifications;
@@ -821,7 +821,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
       this.encIdentifier = encIdentifier;
       this.transportsForReset = transportsForReset;
       this.pinComplexityPolicy = pinComplexityPolicy;
-      this.pinComplexityPolicyURL = pinComplexityPolicyURL;
+      this.pinComplexityPolicyUrl = pinComplexityPolicyUrl;
       this.maxPinLength = maxPinLength;
     }
 
@@ -1069,8 +1069,8 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250228/fido-client-to-authenticator-protocol-v2.2-ps-20250228.html#getinfo-maxrpidsforsetminpinlength">Setting
      *     a minimum PIN Length</a>
      */
-    public int getMaxRPIDsForSetMinPinLength() {
-      return maxRPIDsForSetMinPinLength;
+    public int getMaxRpidsForSetMinPinLength() {
+      return maxRpidsForSetMinPinLength;
     }
 
     /**
@@ -1198,7 +1198,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
 
     /**
      * If present, returns whether the authenticator is enforcing an additional current PIN
-     * complexity policy beyond {@code minPINLength}. PIN complexity policies for authenticators are
+     * complexity policy beyond {@code minPinLength}. PIN complexity policies for authenticators are
      * listed in the FIDO MDS. The authenticator may have a pre-configured PIN complexity policy
      * value that is applied after a reset.
      *
@@ -1219,8 +1219,8 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
      * @return the URL providing more information about the enforced PIN policy
      */
     @Nullable
-    public byte[] getPinComplexityPolicyURL() {
-      return pinComplexityPolicyURL;
+    public byte[] getPinComplexityPolicyUrl() {
+      return pinComplexityPolicyUrl;
     }
 
     /**
@@ -1290,7 +1290,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
           + ", maxCredBlobLength="
           + maxCredBlobLength
           + ", maxRPIDsForSetMinPinLength="
-          + maxRPIDsForSetMinPinLength
+          + maxRpidsForSetMinPinLength
           + ", preferredPlatformUvAttempts="
           + preferredPlatformUvAttempts
           + ", uvModality="
@@ -1314,7 +1314,7 @@ public class Ctap2Session extends ApplicationSession<Ctap2Session> {
           + ", pinComplexityPolicy="
           + pinComplexityPolicy
           + ", pinComplexityPolicyURL="
-          + (pinComplexityPolicyURL != null ? StringUtils.bytesToHex(pinComplexityPolicyURL) : null)
+          + (pinComplexityPolicyUrl != null ? StringUtils.bytesToHex(pinComplexityPolicyUrl) : null)
           + ", maxPINLength="
           + maxPinLength
           + '}';

--- a/fido/src/main/java/com/yubico/yubikit/fido/webauthn/AuthenticatorData.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/webauthn/AuthenticatorData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,21 +77,21 @@ public class AuthenticatorData {
     final byte flags = buffer.get();
     final int signCount = buffer.order(ByteOrder.BIG_ENDIAN).getInt();
 
-    boolean flagAT = getFlag(flags, FLAG_AT);
-    boolean flagED = getFlag(flags, FLAG_ED);
+    boolean flagAt = getFlag(flags, FLAG_AT);
+    boolean flagEd = getFlag(flags, FLAG_ED);
 
     AttestedCredentialData attestedCredentialData =
-        flagAT ? AttestedCredentialData.parseFrom(buffer) : null;
+        flagAt ? AttestedCredentialData.parseFrom(buffer) : null;
 
-    if (!flagED && buffer.hasRemaining()) {
+    if (!flagEd && buffer.hasRemaining()) {
       throw new IllegalArgumentException("Unexpected extensions data");
     }
 
-    if (flagED && !buffer.hasRemaining()) {
+    if (flagEd && !buffer.hasRemaining()) {
       throw new IllegalArgumentException("Missing extensions data");
     }
 
-    Map<String, ?> extensions = flagED ? (Map<String, ?>) Cbor.decodeFrom(buffer) : null;
+    Map<String, ?> extensions = flagEd ? (Map<String, ?>) Cbor.decodeFrom(buffer) : null;
 
     // there should not be anything more in the buffer at this point
     if (buffer.hasRemaining()) {

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/CoreInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/CoreInstrumentedTests.java
@@ -19,7 +19,7 @@ package com.yubico.yubikit.testing.framework;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.core.CoreTestState;
 
-public class CoreInstrumentedTests extends YKInstrumentedTests {
+public class CoreInstrumentedTests extends YkInstrumentedTests {
   protected void withState(TestState.StatefulDeviceCallback<CoreTestState> callback)
       throws Throwable {
     final CoreTestState state =

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/FidoInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/FidoInstrumentedTests.java
@@ -30,7 +30,7 @@ import com.yubico.yubikit.testing.fido.FidoTestState;
 import java.util.Arrays;
 import java.util.List;
 
-public class FidoInstrumentedTests extends YKInstrumentedTests {
+public class FidoInstrumentedTests extends YkInstrumentedTests {
 
   public static List<Class<? extends YubiKeyConnection>> connectionTypes =
       Arrays.asList(FidoConnection.class, SmartCardConnection.class);

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/ManagementInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/ManagementInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.yubico.yubikit.testing.framework;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
 import com.yubico.yubikit.management.ManagementSession;
 
-public class ManagementInstrumentedTests extends YKInstrumentedTests {
+public class ManagementInstrumentedTests extends YkInstrumentedTests {
 
   public interface Callback {
     void invoke(ManagementSession value) throws Throwable;

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/MpeInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/MpeInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import com.yubico.yubikit.piv.PivSession;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.mpe.MpeTestState;
 
-public class MpeInstrumentedTests extends YKInstrumentedTests {
+public class MpeInstrumentedTests extends YkInstrumentedTests {
 
   protected void withPivSession(
       TestState.StatefulSessionCallback<PivSession, MpeTestState> callback) throws Throwable {

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/NeoInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/NeoInstrumentedTests.java
@@ -18,7 +18,7 @@ package com.yubico.yubikit.testing.framework;
 
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
 
-public class NeoInstrumentedTests extends YKInstrumentedTests {
+public class NeoInstrumentedTests extends YkInstrumentedTests {
 
   public interface SmartCardConnectionCallback {
     void invoke(SmartCardConnection value) throws Throwable;

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/OathInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/OathInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.yubico.yubikit.oath.OathSession;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.oath.OathTestState;
 
-public class OathInstrumentedTests extends YKInstrumentedTests {
+public class OathInstrumentedTests extends YkInstrumentedTests {
 
   protected void withDevice(TestState.StatefulDeviceCallback<OathTestState> callback)
       throws Throwable {

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/OpenPgpInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/OpenPgpInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022,2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.yubico.yubikit.openpgp.OpenPgpSession;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.openpgp.OpenPgpTestState;
 
-public class OpenPgpInstrumentedTests extends YKInstrumentedTests {
+public class OpenPgpInstrumentedTests extends YkInstrumentedTests {
   protected void withOpenPgpSession(
       TestState.StatefulSessionCallback<OpenPgpSession, OpenPgpTestState> callback)
       throws Throwable {

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/PivInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/PivInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.yubico.yubikit.piv.PivSession;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.piv.PivTestState;
 
-public class PivInstrumentedTests extends YKInstrumentedTests {
+public class PivInstrumentedTests extends YkInstrumentedTests {
   protected void withPivSession(
       TestState.StatefulSessionCallback<PivSession, PivTestState> callback) throws Throwable {
     final PivTestState state = new PivTestState.Builder(device, usbPid).scpKid(getScpKid()).build();

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/SecurityDomainInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/SecurityDomainInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.yubico.yubikit.testing.framework;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.sd.SecurityDomainTestState;
 
-public class SecurityDomainInstrumentedTests extends YKInstrumentedTests {
+public class SecurityDomainInstrumentedTests extends YkInstrumentedTests {
 
   protected void withState(TestState.StatefulDeviceCallback<SecurityDomainTestState> callback)
       throws Throwable {

--- a/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YkInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/testing/framework/YkInstrumentedTests.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 
-public class YKInstrumentedTests {
+public class YkInstrumentedTests {
 
   private TestActivity activity;
   protected YubiKeyDevice device = null;

--- a/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/CoreInstrumentedTests.java
+++ b/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/CoreInstrumentedTests.java
@@ -19,7 +19,7 @@ package com.yubico.yubikit.testing.desktop.framework;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.core.CoreTestState;
 
-public class CoreInstrumentedTests extends YKInstrumentedTests {
+public class CoreInstrumentedTests extends YkInstrumentedTests {
 
   protected void withState(TestState.StatefulDeviceCallback<CoreTestState> callback)
       throws Throwable {

--- a/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/FidoInstrumentedTests.java
+++ b/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/FidoInstrumentedTests.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.jetbrains.annotations.Nullable;
 
-public class FidoInstrumentedTests extends YKInstrumentedTests {
+public class FidoInstrumentedTests extends YkInstrumentedTests {
 
   public static List<Class<? extends YubiKeyConnection>> connectionTypes =
       Arrays.asList(FidoConnection.class, SmartCardConnection.class);

--- a/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/ManagementInstrumentedTests.java
+++ b/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/ManagementInstrumentedTests.java
@@ -18,7 +18,7 @@ package com.yubico.yubikit.testing.desktop.framework;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
 import com.yubico.yubikit.management.ManagementSession;
 
-public class ManagementInstrumentedTests extends YKInstrumentedTests {
+public class ManagementInstrumentedTests extends YkInstrumentedTests {
 
   public interface Callback {
     void invoke(ManagementSession value) throws Throwable;

--- a/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/MpeInstrumentedTests.java
+++ b/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/MpeInstrumentedTests.java
@@ -20,7 +20,7 @@ import com.yubico.yubikit.piv.PivSession;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.mpe.MpeTestState;
 
-public class MpeInstrumentedTests extends YKInstrumentedTests {
+public class MpeInstrumentedTests extends YkInstrumentedTests {
 
   protected void withPivSession(
       TestState.StatefulSessionCallback<PivSession, MpeTestState> callback) throws Throwable {

--- a/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/OathInstrumentedTests.java
+++ b/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/OathInstrumentedTests.java
@@ -19,7 +19,7 @@ import com.yubico.yubikit.oath.OathSession;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.oath.OathTestState;
 
-public class OathInstrumentedTests extends YKInstrumentedTests {
+public class OathInstrumentedTests extends YkInstrumentedTests {
 
   protected void withDevice(TestState.StatefulDeviceCallback<OathTestState> callback)
       throws Throwable {

--- a/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/OpenPgpInstrumentedTests.java
+++ b/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/OpenPgpInstrumentedTests.java
@@ -19,7 +19,7 @@ import com.yubico.yubikit.openpgp.OpenPgpSession;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.openpgp.OpenPgpTestState;
 
-public class OpenPgpInstrumentedTests extends YKInstrumentedTests {
+public class OpenPgpInstrumentedTests extends YkInstrumentedTests {
   protected void withOpenPgpSession(
       TestState.StatefulSessionCallback<OpenPgpSession, OpenPgpTestState> callback)
       throws Throwable {

--- a/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/PivInstrumentedTests.java
+++ b/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/PivInstrumentedTests.java
@@ -21,7 +21,7 @@ import com.yubico.yubikit.testing.piv.PivTestState;
 import java.security.Security;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
-public class PivInstrumentedTests extends YKInstrumentedTests {
+public class PivInstrumentedTests extends YkInstrumentedTests {
 
   protected void withPivSession(
       TestState.StatefulSessionCallback<PivSession, PivTestState> callback) throws Throwable {

--- a/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/SecurityDomainInstrumentedTests.java
+++ b/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/SecurityDomainInstrumentedTests.java
@@ -18,7 +18,7 @@ package com.yubico.yubikit.testing.desktop.framework;
 import com.yubico.yubikit.testing.TestState;
 import com.yubico.yubikit.testing.sd.SecurityDomainTestState;
 
-public class SecurityDomainInstrumentedTests extends YKInstrumentedTests {
+public class SecurityDomainInstrumentedTests extends YkInstrumentedTests {
 
   protected void withState(TestState.StatefulDeviceCallback<SecurityDomainTestState> callback)
       throws Throwable {

--- a/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/YkInstrumentedTests.java
+++ b/testing-desktop/src/main/java/com/yubico/yubikit/testing/desktop/framework/YkInstrumentedTests.java
@@ -26,7 +26,7 @@ import org.junit.Rule;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestName;
 
-public class YKInstrumentedTests {
+public class YkInstrumentedTests {
 
   private final DesktopTestDriver testDriver = new DesktopTestDriver();
 

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/Ctap2SessionTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/Ctap2SessionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Yubico.
+ * Copyright (C) 2020-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class Ctap2SessionTests {
     assertEquals("Option 'plat' incorrect", false, options.get("plat"));
     assertEquals("Option 'rk' incorrect", true, options.get("rk"));
     assertEquals("Option 'up' incorrect", true, options.get("up"));
-    assertTrue("Options do not contain 'clientPIN'", options.containsKey("clientPin"));
+    assertTrue("Options do not contain 'clientPin'", options.containsKey("clientPin"));
 
     // Check PIN/UV Auth protocol
     List<Integer> pinUvAuthProtocols = info.getPinUvAuthProtocols();


### PR DESCRIPTION
This PR changes identifiers which used abbreviations in capitalized form and treats such abbreviations like normal words. 

Examples: 

`YKInstrumentedTests` -> `YkInstrumentedTests`
`getPinComplexityPolicyURL()` -> `getPinComplexityPolicyUrl()`
`getMaxRPIDsForSetMinPinLength()` -> `getMaxRpidsForSetMinPinLength()`

Breaks public API.

