### PR TITLE
feat: read DeviceInfo pages by TAG_MORE_DATA page count

### DIFF
--- a/management/src/main/java/com/yubico/yubikit/management/DeviceInfo.java
+++ b/management/src/main/java/com/yubico/yubikit/management/DeviceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 Yubico.
+ * Copyright (C) 2020-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -435,7 +435,7 @@ public class DeviceInfo {
   }
 
   /** Reads an int from a variable length byte array. */
-  private static int readInt(byte @Nullable [] data) {
+  static int readInt(byte @Nullable [] data) {
     if (data == null || data.length == 0) {
       return 0;
     }

--- a/management/src/main/java/com/yubico/yubikit/management/ManagementSession.java
+++ b/management/src/main/java/com/yubico/yubikit/management/ManagementSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 Yubico.
+ * Copyright (C) 2019-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,9 @@ public class ManagementSession extends ApplicationSession<ManagementSession> {
   static final byte INS_SET_MODE = 0x16;
   static final byte INS_DEVICE_RESET = 0x1f;
   static final byte P1_DEVICE_CONFIG = 0x11;
+
+  // DeviceInfo TLV tags
+  static final int TAG_MORE_DATA = 0x10; // YK_MORE_DEVICE_INFO
 
   // OTP command constants
   static final byte CMD_DEVICE_CONFIG = 0x11;
@@ -372,17 +375,36 @@ public class ManagementSession extends ApplicationSession<ManagementSession> {
    */
   private DeviceInfo readDeviceInfo() throws IOException, CommandException {
     final Map<Integer, byte[]> tlvs = new HashMap<>();
-    boolean hasMoreData = true;
+    // TAG_MORE_DATA declares the number of pages available after the current one. We start with 1
+    // so that the first page is always read, and decrement before each read. Older firmware sends a
+    // value of 1 to indicate a single additional page, which this logic handles identically.
+    int moreData = 1;
     int page = 0;
 
-    while (hasMoreData) {
+    while (moreData > 0) {
+      moreData--;
       final byte[] encoded = backend.readConfig(page);
-      if (encoded.length - 1 != encoded[0]) {
+      // The leading length byte is an unsigned protocol value (0-255); mask before comparing.
+      if (encoded.length == 0 || encoded.length - 1 != (encoded[0] & 0xff)) {
         throw new BadResponseException("Invalid length");
       }
       Map<Integer, byte[]> decoded = Tlvs.decodeMap(Arrays.copyOfRange(encoded, 1, encoded.length));
-      byte[] moreData = decoded.get(0x10); // YK_MORE_DEVICE_INFO
-      hasMoreData = moreData != null && moreData.length == 1 && moreData[0] == (byte) 1;
+      byte[] moreDataValue = decoded.remove(TAG_MORE_DATA);
+      if (moreDataValue != null) {
+        // TAG_MORE_DATA is the number of pages following this one. readInt is signed, so an
+        // over-long or high-bit value could wrap negative and silently stop paging; and a count
+        // reaching past the single-byte page index space (0-255) must be rejected up front rather
+        // than after many reads or by overflowing the page index when building the request.
+        if (moreDataValue.length > 4) {
+          throw new BadResponseException("Invalid TAG_MORE_DATA length: " + moreDataValue.length);
+        }
+        int declared = DeviceInfo.readInt(moreDataValue);
+        if (declared < 0 || declared > 0xff - page) {
+          throw new BadResponseException("Invalid TAG_MORE_DATA page count: " + declared);
+        }
+        moreData = declared;
+      }
+      logger.debug("Read DeviceInfo page {}, {} more page(s) to read", page, moreData);
       tlvs.putAll(decoded);
       page++;
     }

--- a/management/src/test/java/com/yubico/yubikit/management/ManagementSessionTest.java
+++ b/management/src/test/java/com/yubico/yubikit/management/ManagementSessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Yubico.
+ * Copyright (C) 2025-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,16 +19,25 @@ package com.yubico.yubikit.management;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.yubico.yubikit.core.Version;
+import com.yubico.yubikit.core.application.BadResponseException;
 import com.yubico.yubikit.core.fido.FidoProtocol;
 import com.yubico.yubikit.core.otp.OtpProtocol;
+import com.yubico.yubikit.core.smartcard.Apdu;
 import com.yubico.yubikit.core.smartcard.AppId;
 import com.yubico.yubikit.core.smartcard.SmartCardProtocol;
+import com.yubico.yubikit.core.util.Tlv;
+import com.yubico.yubikit.core.util.Tlvs;
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 public class ManagementSessionTest {
   @Test
@@ -67,5 +76,153 @@ public class ManagementSessionTest {
     }
 
     verify(protocolMock).close();
+  }
+
+  // DeviceInfo TLV tags used to build mocked config pages.
+  private static final int TAG_USB_SUPPORTED = 0x01;
+  private static final int TAG_SERIAL_NUMBER = 0x02;
+  private static final int TAG_MORE_DATA = 0x10;
+
+  /** Wraps TLVs as a config page: a leading length byte followed by the encoded TLVs. */
+  private static byte[] page(Tlv... tlvs) {
+    byte[] data = Tlvs.encodeList(Arrays.asList(tlvs));
+    if (data.length > 0xff) {
+      // The length byte holds 0-255; a larger payload would silently truncate modulo 256.
+      throw new IllegalArgumentException("Config page exceeds 255 bytes: " + data.length);
+    }
+    ByteArrayOutputStream page = new ByteArrayOutputStream();
+    page.write(data.length);
+    page.write(data, 0, data.length);
+    return page.toByteArray();
+  }
+
+  private static Tlv tlv(int tag, int... value) {
+    byte[] bytes = new byte[value.length];
+    for (int i = 0; i < value.length; i++) {
+      bytes[i] = (byte) value[i];
+    }
+    return new Tlv(tag, bytes);
+  }
+
+  private static ManagementSession smartCardSession(SmartCardProtocol protocolMock)
+      throws Exception {
+    when(protocolMock.select(any(byte[].class)))
+        .thenReturn("5.7.0".getBytes(StandardCharsets.UTF_8));
+    return new ManagementSession(protocolMock, null);
+  }
+
+  /** Verifies that read-config APDUs were sent for exactly the given page indices, in order. */
+  private static void assertPagesRead(SmartCardProtocol protocolMock, int... expectedPages)
+      throws Exception {
+    ArgumentCaptor<Apdu> captor = ArgumentCaptor.forClass(Apdu.class);
+    verify(protocolMock, times(expectedPages.length)).sendAndReceive(captor.capture());
+    List<Apdu> apdus = captor.getAllValues();
+    for (int i = 0; i < expectedPages.length; i++) {
+      assertEquals("INS of read " + i, ManagementSession.INS_READ_CONFIG, apdus.get(i).getIns());
+      assertEquals("page index of read " + i, (byte) expectedPages[i], apdus.get(i).getP1());
+    }
+  }
+
+  @Test
+  public void readsSinglePageWhenNoMoreData() throws Exception {
+    SmartCardProtocol protocolMock = mock(SmartCardProtocol.class);
+    when(protocolMock.sendAndReceive(any(Apdu.class)))
+        .thenReturn(page(tlv(TAG_USB_SUPPORTED, 0x3f), tlv(TAG_SERIAL_NUMBER, 0, 0, 0, 42)));
+
+    try (ManagementSession session = smartCardSession(protocolMock)) {
+      DeviceInfo info = session.getDeviceInfo();
+      assertEquals(Integer.valueOf(42), info.getSerialNumber());
+    }
+
+    // Only the first page is read when TAG_MORE_DATA is absent.
+    assertPagesRead(protocolMock, 0);
+  }
+
+  @Test
+  public void readsPageLongerThan127Bytes() throws Exception {
+    // The page's leading length byte is unsigned (0-255); a page over 127 bytes must be accepted.
+    SmartCardProtocol protocolMock = mock(SmartCardProtocol.class);
+    when(protocolMock.sendAndReceive(any(Apdu.class)))
+        .thenReturn(page(tlv(TAG_SERIAL_NUMBER, 0, 0, 0, 42), tlv(0x66, new int[140])));
+
+    try (ManagementSession session = smartCardSession(protocolMock)) {
+      DeviceInfo info = session.getDeviceInfo();
+      assertEquals(Integer.valueOf(42), info.getSerialNumber());
+    }
+
+    assertPagesRead(protocolMock, 0);
+  }
+
+  @Test
+  public void readsTwoPagesWithLegacyMoreDataFlag() throws Exception {
+    // Legacy firmware sends TAG_MORE_DATA = 1 to signal a single additional page, then omits it.
+    SmartCardProtocol protocolMock = mock(SmartCardProtocol.class);
+    when(protocolMock.sendAndReceive(any(Apdu.class)))
+        .thenReturn(
+            page(tlv(TAG_USB_SUPPORTED, 0x3f), tlv(TAG_MORE_DATA, 1)),
+            page(tlv(TAG_SERIAL_NUMBER, 0, 0, 0, 42)));
+
+    try (ManagementSession session = smartCardSession(protocolMock)) {
+      DeviceInfo info = session.getDeviceInfo();
+      // Serial number lives on the second page, proving both pages were merged.
+      assertEquals(Integer.valueOf(42), info.getSerialNumber());
+    }
+
+    assertPagesRead(protocolMock, 0, 1);
+  }
+
+  @Test
+  public void readsAllPagesWhenMoreDataDeclaresPageCount() throws Exception {
+    // Newer firmware may declare the total number of following pages once and omit it afterwards.
+    SmartCardProtocol protocolMock = mock(SmartCardProtocol.class);
+    when(protocolMock.sendAndReceive(any(Apdu.class)))
+        .thenReturn(
+            page(tlv(TAG_USB_SUPPORTED, 0x3f), tlv(TAG_MORE_DATA, 2)),
+            page(tlv(TAG_SERIAL_NUMBER, 0, 0, 0, 42)),
+            page(tlv(TAG_SERIAL_NUMBER, 0, 0, 0, 7)));
+
+    try (ManagementSession session = smartCardSession(protocolMock)) {
+      DeviceInfo info = session.getDeviceInfo();
+      // Later pages override earlier values for the same tag, so the third page wins.
+      assertEquals(Integer.valueOf(7), info.getSerialNumber());
+    }
+
+    assertPagesRead(protocolMock, 0, 1, 2);
+  }
+
+  @Test(expected = BadResponseException.class)
+  public void throwsOnEmptyConfigResponse() throws Exception {
+    // An empty response must surface as a BadResponseException, not an index-out-of-bounds error.
+    SmartCardProtocol protocolMock = mock(SmartCardProtocol.class);
+    when(protocolMock.sendAndReceive(any(Apdu.class))).thenReturn(new byte[0]);
+
+    try (ManagementSession session = smartCardSession(protocolMock)) {
+      session.getDeviceInfo();
+    }
+  }
+
+  @Test(expected = BadResponseException.class)
+  public void throwsWhenMoreDataCountExceedsPageIndexSpace() throws Exception {
+    // A count reaching past the single-byte page index space must be rejected up front (after the
+    // first read), not after hundreds of reads or by overflowing the page index.
+    SmartCardProtocol protocolMock = mock(SmartCardProtocol.class);
+    when(protocolMock.sendAndReceive(any(Apdu.class)))
+        .thenReturn(page(tlv(TAG_MORE_DATA, 0x01, 0x00))); // 256 pages
+
+    try (ManagementSession session = smartCardSession(protocolMock)) {
+      session.getDeviceInfo();
+    }
+  }
+
+  @Test(expected = BadResponseException.class)
+  public void throwsOnNegativeMoreDataCount() throws Exception {
+    // A 4-byte 0xFFFFFFFF parses to -1 as a signed int; it must fail rather than silently stop.
+    SmartCardProtocol protocolMock = mock(SmartCardProtocol.class);
+    when(protocolMock.sendAndReceive(any(Apdu.class)))
+        .thenReturn(page(tlv(TAG_MORE_DATA, 0xff, 0xff, 0xff, 0xff)));
+
+    try (ManagementSession session = smartCardSession(protocolMock)) {
+      session.getDeviceInfo();
+    }
   }
 }


### PR DESCRIPTION
## Summary

Interprets `TAG_MORE_DATA` as the number of remaining DeviceInfo pages rather than a boolean flag. A value of `1` still reads exactly one additional page, so existing firmware behaves identically. Ports the equivalent change from the yubikey-manager PR ([#725](https://github.com/Yubico/yubikey-manager/pull/725)).

## Changes

- Read DeviceInfo pages by `TAG_MORE_DATA` count, preserving legacy behavior
- Add unit tests for the supported paging variants