### PR TITLE
fix(usb): use getProductId instead of getDeviceId in device filter

### DIFF
--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbDeviceManager.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/UsbDeviceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Yubico.
+ * Copyright (C) 2022-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ final class UsbDeviceManager {
       context.registerReceiver(broadcastReceiver, intentFilter);
       for (UsbDevice usbDevice : usbDevices) {
         DeviceFilter deviceFilter = usbConfiguration.getDeviceFilter();
-        if (deviceFilter.checkVendorProductIds(usbDevice.getVendorId(), usbDevice.getDeviceId())) {
+        if (deviceFilter.checkVendorProductIds(usbDevice.getVendorId(), usbDevice.getProductId())) {
           onDeviceAttach(usbDevice);
         }
       }


### PR DESCRIPTION
## Summary

Fixes a bug where initial USB device enumeration used the OS-assigned device ID
instead of the USB product ID when filtering for YubiKey devices.

## Changes

- Replace `usbDevice.getDeviceId()` with `usbDevice.getProductId()` in the
  initial device scan loop in `UsbDeviceManager`