### PR TITLE
[FIDO] Add human-readable error names to CtapException

### DIFF
--- a/core/src/main/java/com/yubico/yubikit/core/fido/CtapException.java
+++ b/core/src/main/java/com/yubico/yubikit/core/fido/CtapException.java
@@ -15,8 +15,12 @@
  */
 package com.yubico.yubikit.core.fido;
 
+import static java.util.Collections.unmodifiableMap;
+
 import com.yubico.yubikit.core.application.CommandException;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * An error on the CTAP-level, returned from the Authenticator.
@@ -84,15 +88,110 @@ public class CtapException extends CommandException {
   public static final byte ERR_VENDOR_FIRST = (byte) 0xF0;
   public static final byte ERR_VENDOR_LAST = (byte) 0xFF;
 
+  private static final Map<Byte, String> ERROR_NAMES = createErrorNamesMap();
+
   private final byte ctapError;
 
+  /**
+   * Constructs a new CtapException with the specified CTAP error code.
+   *
+   * @param ctapError the CTAP error code returned from the authenticator
+   */
   public CtapException(byte ctapError) {
-    super(String.format(Locale.ROOT, "CTAP error: 0x%02x", ctapError));
+    super(
+        String.format(Locale.ROOT, "CTAP error: %s (0x%02x)", getErrorName(ctapError), ctapError));
 
     this.ctapError = ctapError;
   }
 
+  /**
+   * Returns the CTAP error code associated with this exception.
+   *
+   * @return the CTAP error code
+   */
   public byte getCtapError() {
     return ctapError;
+  }
+
+  /**
+   * Returns the name of the CTAP error associated with this exception.
+   *
+   * @return the CTAP error name as a String
+   */
+  public String getErrorName() {
+    return getErrorName(ctapError);
+  }
+
+  private static String getErrorName(byte error) {
+    String name = ERROR_NAMES.get(error);
+    if (name != null) {
+      return name;
+    }
+
+    int errorUnsigned = error & 0xFF;
+    if (errorUnsigned >= (ERR_EXTENSION_FIRST & 0xFF)
+        && errorUnsigned <= (ERR_EXTENSION_LAST & 0xFF)) {
+      return "EXTENSION_ERROR";
+    } else if (errorUnsigned >= (ERR_VENDOR_FIRST & 0xFF)) {
+      return "VENDOR_ERROR";
+    } else {
+      // Unknown error within spec range (0x00-0xDF)
+      return "UNKNOWN";
+    }
+  }
+
+  private static Map<Byte, String> createErrorNamesMap() {
+    Map<Byte, String> map = new HashMap<>();
+    map.put(ERR_SUCCESS, "SUCCESS");
+    map.put(ERR_INVALID_COMMAND, "INVALID_COMMAND");
+    map.put(ERR_INVALID_PARAMETER, "INVALID_PARAMETER");
+    map.put(ERR_INVALID_LENGTH, "INVALID_LENGTH");
+    map.put(ERR_INVALID_SEQ, "INVALID_SEQ");
+    map.put(ERR_TIMEOUT, "TIMEOUT");
+    map.put(ERR_CHANNEL_BUSY, "CHANNEL_BUSY");
+    map.put(ERR_LOCK_REQUIRED, "LOCK_REQUIRED");
+    map.put(ERR_INVALID_CHANNEL, "INVALID_CHANNEL");
+    map.put(ERR_CBOR_UNEXPECTED_TYPE, "CBOR_UNEXPECTED_TYPE");
+    map.put(ERR_INVALID_CBOR, "INVALID_CBOR");
+    map.put(ERR_MISSING_PARAMETER, "MISSING_PARAMETER");
+    map.put(ERR_LIMIT_EXCEEDED, "LIMIT_EXCEEDED");
+    map.put(ERR_UNSUPPORTED_EXTENSION, "UNSUPPORTED_EXTENSION");
+    map.put(ERR_FP_DATABASE_FULL, "FP_DATABASE_FULL");
+    map.put(ERR_LARGE_BLOB_STORAGE_FULL, "LARGE_BLOB_STORAGE_FULL");
+    map.put(ERR_CREDENTIAL_EXCLUDED, "CREDENTIAL_EXCLUDED");
+    map.put(ERR_PROCESSING, "PROCESSING");
+    map.put(ERR_INVALID_CREDENTIAL, "INVALID_CREDENTIAL");
+    map.put(ERR_USER_ACTION_PENDING, "USER_ACTION_PENDING");
+    map.put(ERR_OPERATION_PENDING, "OPERATION_PENDING");
+    map.put(ERR_NO_OPERATIONS, "NO_OPERATIONS");
+    map.put(ERR_UNSUPPORTED_ALGORITHM, "UNSUPPORTED_ALGORITHM");
+    map.put(ERR_OPERATION_DENIED, "OPERATION_DENIED");
+    map.put(ERR_KEY_STORE_FULL, "KEY_STORE_FULL");
+    map.put(ERR_NOT_BUSY, "NOT_BUSY");
+    map.put(ERR_NO_OPERATION_PENDING, "NO_OPERATION_PENDING");
+    map.put(ERR_UNSUPPORTED_OPTION, "UNSUPPORTED_OPTION");
+    map.put(ERR_INVALID_OPTION, "INVALID_OPTION");
+    map.put(ERR_KEEPALIVE_CANCEL, "KEEPALIVE_CANCEL");
+    map.put(ERR_NO_CREDENTIALS, "NO_CREDENTIALS");
+    map.put(ERR_USER_ACTION_TIMEOUT, "USER_ACTION_TIMEOUT");
+    map.put(ERR_NOT_ALLOWED, "NOT_ALLOWED");
+    map.put(ERR_PIN_INVALID, "PIN_INVALID");
+    map.put(ERR_PIN_BLOCKED, "PIN_BLOCKED");
+    map.put(ERR_PIN_AUTH_INVALID, "PIN_AUTH_INVALID");
+    map.put(ERR_PIN_AUTH_BLOCKED, "PIN_AUTH_BLOCKED");
+    map.put(ERR_PIN_NOT_SET, "PIN_NOT_SET");
+    map.put(ERR_PUAT_REQUIRED, "PUAT_REQUIRED");
+    map.put(ERR_PIN_POLICY_VIOLATION, "PIN_POLICY_VIOLATION");
+    map.put(ERR_PIN_TOKEN_EXPIRED, "PIN_TOKEN_EXPIRED");
+    map.put(ERR_REQUEST_TOO_LARGE, "REQUEST_TOO_LARGE");
+    map.put(ERR_ACTION_TIMEOUT, "ACTION_TIMEOUT");
+    map.put(ERR_UP_REQUIRED, "UP_REQUIRED");
+    map.put(ERR_UV_BLOCKED, "UV_BLOCKED");
+    map.put(ERR_INTEGRITY_FAILURE, "INTEGRITY_FAILURE");
+    map.put(ERR_INVALID_SUBCOMMAND, "INVALID_SUBCOMMAND");
+    map.put(ERR_UV_INVALID, "UV_INVALID");
+    map.put(ERR_UNAUTHORIZED_PERMISSION, "UNAUTHORIZED_PERMISSION");
+    map.put(ERR_OTHER, "OTHER");
+    return unmodifiableMap(map);
   }
 }

