### PR TITLE
Update FIDO documentation references to CTAP2.3

### DIFF
--- a/core/src/main/java/com/yubico/yubikit/core/fido/CtapException.java
+++ b/core/src/main/java/com/yubico/yubikit/core/fido/CtapException.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * An error on the CTAP-level, returned from the Authenticator.
  *
  * <p>These error codes are defined by the <a
- * href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#error-responses">CTAP2
+ * href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#error-responses">CTAP2
  * Status codes</a>
  */
 public class CtapException extends CommandException {

--- a/core/src/main/java/com/yubico/yubikit/core/fido/FidoProtocol.java
+++ b/core/src/main/java/com/yubico/yubikit/core/fido/FidoProtocol.java
@@ -47,7 +47,7 @@ public class FidoProtocol implements Closeable {
    * Protocol capabilities
    *
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#usb-hid-init">CTAPHID_INIT</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#usb-hid-init">CTAPHID_INIT</a>
    */
   public static class Capability {
     public static final byte WINK = 0x01;

--- a/fido/README.adoc
+++ b/fido/README.adoc
@@ -2,7 +2,7 @@
 
 The FIDO module enables applications to authenticate WebAuthn credentials on a YubiKey.
 
-The current implementation follows the https://www.w3.org/TR/webauthn-3/[Webauthn Level 3] and https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html[CTAP 2.2] specifications and can include more properties from newer standard versions.
+The current implementation follows the https://www.w3.org/TR/webauthn-3/[Webauthn Level 3] and https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html[CTAP 2.3] specifications and can include more properties from newer standard versions.
 
 https://developers.yubico.com/yubikit-android/JavaDoc/fido/latest/[JavaDoc API documentation]
 

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
@@ -144,7 +144,7 @@ public class Ctap2Client implements WebAuthnClient {
    * @see <a href="https://www.w3.org/TR/webauthn-3/#webauthn-client">Webauthn client</a>
    * @see <a href="https://www.w3.org/TR/webauthn-3/#sctn-extensions">Webauthn extensions</a>
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-defined-extensions">CTAP
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-defined-extensions">CTAP
    *     extensions</a>
    */
   public Ctap2Client(Ctap2Session session) throws IOException, CommandException {
@@ -163,7 +163,7 @@ public class Ctap2Client implements WebAuthnClient {
    * @see <a href="https://www.w3.org/TR/webauthn-3/#webauthn-client">Webauthn client</a>
    * @see <a href="https://www.w3.org/TR/webauthn-3/#sctn-extensions">Webauthn extensions</a>
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-defined-extensions">CTAP
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-defined-extensions">CTAP
    *     extensions</a>
    */
   public Ctap2Client(Ctap2Session session, @Nullable List<Extension> extensions)
@@ -341,7 +341,7 @@ public class Ctap2Client implements WebAuthnClient {
    * @return true if the authenticator is enterprise attestation capable and enterprise attestation
    *     is enabled.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-feature-descriptions-enterp-attstn">Enterprise
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-feature-descriptions-enterp-attstn">Enterprise
    *     Attestation</a>
    */
   public boolean isEnterpriseAttestationSupported() {

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredBlobExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredBlobExtension.java
@@ -30,7 +30,7 @@ import org.jspecify.annotations.Nullable;
  * Implements the Credential Blob (credBlob) CTAP2 extension.
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-credBlob-extension">Credential
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-credBlob-extension">Credential
  *     Blob (credBlob)</a>
  */
 public class CredBlobExtension extends Extension {

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtension.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.Nullable;
  * Implements the Credential Protection CTAP2 extension.
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-credProtect-extension">Credential
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-credProtect-extension">Credential
  *     Protection (credProtect)</a>
  */
 public class CredProtectExtension extends Extension {

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtension.java
@@ -56,10 +56,10 @@ import org.slf4j.LoggerFactory;
  *
  * @see <a href="https://www.w3.org/TR/webauthn-3/#prf-extension">PRF extension</a>
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-extension">HMAC
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-hmac-secret-extension">HMAC
  *     secret extension (hmac-secret)</a>
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-hmac-secret-make-cred-extension">HMAC
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-hmac-secret-make-cred-extension">HMAC
  *     Secret MakeCredential Extension (hmac-secret-mc)</a>
  */
 public class HmacSecretExtension extends Extension {

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * @see <a href="https://www.w3.org/TR/webauthn-3/#sctn-large-blob-extension">Large blob
  *     extension</a>
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-largeBlobKey-extension">Large
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-largeBlobKey-extension">Large
  *     Blob Key (largeBlobKey)</a>
  */
 public class LargeBlobExtension extends Extension {

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/MinPinLengthExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/MinPinLengthExtension.java
@@ -27,7 +27,7 @@ import org.jspecify.annotations.Nullable;
  * Implements the Minimum PIN Length (minPinLength) CTAP2 extension.
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-minpinlength-extension">Minimum
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-minpinlength-extension">Minimum
  *     PIN Length Extension (minPinLength)</a>
  */
 public class MinPinLengthExtension extends Extension {

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtension.java
@@ -37,7 +37,7 @@ import org.jspecify.annotations.Nullable;
  * without a client that supports the WebAuthn payment extension.
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-thirdPartyPayment-extension">Third-Party
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-thirdPartyPayment-extension">Third-Party
  *     Payment authentication (thirdPartyPayment)</a>
  * @see <a href="https://www.w3.org/TR/secure-payment-confirmation">Secure Payment Confirmation</a>
  */

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/BioEnrollment.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/BioEnrollment.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  * Implements Bio enrollment commands.
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorBioEnrollment">authenticatorBioEnrollment</a>
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorBioEnrollment">authenticatorBioEnrollment</a>
  */
 public class BioEnrollment {
   protected static final int RESULT_MODALITY = 0x01;
@@ -64,7 +64,7 @@ public class BioEnrollment {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getUserVerificationModality">Get
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getUserVerificationModality">Get
    *     bio modality</a>
    */
   public static int getModality(Ctap2Session ctap) throws IOException, CommandException {

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/Config.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/Config.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
  * Implements Config commands.
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig">authenticatorConfig</a>
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorConfig">authenticatorConfig</a>
  */
 @SuppressWarnings("unused")
 public class Config {
@@ -119,7 +119,7 @@ public class Config {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enable-enterprise-attestation">Enable
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#enable-enterprise-attestation">Enable
    *     Enterprise Attestation</a>
    */
   public void enableEnterpriseAttestation() throws IOException, CommandException {
@@ -135,7 +135,7 @@ public class Config {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#toggle-alwaysUv">Toggle
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#toggle-alwaysUv">Toggle
    *     Always Require User Verification</a>
    */
   public void toggleAlwaysUv() throws IOException, CommandException {
@@ -155,7 +155,7 @@ public class Config {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#setMinPINLength">Setting
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#setMinPINLength">Setting
    *     a minimum PIN Length</a>
    */
   public void setMinPinLength(
@@ -183,7 +183,7 @@ public class Config {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#vendorPrototype">Vendor
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#vendorPrototype">Vendor
    *     Prototype Command</a>
    */
   public Map<Integer, ?> vendorPrototype(Integer vendorCommandId)

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/Ctap2Session.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/Ctap2Session.java
@@ -54,10 +54,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Implements CTAP 2.2
+ * Implements CTAP 2.3
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html">Client
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html">Client
  *     to Authenticator Protocol (CTAP)</a>
  */
 public class Ctap2Session extends Ctap1Session {
@@ -208,7 +208,7 @@ public class Ctap2Session extends Ctap1Session {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorMakeCredential">authenticatorMakeCredential</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorMakeCredential">authenticatorMakeCredential</a>
    */
   public CredentialData makeCredential(
       byte[] clientDataHash,
@@ -277,9 +277,9 @@ public class Ctap2Session extends Ctap1Session {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorGetAssertion">authenticatorGetAssertion</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorGetAssertion">authenticatorGetAssertion</a>
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorGetNextAssertion">authenticatorGetNextAssertion</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorGetNextAssertion">authenticatorGetNextAssertion</a>
    */
   public List<AssertionData> getAssertions(
       String rpId,
@@ -338,7 +338,7 @@ public class Ctap2Session extends Ctap1Session {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorGetInfo">authenticatorGetInfo</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorGetInfo">authenticatorGetInfo</a>
    */
   public InfoData getInfo() throws IOException, CommandException {
     final Map<Integer, ?> infoData = sendCbor(CMD_GET_INFO, null, null);
@@ -363,7 +363,7 @@ public class Ctap2Session extends Ctap1Session {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorClientPIN">authenticatorClientPIN</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorClientPIN">authenticatorClientPIN</a>
    */
   Map<Integer, ?> clientPin(
       @Nullable Integer pinUvAuthProtocol,
@@ -414,7 +414,7 @@ public class Ctap2Session extends Ctap1Session {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorReset">authenticatorReset</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorReset">authenticatorReset</a>
    */
   public void reset(@Nullable CommandState state) throws IOException, CommandException {
     sendCbor(CMD_RESET, null, state);
@@ -434,7 +434,7 @@ public class Ctap2Session extends Ctap1Session {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorBioEnrollment">authenticatorBioEnrollment</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorBioEnrollment">authenticatorBioEnrollment</a>
    */
   Map<Integer, ?> bioEnrollment(
       @Nullable Integer modality,
@@ -465,7 +465,7 @@ public class Ctap2Session extends Ctap1Session {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorCredentialManagement">authenticatorCredentialManagement</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorCredentialManagement">authenticatorCredentialManagement</a>
    */
   Map<Integer, ?> credentialManagement(
       int subCommand,
@@ -489,7 +489,7 @@ public class Ctap2Session extends Ctap1Session {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorSelection">authenticatorSelection</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorSelection">authenticatorSelection</a>
    */
   public void selection(@Nullable CommandState state) throws IOException, CommandException {
     sendCbor(CMD_SELECTION, null, state);
@@ -509,7 +509,7 @@ public class Ctap2Session extends Ctap1Session {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorLargeBlobs">authenticatorLargeBlobs</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorLargeBlobs">authenticatorLargeBlobs</a>
    */
   public Map<Integer, ?> largeBlobs(
       int offset,
@@ -569,7 +569,7 @@ public class Ctap2Session extends Ctap1Session {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig">authenticatorConfig</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorConfig">authenticatorConfig</a>
    */
   public Map<Integer, ?> config(
       byte subCommand,
@@ -605,7 +605,7 @@ public class Ctap2Session extends Ctap1Session {
    * Data object containing the information readable form a YubiKey using the getInfo command.
    *
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorGetInfo">authenticatorGetInfo</a>
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorGetInfo">authenticatorGetInfo</a>
    */
   public static class InfoData {
     private static final int RESULT_VERSIONS = 0x01;
@@ -810,7 +810,7 @@ public class Ctap2Session extends Ctap1Session {
      * List of supported versions.
      *
      * <p>Supported versions are: {@code FIDO_2_0}, {@code FIDO_2_1_PRE}, {@code FIDO_2_1} and
-     * {@code FIDO_2_2} for CTAP2 / FIDO2 / Web Authentication authenticators and {@code U2F_V2} for
+     * {@code FIDO_2_3} for CTAP2 / FIDO2 / Web Authentication authenticators and {@code U2F_V2} for
      * CTAP1/U2F authenticators.
      *
      * @return list of supported versions
@@ -861,7 +861,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return a list of supported protocol versions
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-pinuvauthprotocols">pinUvAuthProtocols</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-pinuvauthprotocols">pinUvAuthProtocols</a>
      */
     public List<Integer> getPinUvAuthProtocols() {
       return pinUvAuthProtocols;
@@ -921,7 +921,7 @@ public class Ctap2Session extends Ctap1Session {
      * @return maximum size of serialized large-blob array the authenticator can store if {@code
      *     authenticatorLargeBlobs} command is supported by the authenticator, 0 otherwise
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-maxserializedlargeblobarray">authenticatorLargeBlobs</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-maxserializedlargeblobarray">authenticatorLargeBlobs</a>
      */
     public int getMaxSerializedLargeBlobArray() {
       return maxSerializedLargeBlobArray;
@@ -932,8 +932,8 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return force PIN Change requirement
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-forcepinchange">PIN
-     *     Change</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-forcepinchange">Force
+     *     PIN Change</a>
      */
     public boolean getForcePinChange() {
       return forcePinChange;
@@ -948,7 +948,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return current minimum PIN length
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-minpinlength">Minimum
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-minpinlength">Minimum
      *     PIN length</a>
      */
     public int getMinPinLength() {
@@ -970,7 +970,7 @@ public class Ctap2Session extends Ctap1Session {
      * @return maximum credBlob length if the authenticator supports {@code credBlob} extension, 0
      *     otherwise
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-maxcredbloblength">Maximum
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-maxcredbloblength">Maximum
      *     credBlob length</a>
      */
     public int getMaxCredBlobLength() {
@@ -984,8 +984,8 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return the maximum number of RP IDs
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-maxrpidsforsetminpinlength">Setting
-     *     a minimum PIN Length</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-maxrpidsforsetminpinlength">Maximum
+     *     number of RPIDs for setMinPinLength</a>
      */
     public int getMaxRpidsForSetMinPinLength() {
       return maxRpidsForSetMinPinLength;
@@ -998,7 +998,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return the preferred number of {@code getPinUvAuthTokenUsingUvWithPermissions} invocations
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-preferredplatformuvattempts">Preferred
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-preferredplatformuvattempts">Preferred
      *     platfrom UV attempts</a>
      */
     @Nullable
@@ -1025,7 +1025,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return certifications in the form key-value pairs with string IDs and integer values
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-feature-descriptions-certifications">Authenticator
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-feature-descriptions-certifications">Authenticator
      *     Certifications</a>
      */
     public final Map<String, Object> getCertifications() {
@@ -1047,7 +1047,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return list of vendor command id's
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-vendorprototypeconfigcommands">Vendor
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-vendorprototypeconfigcommands">Vendor
      *     prototype config commands</a>
      */
     @Nullable
@@ -1073,7 +1073,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return the count of UV attempts since the last PIN entry
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-uvcountsincelastpinentry">uvCountSinceLastPinEntry</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-uvcountsincelastpinentry">uvCountSinceLastPinEntry</a>
      */
     @Nullable
     public Integer getUvCountSinceLastPinEntry() {
@@ -1094,7 +1094,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return the encrypted identifier
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-encidentifier">encIdentifier</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-encidentifier">encIdentifier</a>
      */
     public byte @Nullable [] getEncIdentifier() {
       return encIdentifier;
@@ -1105,7 +1105,10 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return list of transports that support the reset command
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorReset">authenticatorReset</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-transportsforreset">Transports
+     *     for reset</a>
+     * @see <a
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorReset">authenticatorReset</a>
      * @see <a href="https://www.w3.org/TR/webauthn/#enumdef-authenticatortransport">WebAuthn
      *     Authenticator Transport Enumeration</a>
      */
@@ -1122,7 +1125,7 @@ public class Ctap2Session extends Ctap1Session {
      * @return true if whether the authenticator is enforcing an additional current PIN complexity
      *     policy
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-pincomplexitypolicy">pinComplexityPolicy</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-pincomplexitypolicy">pinComplexityPolicy</a>
      */
     @Nullable
     public Boolean getPinComplexityPolicy() {
@@ -1135,7 +1138,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return the URL providing more information about the enforced PIN policy
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-pincomplexitypolicyurl">pinComplexityPolicyURL</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-pincomplexitypolicyurl">pinComplexityPolicyURL</a>
      */
     public byte @Nullable [] getPinComplexityPolicyUrl() {
       return pinComplexityPolicyUrl;
@@ -1147,7 +1150,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return the maximum PIN length
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-maxpinlength">maxPinLength</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-maxpinlength">maxPinLength</a>
      */
     public int getMaxPinLength() {
       return maxPinLength;
@@ -1158,7 +1161,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return the decrypted encIdentifier
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getinfo-encidentifier">encIdentifier</a>
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-encidentifier">encIdentifier</a>
      */
     public byte @Nullable [] getIdentifier(byte[] persistentPinUvAuthToken)
         throws GeneralSecurityException {
@@ -1172,6 +1175,8 @@ public class Ctap2Session extends Ctap1Session {
      * Get decrypted encCredStoreState.
      *
      * @return the decrypted credStoreState
+     * @see <a
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-enccredstorestate">encCredStoreState</a>
      */
     public byte @Nullable [] getCredStoreState(byte[] persistentPinUvAuthToken)
         throws GeneralSecurityException {
@@ -1185,6 +1190,9 @@ public class Ctap2Session extends Ctap1Session {
      * List of supported authenticator config commands.
      *
      * @return list of supported authenticator config commands.
+     * @see <a
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getinfo-authenticatorconfigcommands">List
+     *     of supported config commands</a>
      */
     @Nullable
     public List<Integer> getAuthenticatorConfigCommands() {
@@ -1378,7 +1386,7 @@ public class Ctap2Session extends Ctap1Session {
    * Data class holding the result of getAssertion.
    *
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
    *     response structure</a>.
    */
   public static class AssertionData {
@@ -1475,7 +1483,7 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return Total number of account credentials for the RP.
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
      *     response structure</a>.
      */
     @Nullable
@@ -1496,7 +1504,7 @@ public class Ctap2Session extends Ctap1Session {
      * @return True if the credential was selected by the user via interaction directly with the
      *     authenticator.
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
      *     response structure</a>.
      */
     @Nullable
@@ -1510,10 +1518,10 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return The contents of the associated largeBlobKey.
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorgetassertion-response-structure">authenticatorGetAssertion
      *     response structure</a>.
      * @see <a
-     *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-largeBlobKey-extension">Large
+     *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#sctn-largeBlobKey-extension">Large
      *     Blob Key Extension</a>.
      */
     public byte @Nullable [] getLargeBlobKey() {

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/FingerprintBioEnrollment.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/FingerprintBioEnrollment.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * Implements Fingerprint Bio Enrollment commands.
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig">authenticatorConfig</a>
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorConfig">authenticatorConfig</a>
  */
 public class FingerprintBioEnrollment extends BioEnrollment {
   private static final int CMD_ENROLL_BEGIN = 0x01;
@@ -286,7 +286,7 @@ public class FingerprintBioEnrollment extends BioEnrollment {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication error in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getFingerprintSensorInfo">Get
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#getFingerprintSensorInfo">Get
    *     fingerprint sensor info</a>
    */
   public SensorInfo getSensorInfo() throws IOException, CommandException {
@@ -313,7 +313,7 @@ public class FingerprintBioEnrollment extends BioEnrollment {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication error in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enrollingFingerprint">Enrolling
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#enrollingFingerprint">Enrolling
    *     fingerprint</a>
    */
   public EnrollBeginStatus enrollBegin(@Nullable Integer timeout, @Nullable CommandState state)
@@ -347,7 +347,7 @@ public class FingerprintBioEnrollment extends BioEnrollment {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication error in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enrollingFingerprint">Enrolling
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#enrollingFingerprint">Enrolling
    *     fingerprint</a>
    */
   public CaptureStatus enrollCaptureNext(
@@ -373,7 +373,7 @@ public class FingerprintBioEnrollment extends BioEnrollment {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication error in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#cancelEnrollment">Cancel
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#cancelEnrollment">Cancel
    *     current enrollment</a>
    */
   public void enrollCancel() throws IOException, CommandException {
@@ -399,7 +399,7 @@ public class FingerprintBioEnrollment extends BioEnrollment {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication error in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enumerateEnrollments">Enumerate
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#enumerateEnrollments">Enumerate
    *     enrollments</a>
    */
   public Map<byte[], @Nullable String> enumerateEnrollments() throws IOException, CommandException {
@@ -439,7 +439,7 @@ public class FingerprintBioEnrollment extends BioEnrollment {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication error in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#setFriendlyName">Rename/Set
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#setFriendlyName">Rename/Set
    *     FriendlyName</a>
    */
   public void setName(byte[] templateId, String name) throws IOException, CommandException {
@@ -460,7 +460,7 @@ public class FingerprintBioEnrollment extends BioEnrollment {
    * @throws IOException A communication error in the transport layer.
    * @throws CommandException A communication error in the protocol layer.
    * @see <a
-   *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#removeEnrollment">Remove
+   *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#removeEnrollment">Remove
    *     enrollment</a>
    */
   public void removeEnrollment(byte[] templateId) throws IOException, CommandException {

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/PinUvAuthDummyProtocol.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/PinUvAuthDummyProtocol.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * Implements a dummy PIN/UV Auth Protocol
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authnrClientPin-puaprot-abstract-dfn">PIN/UV
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authnrClientPin-puaprot-abstract-dfn">PIN/UV
  *     Auth Protocol Abstract Definition</a>.
  */
 public class PinUvAuthDummyProtocol implements PinUvAuthProtocol {

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/PinUvAuthProtocolV1.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/PinUvAuthProtocolV1.java
@@ -46,9 +46,9 @@ import javax.crypto.spec.SecretKeySpec;
  * Implements PIN/UV Auth Protocol 1
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorClientPIN">authenticatorClientPIN</a>.
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorClientPIN">authenticatorClientPIN</a>.
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#pinProto1">PIN/UV
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#pinProto1">PIN/UV
  *     Auth Protocol One</a>.
  */
 public class PinUvAuthProtocolV1 implements PinUvAuthProtocol {

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/PinUvAuthProtocolV2.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/PinUvAuthProtocolV2.java
@@ -36,9 +36,9 @@ import javax.crypto.spec.SecretKeySpec;
  * Implements PIN/UV Auth Protocol 2
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorClientPIN">authenticatorClientPIN</a>.
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorClientPIN">authenticatorClientPIN</a>.
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#pinProto2">PIN/UV
+ *     href="https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#pinProto2">PIN/UV
  *     Auth Protocol Two</a>.
  */
 public class PinUvAuthProtocolV2 extends PinUvAuthProtocolV1 {

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/UserVerify.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/UserVerify.java
@@ -23,7 +23,7 @@ import java.util.Locale;
  * describe the methods and capabilities of a FIDO authenticator for locally verifying a user.
  *
  * @see <a
- *     href="https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#user-verification-methods">User
+ *     href="https://fidoalliance.org/specs/common-specs/fido-registry-v2.2-ps-20220523.html#user-verification-methods">User
  *     Verification Methods</a>
  */
 public enum UserVerify {

--- a/testing/src/main/java/com/yubico/yubikit/fido/ctap/Ctap2SessionTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/fido/ctap/Ctap2SessionTests.java
@@ -49,7 +49,9 @@ public class Ctap2SessionTests {
         versions.contains("U2F_V2")
             || versions.contains("FIDO_2_0")
             || versions.contains("FIDO_2_1_PRE")
-            || versions.contains("FIDO_2_1"));
+            || versions.contains("FIDO_2_1")
+            || versions.contains("FIDO_2_2")
+            || versions.contains("FIDO_2_3"));
 
     // Check AAGUID
     byte[] aaguid = info.getAaguid();


### PR DESCRIPTION
This pull request updates all FIDO CTAP-related references and documentation from version 2.2 to version 2.3 of the CTAP specification. The changes ensure that the codebase and documentation point to the latest official FIDO Alliance protocol documents, improving accuracy and future compatibility.
