### PR TITLE
 spotbugs-annotations compileOnly

### DIFF
--- a/build-logic/src/main/kotlin/yubikit-spotbugs.gradle.kts
+++ b/build-logic/src/main/kotlin/yubikit-spotbugs.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     spotbugs(libs.findLibrary("spotbugs").get())
     spotbugsPlugins(libs.findLibrary("findsecbugs-plugin").get())
 
-    add("implementation", libs.findLibrary("spotbugs-annotations").get())
+    add("compileOnly", libs.findLibrary("spotbugs-annotations").get())
 }
 
 spotbugs {


### PR DESCRIPTION
The dependency on `spotbugs-annotations` is now declared as `compileOnly` instead of `implementation`, ensuring that annotation classes are only available at compile time and not included in the final artifact.

Fixes #251 