--- a/core/src/test/java/com/yubico/yubikit/core/fido/CtapExceptionTest.java
+++ b/core/src/test/java/com/yubico/yubikit/core/fido/CtapExceptionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.core.fido;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class CtapExceptionTest {
+  @Test
+  public void testKnownErrorCode() {
+    CtapException ex = new CtapException(CtapException.ERR_INVALID_COMMAND);
+    assertEquals(CtapException.ERR_INVALID_COMMAND, ex.getCtapError());
+    assertEquals("INVALID_COMMAND", ex.getErrorName());
+    assertTrue(ex.getMessage().contains("INVALID_COMMAND"));
+    assertTrue(ex.getMessage().contains("0x01"));
+  }
+
+  @Test
+  public void testUnknownErrorCode() {
+    // Test unknown error in the middle of spec range
+    byte unknown = (byte) 0x55;
+    CtapException ex = new CtapException(unknown);
+    assertEquals(unknown, ex.getCtapError());
+    assertEquals("UNKNOWN", ex.getErrorName());
+    assertTrue(ex.getMessage().contains("UNKNOWN"));
+    assertTrue(ex.getMessage().contains("0x55"));
+
+    // Test unknown error at ERR_SPEC_LAST boundary
+    byte unknownAtBoundary = CtapException.ERR_SPEC_LAST;
+    CtapException exAtBoundary = new CtapException(unknownAtBoundary);
+    assertEquals(unknownAtBoundary, exAtBoundary.getCtapError());
+    assertEquals("UNKNOWN", exAtBoundary.getErrorName());
+    assertTrue(exAtBoundary.getMessage().contains("UNKNOWN"));
+    assertTrue(exAtBoundary.getMessage().contains("0xdf"));
+
+    // Test unknown error just before ERR_SPEC_LAST
+    byte unknownBeforeBoundary = (byte) 0xDE;
+    CtapException exBeforeBoundary = new CtapException(unknownBeforeBoundary);
+    assertEquals(unknownBeforeBoundary, exBeforeBoundary.getCtapError());
+    assertEquals("UNKNOWN", exBeforeBoundary.getErrorName());
+    assertTrue(exBeforeBoundary.getMessage().contains("UNKNOWN"));
+    assertTrue(exBeforeBoundary.getMessage().contains("0xde"));
+  }
+
+  @Test
+  public void testExtensionErrorCode() {
+    // Test extension range boundary - first
+    byte extensionFirst = CtapException.ERR_EXTENSION_FIRST;
+    CtapException exFirst = new CtapException(extensionFirst);
+    assertEquals(extensionFirst, exFirst.getCtapError());
+    assertEquals("EXTENSION_ERROR", exFirst.getErrorName());
+    assertTrue(exFirst.getMessage().contains("EXTENSION_ERROR"));
+    assertTrue(exFirst.getMessage().contains("0xe0"));
+
+    // Test extension range middle
+    byte extension = (byte) 0xE1;
+    CtapException ex = new CtapException(extension);
+    assertEquals(extension, ex.getCtapError());
+    assertEquals("EXTENSION_ERROR", ex.getErrorName());
+    assertTrue(ex.getMessage().contains("EXTENSION_ERROR"));
+    assertTrue(ex.getMessage().contains("0xe1"));
+
+    // Test extension range boundary - last
+    byte extensionLast = CtapException.ERR_EXTENSION_LAST;
+    CtapException exLast = new CtapException(extensionLast);
+    assertEquals(extensionLast, exLast.getCtapError());
+    assertEquals("EXTENSION_ERROR", exLast.getErrorName());
+    assertTrue(exLast.getMessage().contains("EXTENSION_ERROR"));
+    assertTrue(exLast.getMessage().contains("0xef"));
+  }
+
+  @Test
+  public void testVendorErrorCode() {
+    // Test vendor range boundary - first
+    byte vendorFirst = CtapException.ERR_VENDOR_FIRST;
+    CtapException exFirst = new CtapException(vendorFirst);
+    assertEquals(vendorFirst, exFirst.getCtapError());
+    assertEquals("VENDOR_ERROR", exFirst.getErrorName());
+    assertTrue(exFirst.getMessage().contains("VENDOR_ERROR"));
+    assertTrue(exFirst.getMessage().contains("0xf0"));
+
+    // Test vendor range middle
+    byte vendor = (byte) 0xF2;
+    CtapException ex = new CtapException(vendor);
+    assertEquals(vendor, ex.getCtapError());
+    assertEquals("VENDOR_ERROR", ex.getErrorName());
+    assertTrue(ex.getMessage().contains("VENDOR_ERROR"));
+    assertTrue(ex.getMessage().contains("0xf2"));
+
+    // Test vendor range boundary - last
+    byte vendorLast = CtapException.ERR_VENDOR_LAST;
+    CtapException exLast = new CtapException(vendorLast);
+    assertEquals(vendorLast, exLast.getCtapError());
+    assertEquals("VENDOR_ERROR", exLast.getErrorName());
+    assertTrue(exLast.getMessage().contains("VENDOR_ERROR"));
+    assertTrue(exLast.getMessage().contains("0xff"));
+  }
+
+  @Test
+  public void testAllKnownErrorNames() {
+    // Spot check a few known error codes
+    assertEquals("SUCCESS", new CtapException(CtapException.ERR_SUCCESS).getErrorName());
+    assertEquals(
+        "INVALID_PARAMETER", new CtapException(CtapException.ERR_INVALID_PARAMETER).getErrorName());
+    assertEquals("TIMEOUT", new CtapException(CtapException.ERR_TIMEOUT).getErrorName());
+    assertEquals("PIN_INVALID", new CtapException(CtapException.ERR_PIN_INVALID).getErrorName());
+    assertEquals("OTHER", new CtapException(CtapException.ERR_OTHER).getErrorName());
+    assertEquals("INVALID_CBOR", new CtapException(CtapException.ERR_INVALID_CBOR).getErrorName());
+    assertEquals(
+        "PIN_POLICY_VIOLATION",
+        new CtapException(CtapException.ERR_PIN_POLICY_VIOLATION).getErrorName());
+  }
+}

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2ClientPinInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/testing/fido/Ctap2ClientPinInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,11 @@ public class Ctap2ClientPinInstrumentedTests {
     @Test
     public void testPinComplexity() throws Throwable {
       withDevice(Ctap2ClientPinTests::testPinComplexity);
+    }
+
+    @Test
+    public void testCtapExceptionMessage() throws Throwable {
+      withCtap2Session(Ctap2ClientPinTests::testCtapExceptionMessage);
     }
   }
 

