### PR TITLE
fix(fido): honor userVerification=discouraged for non-discoverable operations

### DIFF
--- a/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
@@ -493,7 +493,15 @@ public class Ctap2Client implements WebAuthnClient {
         ResidentKeyRequirement.REQUIRED.equals(selectionResidentKey)
             || (ResidentKeyRequirement.PREFERRED.equals(selectionResidentKey) && rkSupported);
 
-    final AuthParams authParams = getAuthParams(pin, userVerification, permissions, rpId, state);
+    // Validate before getAuthParams (which may trigger user verification) so a required-but-
+    // unsupported resident key fails fast instead of prompting for a PIN and then erroring.
+    if (rk && !rkSupported) {
+      throw new ClientError(
+          ClientError.Code.CONFIGURATION_UNSUPPORTED, "Resident key not supported");
+    }
+
+    final AuthParams authParams =
+        getAuthParams(pin, userVerification, permissions, rpId, rk, state);
 
     Map<String, Boolean> ctapOptions;
     if (!(rk || authParams.internalUv)) {
@@ -501,10 +509,6 @@ public class Ctap2Client implements WebAuthnClient {
     } else {
       ctapOptions = new HashMap<>();
       if (rk) {
-        if (!rkSupported) {
-          throw new ClientError(
-              ClientError.Code.CONFIGURATION_UNSUPPORTED, "Resident key not supported");
-        }
         ctapOptions.put(OPTION_RESIDENT_KEY, true);
       }
       if (authParams.internalUv) {
@@ -626,7 +630,10 @@ public class Ctap2Client implements WebAuthnClient {
     }
 
     final String userVerification = options.getUserVerification();
-    final AuthParams authParams = getAuthParams(pin, userVerification, permissions, rpId, state);
+    // An empty allowList is a usernameless (discoverable) assertion: UV is needed so the
+    // authenticator reveals user name/displayName for account selection.
+    final AuthParams authParams =
+        getAuthParams(pin, userVerification, permissions, rpId, allowCredentials.isEmpty(), state);
 
     PublicKeyCredentialDescriptor selectedCred =
         allowCredentials.isEmpty()
@@ -710,8 +717,16 @@ public class Ctap2Client implements WebAuthnClient {
    * @return true if user verification should be used, false otherwise.
    * @throws ClientError If user verification is required but not configured or supported.
    */
-  private boolean shouldUseUv(
-      Ctap2Session.InfoData info, @Nullable String userVerification, int permissions)
+  // Package-private (not private) so it can be unit-tested directly across the
+  // userVerification × makeCredential/getAssertion × discoverable × makeCredUvNotRqd matrix.
+  //
+  // discoverable means the operation involves discoverable (resident) credentials: for
+  // makeCredential it is rk=true; for getAssertion it is an empty allowList (usernameless).
+  boolean shouldUseUv(
+      Ctap2Session.InfoData info,
+      @Nullable String userVerification,
+      int permissions,
+      boolean discoverable)
       throws ClientError {
     Map<String, ?> options = info.getOptions();
 
@@ -728,7 +743,6 @@ public class Ctap2Client implements WebAuthnClient {
         || ((UserVerificationRequirement.PREFERRED.equals(userVerification)
                 || userVerification == null)
             && supportsUv)
-        || ((UserVerificationRequirement.DISCOURAGED.equals(userVerification)) && pinConfigured)
         || Boolean.TRUE.equals(options.get(OPTION_ALWAYS_UV))) {
       if (!hasUvConfigured) {
         throw new ClientError(
@@ -737,6 +751,16 @@ public class Ctap2Client implements WebAuthnClient {
       }
       return true;
     }
+    // Discoverable-credential operations on a UV-configured authenticator need UV even when
+    // userVerification=discouraged:
+    //  - makeCredential rk=true: the authenticator rejects resident-key creation without UV
+    //    (CTAP2_ERR_PUAT_REQUIRED); makeCredUvNotRqd only exempts NON-discoverable creation.
+    //  - getAssertion with an empty allowList: without UV the authenticator omits user name and
+    //    displayName (single-factor privacy), leaving no way to present an account picker.
+    if (discoverable && hasUvConfigured) {
+      return true;
+    }
+    // Non-discoverable makeCredential needs UV unless makeCredUvNotRqd lets it skip.
     if (mc && hasUvConfigured && !Boolean.TRUE.equals(options.get(OPTION_MC_UV_NOT_RQD))) {
       return true;
     }
@@ -779,6 +803,7 @@ public class Ctap2Client implements WebAuthnClient {
       @Nullable String userVerification,
       int permissions,
       @Nullable String rpId,
+      boolean discoverable,
       @Nullable CommandState state)
       throws IOException, CommandException, ClientError {
     Ctap2Session.InfoData info = ctap.getCachedInfo();
@@ -786,7 +811,7 @@ public class Ctap2Client implements WebAuthnClient {
     byte[] pinToken = null;
     boolean internalUv = false;
 
-    if (shouldUseUv(info, userVerification, permissions)) {
+    if (shouldUseUv(info, userVerification, permissions, discoverable)) {
       boolean allowInternalUv =
           (permissions & ~(ClientPin.PIN_PERMISSION_MC | ClientPin.PIN_PERMISSION_GA)) == 0;
       pinToken = getToken(pin, permissions, rpId, allowInternalUv, state);

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/Ctap2ClientShouldUseUvTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/Ctap2ClientShouldUseUvTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client;
+
+import static com.yubico.yubikit.fido.ctap.ClientPin.PIN_PERMISSION_GA;
+import static com.yubico.yubikit.fido.ctap.ClientPin.PIN_PERMISSION_MC;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yubico.yubikit.fido.ctap.Ctap2Session;
+import com.yubico.yubikit.fido.webauthn.UserVerificationRequirement;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Matrix tests for {@link Ctap2Client#shouldUseUv} covering the interaction of {@code
+ * userVerification}, makeCredential vs getAssertion, discoverable ({@code rk}) creation, and the
+ * {@code makeCredUvNotRqd} authenticator option.
+ *
+ * <p>Spec basis (CTAP2.1+ §authenticatorMakeCredential, unchanged through 2.3): {@code
+ * makeCredUvNotRqd} only exempts <em>non-discoverable</em> credential creation from user
+ * verification; creating a discoverable ({@code rk=true}) credential on a UV-configured
+ * authenticator always requires UV (otherwise the authenticator returns {@code
+ * CTAP2_ERR_PUAT_REQUIRED}). {@code userVerification=discouraged} is a relying-party preference and
+ * does not override that.
+ */
+public class Ctap2ClientShouldUseUvTest {
+
+  /** Options for a modern PIN-configured key that supports makeCredUvNotRqd. */
+  private static Map<String, Object> pinSetModern() {
+    Map<String, Object> options = new HashMap<>();
+    options.put(Ctap2Client.OPTION_CLIENT_PIN, true);
+    options.put(Ctap2Client.OPTION_MC_UV_NOT_RQD, true);
+    return options;
+  }
+
+  private void assertShouldUseUv(
+      Map<String, ?> options,
+      String userVerification,
+      int permissions,
+      boolean discoverable,
+      boolean expected)
+      throws Throwable {
+    Ctap2Session.InfoData info = mock(Ctap2Session.InfoData.class);
+    doReturn(options).when(info).getOptions();
+    when(info.getPinUvAuthProtocols()).thenReturn(Arrays.asList(1, 2));
+    Ctap2Session ctap = mock(Ctap2Session.class);
+    when(ctap.getInfo()).thenReturn(info);
+    when(ctap.getCachedInfo()).thenReturn(info);
+    Ctap2Client client = new Ctap2Client(ctap);
+
+    String label =
+        "uv="
+            + userVerification
+            + " mc="
+            + ((permissions & PIN_PERMISSION_MC) != 0)
+            + " discoverable="
+            + discoverable;
+    assertEquals(
+        label, expected, client.shouldUseUv(info, userVerification, permissions, discoverable));
+  }
+
+  // --- userVerification=discouraged on a modern PIN-configured key ---
+
+  @Test
+  public void discouragedAllowListSignInDoesNotUseUv() throws Throwable {
+    // getAssertion with a non-empty allowList (server-side credential) → no PIN prompt.
+    assertShouldUseUv(
+        pinSetModern(), UserVerificationRequirement.DISCOURAGED, PIN_PERMISSION_GA, false, false);
+  }
+
+  @Test
+  public void discouragedUsernamelessSignInUsesUv() throws Throwable {
+    // getAssertion with an empty allowList (discoverable/usernameless) → UV required so the
+    // authenticator reveals user name/displayName for the account picker.
+    assertShouldUseUv(
+        pinSetModern(), UserVerificationRequirement.DISCOURAGED, PIN_PERMISSION_GA, true, true);
+  }
+
+  @Test
+  public void discouragedNonDiscoverableCreateDoesNotUseUv() throws Throwable {
+    // makeCredential + discouraged + rk=false + makeCredUvNotRqd → no PIN prompt.
+    assertShouldUseUv(
+        pinSetModern(), UserVerificationRequirement.DISCOURAGED, PIN_PERMISSION_MC, false, false);
+  }
+
+  @Test
+  public void discouragedDiscoverableCreateUsesUv() throws Throwable {
+    // makeCredential + discouraged + rk=true → UV required (discoverable creation always needs it).
+    assertShouldUseUv(
+        pinSetModern(), UserVerificationRequirement.DISCOURAGED, PIN_PERMISSION_MC, true, true);
+  }
+
+  // --- non-discouraged requirements are unaffected ---
+
+  @Test
+  public void requiredAlwaysUsesUv() throws Throwable {
+    assertShouldUseUv(
+        pinSetModern(), UserVerificationRequirement.REQUIRED, PIN_PERMISSION_GA, false, true);
+    assertShouldUseUv(
+        pinSetModern(), UserVerificationRequirement.REQUIRED, PIN_PERMISSION_MC, true, true);
+  }
+
+  @Test
+  public void preferredUsesUvWhenSupported() throws Throwable {
+    // clientPin present ⇒ UV supported ⇒ preferred uses UV.
+    assertShouldUseUv(
+        pinSetModern(), UserVerificationRequirement.PREFERRED, PIN_PERMISSION_GA, false, true);
+  }
+
+  @Test
+  public void nullUserVerificationBehavesAsPreferred() throws Throwable {
+    assertShouldUseUv(pinSetModern(), null, PIN_PERMISSION_GA, false, true);
+  }
+
+  // --- edge cases ---
+
+  @Test
+  public void discouragedNonDiscoverableCreateUsesUvWithoutMakeCredUvNotRqd() throws Throwable {
+    // Older key that does NOT advertise makeCredUvNotRqd: even non-discoverable creation needs UV.
+    Map<String, Object> pinSetLegacy = new HashMap<>();
+    pinSetLegacy.put(Ctap2Client.OPTION_CLIENT_PIN, true);
+    assertShouldUseUv(
+        pinSetLegacy, UserVerificationRequirement.DISCOURAGED, PIN_PERMISSION_MC, false, true);
+  }
+
+  @Test
+  public void alwaysUvForcesUvEvenForDiscouragedSignIn() throws Throwable {
+    Map<String, Object> alwaysUv = pinSetModern();
+    alwaysUv.put(Ctap2Client.OPTION_ALWAYS_UV, true);
+    assertShouldUseUv(
+        alwaysUv, UserVerificationRequirement.DISCOURAGED, PIN_PERMISSION_GA, false, true);
+  }
+
+  @Test
+  public void noUvConfiguredNeverUsesUv() throws Throwable {
+    // No PIN/UV configured at all: the client can't perform UV, so it never tries.
+    Map<String, Object> noUv = new HashMap<>();
+    assertShouldUseUv(
+        noUv, UserVerificationRequirement.DISCOURAGED, PIN_PERMISSION_MC, true, false);
+  }
+}


### PR DESCRIPTION
## Module
`fido` (core CTAP2 client — `Ctap2Client`).

## Problem
`Ctap2Client.shouldUseUv` forces user verification whenever a client PIN is configured, ignoring the relying party's `userVerification` preference. So a relying party requesting `userVerification=discouraged` still triggers a PIN prompt on every makeCredential/getAssertion when the key has a PIN set.

## Fix
Honor `userVerification=discouraged`, but only for **non-discoverable** operations — discoverable (resident-credential) operations still require UV per CTAP:

- `getAssertion` with a non-empty allowList → no UV (server-side credential).
- `getAssertion` with an empty allowList (usernameless) → UV; without it the authenticator omits `user.name`/`user.displayName`, leaving nothing to show in an account picker.
- `makeCredential` with `rk=false` → no UV when `makeCredUvNotRqd` is supported.
- `makeCredential` with `rk=true` → UV; the authenticator otherwise rejects resident-key creation with `CTAP2_ERR_PUAT_REQUIRED`.
- `required` / `preferred` / `alwaysUv`, and extensions that require a permission, are unchanged and still perform UV.

Implemented by threading a `discoverable` flag into `shouldUseUv` (resident-key creation for makeCredential; empty allowList for getAssertion) and requiring UV when it's set.

## Spec basis
CTAP2.1+: `makeCredUvNotRqd` only exempts non-discoverable creation, and discoverable creation returns `CTAP2_ERR_PUAT_REQUIRED` without UV. Verified unchanged through CTAP 2.3.

## Tests
Adds `Ctap2ClientShouldUseUvTest`, covering the userVerification × makeCredential/getAssertion × discoverable × makeCredUvNotRqd matrix. `:fido:test` and `:fido:spotlessCheck` pass.

## Notes
No public API change — `shouldUseUv` is internal (widened from `private` to package-private only so the test can call it directly).