### PR TITLE
feat: added Brave Browser SHA256 cert hash to allow list

### DIFF
--- a/fido-android-provider-service/src/main/java/com/yubico/yubikit/fido/android/provider_service/YubiKitProviderService.kt
+++ b/fido-android-provider-service/src/main/java/com/yubico/yubikit/fido/android/provider_service/YubiKitProviderService.kt
@@ -221,6 +221,18 @@ class YubiKitProviderService : CredentialProviderService() {
                 {
                   "type": "android",
                   "info": {
+                    "package_name": "com.brave.browser",
+                    "signatures": [
+                      {
+                        "build": "release",
+                        "cert_fingerprint_sha256": "9C:2D:B7:05:13:51:5F:DB:FB:BC:58:5B:3E:DF:3D:71:23:D4:DC:67:C9:4F:FD:30:63:61:C1:D7:9B:BF:18:AC"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "android",
+                  "info": {
                     "package_name": "com.google.android.gms",
                     "signatures": [
                       {


### PR DESCRIPTION
This pull request adds support for the Brave browser to the allowlist of trusted Android applications in the `YubiKitProviderService`.

Allowlist update:

* Added an entry for the Brave browser (`com.brave.browser`) with its release build signature to the list of trusted Android applications in `YubiKitProviderService.kt`.

Cert SHA 256 hash retrieved using [APK Analyzer](https://github.com/MartinStyk/AndroidApkAnalyzer):
`9C:2D:B7:05:13:51:5F:DB:FB:BC:58:5B:3E:DF:3D:71:23:D4:DC:67:C9:4F:FD:30:63:61:C1:D7:9B:BF:18:AC`