--- a/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/Ctap2ClientPinInstrumentedTests.java
+++ b/testing-desktop/src/integrationTest/java/com/yubico/yubikit/testing/desktop/fido/Ctap2ClientPinInstrumentedTests.java
@@ -41,6 +41,11 @@ public class Ctap2ClientPinInstrumentedTests {
     public void testPinComplexity() throws Throwable {
       withDevice(Ctap2ClientPinTests::testPinComplexity);
     }
+
+    @Test
+    public void testCtapExceptionMessage() throws Throwable {
+      withCtap2Session(Ctap2ClientPinTests::testCtapExceptionMessage);
+    }
   }
 
   @Category(PinUvAuthProtocolV1Test.class)

--- a/testing/src/main/java/com/yubico/yubikit/testing/fido/Ctap2ClientPinTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/testing/fido/Ctap2ClientPinTests.java
@@ -102,4 +102,22 @@ public class Ctap2ClientPinTests {
           assertThat(pin.getPinRetries().getCount(), is(8));
         });
   }
+
+  public static void testCtapExceptionMessage(Ctap2Session session, FidoTestState state)
+      throws Throwable {
+    ClientPin pin = new ClientPin(session, state.getPinUvAuthProtocol());
+
+    try {
+      pin.getPinToken(
+          TestData.OTHER_PIN,
+          ClientPin.PIN_PERMISSION_MC | ClientPin.PIN_PERMISSION_GA,
+          "localhost");
+      fail("Wrong PIN was accepted");
+    } catch (CtapException e) {
+      assertThat(e.getCtapError(), is(CtapException.ERR_PIN_INVALID));
+      assertThat(e.getMessage().contains("PIN_INVALID"), is(true));
+      assertThat(e.getMessage().contains("0x31"), is(true));
+      assertThat(e.getErrorName(), is("PIN_INVALID"));
+    }
+  }
 }


