### PR TITLE
fix: remove SpotBugs annotations leaking into consumer builds

### DIFF
--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnection.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnection.java
@@ -22,7 +22,6 @@ import android.hardware.usb.UsbInterface;
 import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.smartcard.SmartCardConnection;
 import com.yubico.yubikit.core.util.StringUtils;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -264,9 +263,6 @@ public class UsbSmartCardConnection extends UsbYubiKeyConnection implements Smar
     private byte status;
     private byte error;
 
-    @SuppressFBWarnings("URF_UNREAD_FIELD")
-    private byte messageSpecificByte;
-
     private MessageHeader(byte[] buffer) {
       if (buffer.length > SIZE_OF_CCID_PREFIX) {
         ByteBuffer responseBuffer =
@@ -277,7 +273,7 @@ public class UsbSmartCardConnection extends UsbYubiKeyConnection implements Smar
         sequence = responseBuffer.get();
         status = responseBuffer.get();
         error = responseBuffer.get();
-        messageSpecificByte = responseBuffer.get();
+        responseBuffer.get(); /* unused messageSpecificByte */
       }
     }
 

--- a/build-logic/src/main/kotlin/yubikit-spotbugs.gradle.kts
+++ b/build-logic/src/main/kotlin/yubikit-spotbugs.gradle.kts
@@ -43,9 +43,6 @@ afterEvaluate {
         spotbugsRuntime(libs.findLibrary("jsr250-api").get())
 
         spotbugsRuntime(libs.findLibrary("slf4j-nop").get())
-
-        // Add compile-time annotations
-        add("compileOnly", libs.findLibrary("spotbugs-annotations").get())
     }
 }
 

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/PinUvAuthProtocolV1.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/PinUvAuthProtocolV1.java
@@ -17,7 +17,6 @@
 package com.yubico.yubikit.fido.ctap;
 
 import com.yubico.yubikit.core.util.Pair;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -116,12 +115,6 @@ public class PinUvAuthProtocolV1 implements PinUvAuthProtocol {
     }
   }
 
-  @SuppressFBWarnings(
-      value = {"CIPHER_INTEGRITY", "STATIC_IV"},
-      justification =
-          "No padding is performed as the size of demPlaintext is required "
-              + "to be a multiple of the AES block length. The specification for "
-              + "PIN/UV Auth Protocol One expects all null IV")
   @Override
   public byte[] encrypt(byte[] key, byte[] demPlaintext) {
     try {
@@ -138,11 +131,6 @@ public class PinUvAuthProtocolV1 implements PinUvAuthProtocol {
     }
   }
 
-  @SuppressFBWarnings(
-      value = "CIPHER_INTEGRITY",
-      justification =
-          "No padding is performed as the size of demPlaintext is required "
-              + "to be a multiple of the AES block length.")
   @Override
   public byte[] decrypt(byte[] key, byte[] demCiphertext) {
     try {

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/PinUvAuthProtocolV2.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/PinUvAuthProtocolV2.java
@@ -17,7 +17,6 @@
 package com.yubico.yubikit.fido.ctap;
 
 import com.yubico.yubikit.core.util.RandomUtils;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
@@ -130,12 +129,6 @@ public class PinUvAuthProtocolV2 extends PinUvAuthProtocolV1 {
     }
   }
 
-  @SuppressFBWarnings(
-      value = {"CIPHER_INTEGRITY", "STATIC_IV"},
-      justification =
-          "No padding is performed as the size of demPlaintext is required "
-              + "to be a multiple of the AES block length. The IV is randomly generated "
-              + "for every encrypt operation")
   private Cipher getCipher(int mode, byte[] secret, byte[] iv) {
     try {
       Cipher cipher = Cipher.getInstance("AES/CBC/NoPadding");

--- a/spotbugs/excludeFilter.xml
+++ b/spotbugs/excludeFilter.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2024 Yubico.
+  ~ Copyright (C) 2024-2026 Yubico.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -16,6 +16,15 @@
 <FindBugsFilter>
     <Match>
         <Bug code="EI, EI2, CT" />
+    </Match>
+    <!-- Previously suppressed via @SuppressFBWarnings in source; moved here to avoid
+         leaking the SpotBugs annotation dependency into consumer builds -->
+    <Match>
+        <Or>
+            <Class name="com.yubico.yubikit.fido.ctap.PinUvAuthProtocolV1" />
+            <Class name="com.yubico.yubikit.fido.ctap.PinUvAuthProtocolV2" />
+        </Or>
+        <Bug pattern="CIPHER_INTEGRITY,STATIC_IV" />
     </Match>
     <!-- Kotlin/Compose code triggers false NP warnings because SpotBugs doesn't understand
          Kotlin nullable types (String?) or Compose compiler-generated parameters ($composer) -->


### PR DESCRIPTION
### Summary
Removes `@SuppressFBWarnings` annotations from compiled bytecode to fix R8/ProGuard build failures in consumer projects that cannot resolve the `edu.umd.cs.findbugs.annotations` class.
### Changes
- Removed all `@SuppressFBWarnings` usages from `PinUvAuthProtocolV1`, `PinUvAuthProtocolV2`, and `UsbSmartCardConnection`
- Moved `CIPHER_INTEGRITY` and `STATIC_IV` suppressions to spotbugs/excludeFilter.xml
- Eliminated unused `messageSpecificByte` field (replaced with direct buffer discard)
- Removed the `compileOnly` dependency on `spotbugs-annotations` from the build plugin

Fixes #325