### PR TITLE
chore: bump deps, compileSdk, and CI actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,12 +16,12 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Set up JDK
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,17 +11,17 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Set up JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -33,7 +33,7 @@ jobs:
         run: NO_GPG_SIGN=true ./gradlew --stacktrace check test javadocJar publishToMavenLocal
 
       - name: Upload jars
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: maven-repo
           path: ~/.m2/repository/com/yubico/yubikit/

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -34,7 +34,7 @@ jobs:
         egress-policy: audit
 
     - name: Checkout repository
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -43,7 +43,7 @@ jobs:
         languages: ${{ matrix.language }}
 
     - name: Setup Java
-      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
       with:
         distribution: 'temurin'
         java-version: '17'

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -29,27 +29,27 @@ jobs:
 
     steps:
     - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
         egress-policy: audit
 
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
 
     - name: Setup Java
-      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
       with:
         distribution: 'temurin'
         java-version: '17'
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -41,7 +41,7 @@ jobs:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -68,7 +68,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
@@ -76,6 +76,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/spotbugs-scan.yml
+++ b/.github/workflows/spotbugs-scan.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: "temurin"
           java-version: "17"
@@ -39,7 +39,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew spotbugsSarif
 
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sarif-files
           path: ./build/spotbugs/*.sarif
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
 
@@ -100,7 +100,7 @@ jobs:
           jq -c '.' > ${OUTPUT}
 
       - name: Upload SARIF for ${{ matrix.module }}
-        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: spotbugs-${{ matrix.module }}.json
           category: spotbugs-analysis-${{ matrix.module }}

--- a/.github/workflows/spotbugs-scan.yml
+++ b/.github/workflows/spotbugs-scan.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Java
-        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: "temurin"
           java-version: "17"

--- a/AndroidDemo/build.gradle.kts
+++ b/AndroidDemo/build.gradle.kts
@@ -39,7 +39,7 @@ android {
 
     defaultConfig {
         minSdk = 23
-        targetSdk = 36
+        targetSdk = 37
         versionName = version.toString()
         versionCode = 1
         multiDexEnabled = true

--- a/AndroidDemo/build.gradle.kts
+++ b/AndroidDemo/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     signingConfigs {
         create("release") {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 21

--- a/fido-android-ui/build.gradle.kts
+++ b/fido-android-ui/build.gradle.kts
@@ -137,7 +137,7 @@ dependencies {
     testImplementation(libs.turbine)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.robolectric)
-    testImplementation(libs.ui.test.junit4)
+    testImplementation(libs.androidx.ui.test.junit4)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.slf4j.api)
     testRuntimeOnly(libs.logback.classic)

--- a/fido-android-ui/build.gradle.kts
+++ b/fido-android-ui/build.gradle.kts
@@ -61,6 +61,7 @@ android {
     testOptions {
         managedDevices {
             allDevices {
+                // apiLevel stays at 36 — API 37 aosp system images not yet available
                 create("smallPhone", ManagedVirtualDevice::class) {
                     device = "Pixel 4"
                     apiLevel = 36

--- a/fido-android-ui/build.gradle.kts
+++ b/fido-android-ui/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 
 android {
     namespace = "com.yubico.yubikit.fido.android.ui"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 23

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,8 +20,8 @@ webkit = "1.15.0" # needed for minSdk 23
 
 # --- AndroidX Lifecycle ---
 lifecycle-extensions = "2.2.0"
-lifecycle-viewmodel-compose = "2.10.0"
-lifecycle-viewmodel-ktx = "2.10.0"
+lifecycle-viewmodel-compose = "2.11.0"
+lifecycle-viewmodel-ktx = "2.11.0"
 
 # --- AndroidX Navigation ---
 navigation-fragment-ktx = "2.9.8"
@@ -29,9 +29,9 @@ navigation-fragment-ktx = "2.9.8"
 # --- Jetpack Compose ---
 activity-compose = "1.13.0"
 activity-ktx = "1.13.0"
-compose-bom = "2026.05.01"
-material3 = "1.5.0-alpha21"
-runtime-livedata = "1.11.2"
+compose-bom = "2026.06.00"
+material3 = "1.5.0-alpha22"
+runtime-livedata = "1.11.3"
 
 # --- Kotlin / KotlinX ---
 kotlinx-coroutines-android = "1.11.0"
@@ -39,7 +39,7 @@ kotlinx-serialization-json = "1.11.0"
 
 # --- Logging ---
 logback-android = "3.0.0"
-logback-classic = "1.5.34"
+logback-classic = "1.5.36"
 slf4j-api = "2.0.18"
 slf4j-nop = "2.0.18"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,21 +2,21 @@
 
 # --- Build toolchain ---
 java = "8"
-kotlin = "2.3.10"
-android-gradle = "9.1.0"
+kotlin = "2.4.0"
+android-gradle = "9.2.1"
 
 # --- AndroidX core ---
-androidx-annotation = "1.9.1"
+androidx-annotation = "1.10.0"
 appcompat = "1.7.1"
-core-ktx = "1.18.0"
-credentials = "1.6.0-rc02"
+core-ktx = "1.19.0"
+credentials = "1.6.0"
 desugar_jdk_libs = "2.1.5"
 fragment-ktx = "1.8.9"
 legacy-support-v4 = "1.0.0"
-material = "1.13.0"
+material = "1.14.0"
 multidex = "2.0.1"
 recyclerview = "1.4.0"
-webkit = "1.15.0"
+webkit = "1.15.0" # needed for minSdk 23
 
 # --- AndroidX Lifecycle ---
 lifecycle-extensions = "2.2.0"
@@ -24,28 +24,27 @@ lifecycle-viewmodel-compose = "2.10.0"
 lifecycle-viewmodel-ktx = "2.10.0"
 
 # --- AndroidX Navigation ---
-navigation-fragment-ktx = "2.9.7"
+navigation-fragment-ktx = "2.9.8"
 
 # --- Jetpack Compose ---
 activity-compose = "1.13.0"
 activity-ktx = "1.13.0"
-compose-bom = "2026.03.01"
-ksp = "2.2.21-2.0.4"
-material3 = "1.5.0-alpha16"
-runtime-livedata = "1.10.6"
+compose-bom = "2026.05.01"
+material3 = "1.5.0-alpha21"
+runtime-livedata = "1.11.2"
 
 # --- Kotlin / KotlinX ---
-kotlinx-coroutines-android = "1.10.2"
-kotlinx-serialization-json = "1.10.0"
+kotlinx-coroutines-android = "1.11.0"
+kotlinx-serialization-json = "1.11.0"
 
 # --- Logging ---
 logback-android = "3.0.0"
-logback-classic = "1.5.32"
-slf4j-api = "2.0.17"
-slf4j-nop = "2.0.17"
+logback-classic = "1.5.34"
+slf4j-api = "2.0.18"
+slf4j-nop = "2.0.18"
 
 # --- Cryptography ---
-bcpkix-jdk15to18 = "1.83"
+bcpkix-jdk15to18 = "1.84"
 
 # --- Serialization / Data ---
 moshi = "1.15.2"
@@ -65,7 +64,7 @@ espresso-core = "3.7.0"
 hamcrest = "3.0"
 hamcrest-library = "3.0"
 junit-version = "4.13.2"
-kotlinx-coroutines-test = "1.10.2"
+kotlinx-coroutines-test = "1.11.0"
 mockito = "5.23.0"
 mockito-kotlin = "6.3.0"
 robolectric = "4.16.1"
@@ -73,8 +72,8 @@ turbine = "1.2.1"
 
 # --- Static analysis ---
 findsecbugs = "1.14.0"
-spotbugs-core = "4.9.8"
-spotless = "8.4.0"
+spotbugs-core = "4.10.2"
+spotless = "8.7.0"
 
 [libraries]
 
@@ -152,7 +151,6 @@ mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockito-kotlin" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 
 # --- Static analysis (SpotBugs) ---
 findsecbugs-plugin = { module = "com.h3xstream.findsecbugs:findsecbugs-plugin", version.ref = "findsecbugs" }
@@ -166,7 +164,6 @@ spotless-plugin-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradl
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle" }
 android-library = { id = "com.android.library", version.ref = "android-gradle" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jul 17 16:26:11 CEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/testing-android/build.gradle.kts
+++ b/testing-android/build.gradle.kts
@@ -47,7 +47,7 @@ android {
     }
 
     testOptions {
-        targetSdk = 36
+        targetSdk = 37
     }
 
     namespace = "com.yubico.yubikit.testing"

--- a/testing-android/build.gradle.kts
+++ b/testing-android/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 21


### PR DESCRIPTION
## Summary

Routine dependency and toolchain bump. Updates the version catalog, Gradle wrapper, compileSdk/targetSdk, and GitHub Actions to their latest versions. Also removes two unused catalog entries found during the update.

## Changes

- Bump Kotlin 2.3.10 → 2.4.0, AGP 9.1.0 → 9.2.1, Gradle 9.4.1 → 9.5.1
- Bump AndroidX, KotlinX, logging, bcpkix, spotbugs, spotless
- Bump compose-bom, material3, runtime-livedata, navigation
- Bump compileSdk/targetSdk 36 → 37 across all modules
- Remove unused `ksp` plugin/version alias
- Remove duplicate `ui-test-junit4` alias; consolidate to `libs.androidx.ui.test.junit4`
- Bump GitHub Actions: checkout v6.0.3, setup-java v5.3.0, upload-artifact v7.0.1, codeql-action v4.36.2, harden-runner v2.19.4 (all pinned to full SHA)