### PR DESCRIPTION
This pull request enhances the `CtapException` class to provide more descriptive error messages and error name lookups for CTAP error codes. It introduces a mapping from error codes to human-readable names, updates the exception message formatting, and adds comprehensive unit and integration tests to verify the new behavior.

**Enhancements to error handling and reporting:**

* The `CtapException` class now maps CTAP error codes to descriptive error names, and includes these names in exception messages for improved clarity. Unknown, extension, and vendor error codes are handled with appropriate labels ("UNKNOWN", "EXTENSION_ERROR", "VENDOR_ERROR").
* The constructor and API of `CtapException` have been updated to support error name retrieval via a new `getErrorName()` method.

**Testing improvements:**

* A new unit test class, `CtapExceptionTest`, has been added to thoroughly test the error name mapping, message formatting, and handling of known, unknown, extension, and vendor error codes.
* New integration tests for both Android and desktop environments verify that `CtapException` messages and error names behave as expected during client PIN operations. [[1]](diffhunk://#diff-1f9a73d1a0f0937f9d3f8e9cc26f39c5faab156d175c9f38bfc81452147d0611R44-R48) [[2]](diffhunk://#diff-acc8b6ec0a99a8117660d9688d456b55380b7d5ba604fed7da112e767495fa53R44-R48) [[3]](diffhunk://#diff-0a71570bd1244ca0b3d2b2d40bc18f1fb9c1c6974f549188cb2c1e1eb24ef0ccR105-R122)

**Other changes:**

* Copyright years updated to 2025 where relevant.