### PR TITLE
fix(fido): isolate client extension processing failures

### DIFF
--- a/fido/src/main/java/com/yubico/yubikit/fido/client/ClientError.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/ClientError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Yubico.
+ * Copyright (C) 2020-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/ClientError.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/ClientError.java
@@ -60,6 +60,11 @@ public class ClientError extends Exception {
     this.errorCode = errorCode;
   }
 
+  public ClientError(Code errorCode, String message, Throwable cause) {
+    super(errorCode + " - " + message, cause);
+    this.errorCode = errorCode;
+  }
+
   @SuppressWarnings("unused")
   public Code getErrorCode() {
     return errorCode;

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
@@ -583,24 +583,24 @@ public class Ctap2Client implements WebAuthnClient {
             state);
 
     ClientExtensionResults clientExtensionResults = new ClientExtensionResults();
-    // Parse the attestation once for extension-output processing and share it across all
-    // processors (the public makeCredential() parses it again to build the response). A failure
-    // here is not extension-specific (the authenticator's attestation could not be parsed); since
-    // the credential was already created, log it and return without extension outputs rather than
-    // failing the whole ceremony or reporting it as an extension error.
-    AttestationObject attestationObject = null;
+    // Parse the attestation for extension-output processing. A parse failure is not
+    // extension-specific (the authenticator returned an unparseable attestation) and is not caller
+    // input, so it is surfaced as a typed ClientError rather than an untyped unchecked exception.
+    // The attestation is mandatory to build the response, so a parse failure must abort the
+    // ceremony;
+    // continuing without extension outputs would only defer the crash. The public makeCredential()
+    // parses it again to build the response; that re-parse cannot fail once this one succeeds.
+    final AttestationObject attestationObject;
     try {
       attestationObject = AttestationObject.fromCredential(credentialData);
     } catch (RuntimeException e) {
-      logger.warn("Failed to parse attestation object; skipping extension outputs", e);
+      throw new ClientError(ClientError.Code.OTHER_ERROR, "Failed to parse attestation object", e);
     }
-    if (attestationObject != null) {
-      for (Extension.RegistrationProcessor processor : registrationProcessors) {
-        try {
-          clientExtensionResults.add(processor.getOutput(attestationObject, authParams.pinToken));
-        } catch (RuntimeException e) {
-          handleExtensionFailure(e);
-        }
+    for (Extension.RegistrationProcessor processor : registrationProcessors) {
+      try {
+        clientExtensionResults.add(processor.getOutput(attestationObject, authParams.pinToken));
+      } catch (RuntimeException e) {
+        handleExtensionFailure(e);
       }
     }
     return new Pair<>(credentialData, clientExtensionResults);
@@ -882,16 +882,87 @@ public class Ctap2Client implements WebAuthnClient {
   }
 
   /**
-   * Handles a {@link RuntimeException} raised while processing a single client extension, applying
-   * the three-way policy that keeps one extension from breaking a whole ceremony:
+   * Handles a {@link RuntimeException} raised while processing a single client extension.
+   *
+   * <h2>Extension input contract</h2>
+   *
+   * Client extensions communicate their outcome with exactly two signals, so that one extension can
+   * never silently corrupt or abort a ceremony it shouldn't:
+   *
+   * <ul>
+   *   <li><b>Return {@code null} — ignore.</b> The extension does not apply and is skipped; the
+   *       ceremony continues with the remaining extensions. This is the {@code SHOULD ignore} path
+   *       of <a href="https://www.w3.org/TR/webauthn-3/#sctn-extensions">WebAuthn §9</a> and
+   *       covers: not requested; not supported by the authenticator; nothing to evaluate; an
+   *       extension this client has no handler for (never dispatched, left ignorable for
+   *       forward-compatibility); and malformed <em>authenticator</em> output (the device's fault,
+   *       not the caller's). Note a recognized extension's unrecognized <em>value</em> (e.g. an
+   *       unknown {@code credProtect} policy or {@code largeBlob} support) is a caller error and is
+   *       surfaced, not ignored — see the enum-member rule below.
+   *   <li><b>Throw — abort.</b> The ceremony fails with a {@link ClientError}. Reserved for a
+   *       caller error or an explicitly-requested capability that cannot be satisfied (see below).
+   * </ul>
+   *
+   * <p>Whether malformed <em>client</em> input is an error or is ignored is decided per member
+   * kind, mirroring what a browser's WebIDL binding does before extension processing runs:
+   *
+   * <ul>
+   *   <li><b>Missing a required member → error.</b> A {@code required} member that is absent is a
+   *       {@code TypeError} at the binding (e.g. {@code prf.eval.first}, {@code
+   *       hmacGetSecret.salt1}).
+   *   <li><b>Wrong type on a dictionary or {@code BufferSource} member → error.</b> These
+   *       correspond to WebIDL conversions that throw {@code TypeError} (e.g. a non-object {@code
+   *       largeBlob}/{@code payment}/{@code prf}, or a non-string {@code credBlob}/{@code
+   *       largeBlob.write}/prf salt).
+   *   <li><b>Invalid encoding of a {@code BufferSource} member → error.</b> A well-typed string
+   *       that is not valid base64url is undecodable and can never be correct, so it is surfaced
+   *       (via {@link com.yubico.yubikit.core.internal.codec.Base64#fromUrlSafeString}) rather than
+   *       silently dropped. This is intentionally stricter than §9.3's {@code SHOULD ignore},
+   *       trading strict spec-leniency for SDK ergonomics (a bad value is a caller bug worth
+   *       reporting).
+   *   <li><b>Invalid value of an enum member → error.</b> {@code credProtect}'s {@code
+   *       credentialProtectionPolicy} (one of the three defined policy strings) and {@code
+   *       largeBlob}'s {@code support} ({@code "required"} or {@code "preferred"}) must be a
+   *       recognized value; an unrecognized string or a non-string is surfaced rather than silently
+   *       dropped. For {@code credProtect} the client maps the string to an integer, so silently
+   *       dropping it would mint a credential without the requested protection. An absent (or
+   *       {@code null}) member is "not requested" and ignored.
+   *   <li><b>Wrong type on a boolean member → error.</b> Every recognized boolean client-input
+   *       member is validated: a non-boolean value for {@code minPinLength}, {@code credProps},
+   *       {@code payment.isPayment}, {@code getCredBlob}, {@code largeBlob.read}, {@code
+   *       hmacCreateSecret}, or {@code enforceCredentialProtectionPolicy} is malformed caller input
+   *       and is surfaced (stricter than WebIDL {@code ToBoolean} coercion, matching this SDK's
+   *       strict-typing stance). The request flags treat {@code false} (and absent/{@code null}) as
+   *       "not requested" and ignore it — only {@code true} produces authenticator input; {@code
+   *       enforceCredentialProtectionPolicy} treats {@code false} as best-effort (its normal
+   *       meaning).
+   * </ul>
+   *
+   * <p><b>Invariant:</b> a throw only becomes a clean {@link ClientError} if it happens in the
+   * synchronous phase caught here. The deferred output providers ({@code serializationType -> ...}
+   * returned by {@code getOutput}) run later during response serialization, <em>outside</em> this
+   * handler, so they MUST NOT throw — any throwing work (parsing/decrypting/validating
+   * authenticator output) is done synchronously and yields {@code null} on failure, leaving the
+   * provider as pure formatting.
+   *
+   * <h2>Exception mapping</h2>
    *
    * <ul>
    *   <li><b>{@link ExtensionConfigurationException} — abort.</b> The relying party explicitly
-   *       requested a capability that cannot be satisfied (e.g. {@code credProtect} with {@code
-   *       enforceCredentialProtectionPolicy}, or {@code largeBlob} {@code support:"required"} on an
-   *       authenticator that does not support it). Surfaced as a {@link ClientError} that fails the
-   *       ceremony, carrying the {@link ClientError.Code} the extension chose.
-   *   <li><b>{@link IllegalArgumentException} — skip.</b> See the inline note below.
+   *       requested a capability that cannot be satisfied, or a spec-defined {@code
+   *       NotSupportedError} condition (e.g. {@code credProtect} with {@code
+   *       enforceCredentialProtectionPolicy}, {@code largeBlob} {@code support:"required"} on an
+   *       unsupported authenticator, or {@code prf} {@code evalByCredential} during registration).
+   *       Surfaced as a {@link ClientError} carrying the {@link ClientError.Code} the extension
+   *       chose (defaulting to {@link ClientError.Code#CONFIGURATION_UNSUPPORTED}).
+   *   <li><b>{@link IllegalArgumentException} — abort as {@link ClientError.Code#BAD_REQUEST}.</b>
+   *       Malformed caller input for a requested extension: a missing required member, a wrong type
+   *       on a dictionary/{@code BufferSource} member, an invalid base64url value, or a
+   *       spec-defined {@code SyntaxError} (e.g. a {@code prf} {@code evalByCredential} key that
+   *       does not match an allowed credential). This is surfaced regardless of whether the
+   *       authenticator supports the extension, since several extensions validate their input
+   *       before checking support (e.g. {@code largeBlob}, {@code previewSign}). Distinct from the
+   *       {@code null} "not applicable" path.
    *   <li><b>Anything else — rethrow.</b> Any other unchecked exception (e.g. {@link
    *       NullPointerException}, {@link ClassCastException}, {@link IllegalStateException}) is
    *       treated as a genuine defect and propagated unchanged rather than silently swallowed.
@@ -900,26 +971,18 @@ public class Ctap2Client implements WebAuthnClient {
   private void handleExtensionFailure(RuntimeException e) throws ClientError {
     if (e instanceof ExtensionConfigurationException) {
       ExtensionConfigurationException configError = (ExtensionConfigurationException) e;
-      throw new ClientError(configError.getCode(), configError.getMessage(), configError);
+      String message =
+          configError.getMessage() != null ? configError.getMessage() : configError.toString();
+      throw new ClientError(configError.getCode(), message, configError);
     }
     if (e instanceof IllegalArgumentException) {
-      // An IllegalArgumentException here means an extension could not process its data; the failure
-      // is recoverable by dropping that one extension. It is raised by the decode/validation
-      // helpers an extension calls, not by our extensions signaling "not applicable" (that case
-      // returns null instead of throwing). Typical sources are malformed relying-party input (e.g.
-      // invalid base64url rejected by Base64.fromUrlSafeString while decoding prf/hmac-secret
-      // salts,
-      // a credBlob, sign keyHandle/tbs, or a largeBlob payload) and malformed authenticator output
-      // (e.g. AuthenticatorData.parseFrom or CBOR decoding).
-      //
-      // Per WebAuthn (https://www.w3.org/TR/webauthn-3/#sctn-extensions, section 9), "ignoring an
-      // extension is never considered a failure", so a malformed *optional* extension must not
-      // abort the whole registration/authentication. We log it and drop only this extension,
-      // letting the ceremony and the remaining extensions proceed. The catch is intentionally
-      // narrowed to IllegalArgumentException so that unrelated programming errors - handled by
-      // the final rethrow - are not masked.
-      logger.warn("Skipping extension that failed during processing", e);
-      return;
+      // Malformed caller input for a requested extension (see the class of cases in the Javadoc
+      // contract above); surfaced regardless of authenticator support, since several extensions
+      // validate input before checking support. Surfaced as BAD_REQUEST rather than silently
+      // dropped, which would mask a relying-party bug. Genuine programming defects (other unchecked
+      // exceptions) are not masked: they fall through to the final rethrow.
+      String message = e.getMessage() != null ? e.getMessage() : e.toString();
+      throw new ClientError(ClientError.Code.BAD_REQUEST, message, e);
     }
     throw e;
   }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 Yubico.
+ * Copyright (C) 2020-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import com.yubico.yubikit.fido.client.extensions.CredBlobExtension;
 import com.yubico.yubikit.fido.client.extensions.CredPropsExtension;
 import com.yubico.yubikit.fido.client.extensions.CredProtectExtension;
 import com.yubico.yubikit.fido.client.extensions.Extension;
+import com.yubico.yubikit.fido.client.extensions.ExtensionConfigurationException;
 import com.yubico.yubikit.fido.client.extensions.HmacSecretExtension;
 import com.yubico.yubikit.fido.client.extensions.LargeBlobExtension;
 import com.yubico.yubikit.fido.client.extensions.MinPinLengthExtension;
@@ -474,11 +475,15 @@ public class Ctap2Client implements WebAuthnClient {
             | (excludeCredentials.isEmpty() ? 0 : ClientPin.PIN_PERMISSION_GA);
     List<Extension.RegistrationProcessor> registrationProcessors = new ArrayList<>();
     for (Extension extension : extensions) {
-      Extension.RegistrationProcessor processor =
-          extension.makeCredential(ctap, options, clientPin.getPinUvAuth());
-      if (processor != null) {
-        registrationProcessors.add(processor);
-        permissions |= processor.getPermissions();
+      try {
+        Extension.RegistrationProcessor processor =
+            extension.makeCredential(ctap, options, clientPin.getPinUvAuth());
+        if (processor != null) {
+          registrationProcessors.add(processor);
+          permissions |= processor.getPermissions();
+        }
+      } catch (RuntimeException e) {
+        handleExtensionFailure(e);
       }
     }
 
@@ -518,7 +523,11 @@ public class Ctap2Client implements WebAuthnClient {
 
     HashMap<String, Object> authenticatorInputs = new HashMap<>();
     for (Extension.RegistrationProcessor processor : registrationProcessors) {
-      authenticatorInputs.putAll(processor.getInput(authParams.pinToken));
+      try {
+        authenticatorInputs.putAll(processor.getInput(authParams.pinToken));
+      } catch (RuntimeException e) {
+        handleExtensionFailure(e);
+      }
     }
 
     final PublicKeyCredentialDescriptor credToExclude =
@@ -574,9 +583,25 @@ public class Ctap2Client implements WebAuthnClient {
             state);
 
     ClientExtensionResults clientExtensionResults = new ClientExtensionResults();
-    for (Extension.RegistrationProcessor processor : registrationProcessors) {
-      AttestationObject attestationObject = AttestationObject.fromCredential(credentialData);
-      clientExtensionResults.add(processor.getOutput(attestationObject, authParams.pinToken));
+    // Parse the attestation once for extension-output processing and share it across all
+    // processors (the public makeCredential() parses it again to build the response). A failure
+    // here is not extension-specific (the authenticator's attestation could not be parsed); since
+    // the credential was already created, log it and return without extension outputs rather than
+    // failing the whole ceremony or reporting it as an extension error.
+    AttestationObject attestationObject = null;
+    try {
+      attestationObject = AttestationObject.fromCredential(credentialData);
+    } catch (RuntimeException e) {
+      logger.warn("Failed to parse attestation object; skipping extension outputs", e);
+    }
+    if (attestationObject != null) {
+      for (Extension.RegistrationProcessor processor : registrationProcessors) {
+        try {
+          clientExtensionResults.add(processor.getOutput(attestationObject, authParams.pinToken));
+        } catch (RuntimeException e) {
+          handleExtensionFailure(e);
+        }
+      }
     }
     return new Pair<>(credentialData, clientExtensionResults);
   }
@@ -621,11 +646,15 @@ public class Ctap2Client implements WebAuthnClient {
     int permissions = ClientPin.PIN_PERMISSION_GA;
     List<Extension.AuthenticationProcessor> authenticationProcessors = new ArrayList<>();
     for (Extension extension : extensions) {
-      Extension.AuthenticationProcessor processor =
-          extension.getAssertion(ctap, options, clientPin.getPinUvAuth());
-      if (processor != null) {
-        authenticationProcessors.add(processor);
-        permissions |= processor.getPermissions();
+      try {
+        Extension.AuthenticationProcessor processor =
+            extension.getAssertion(ctap, options, clientPin.getPinUvAuth());
+        if (processor != null) {
+          authenticationProcessors.add(processor);
+          permissions |= processor.getPermissions();
+        }
+      } catch (RuntimeException e) {
+        handleExtensionFailure(e);
       }
     }
 
@@ -648,7 +677,11 @@ public class Ctap2Client implements WebAuthnClient {
 
     HashMap<String, Object> authenticatorInputs = new HashMap<>();
     for (Extension.AuthenticationProcessor processor : authenticationProcessors) {
-      authenticatorInputs.putAll(processor.getInput(selectedCred, authParams.pinToken));
+      try {
+        authenticatorInputs.putAll(processor.getInput(selectedCred, authParams.pinToken));
+      } catch (RuntimeException e) {
+        handleExtensionFailure(e);
+      }
     }
 
     if (!allowCredentials.isEmpty() && selectedCred == null) {
@@ -687,7 +720,11 @@ public class Ctap2Client implements WebAuthnClient {
       for (final Ctap2Session.AssertionData assertionData : assertions) {
         ClientExtensionResults clientExtensionResults = new ClientExtensionResults();
         for (Extension.AuthenticationProcessor processor : authenticationProcessors) {
-          clientExtensionResults.add(processor.getOutput(assertionData, authParams.pinToken));
+          try {
+            clientExtensionResults.add(processor.getOutput(assertionData, authParams.pinToken));
+          } catch (RuntimeException e) {
+            handleExtensionFailure(e);
+          }
         }
         result.add(new Pair<>(assertionData, clientExtensionResults));
       }
@@ -842,6 +879,49 @@ public class Ctap2Client implements WebAuthnClient {
     }
 
     return new PinUvAuthDummyProtocol();
+  }
+
+  /**
+   * Handles a {@link RuntimeException} raised while processing a single client extension, applying
+   * the three-way policy that keeps one extension from breaking a whole ceremony:
+   *
+   * <ul>
+   *   <li><b>{@link ExtensionConfigurationException} — abort.</b> The relying party explicitly
+   *       requested a capability that cannot be satisfied (e.g. {@code credProtect} with {@code
+   *       enforceCredentialProtectionPolicy}, or {@code largeBlob} {@code support:"required"} on an
+   *       authenticator that does not support it). Surfaced as a {@link ClientError} that fails the
+   *       ceremony, carrying the {@link ClientError.Code} the extension chose.
+   *   <li><b>{@link IllegalArgumentException} — skip.</b> See the inline note below.
+   *   <li><b>Anything else — rethrow.</b> Any other unchecked exception (e.g. {@link
+   *       NullPointerException}, {@link ClassCastException}, {@link IllegalStateException}) is
+   *       treated as a genuine defect and propagated unchanged rather than silently swallowed.
+   * </ul>
+   */
+  private void handleExtensionFailure(RuntimeException e) throws ClientError {
+    if (e instanceof ExtensionConfigurationException) {
+      ExtensionConfigurationException configError = (ExtensionConfigurationException) e;
+      throw new ClientError(configError.getCode(), configError.getMessage(), configError);
+    }
+    if (e instanceof IllegalArgumentException) {
+      // An IllegalArgumentException here means an extension could not process its data; the failure
+      // is recoverable by dropping that one extension. It is raised by the decode/validation
+      // helpers an extension calls, not by our extensions signaling "not applicable" (that case
+      // returns null instead of throwing). Typical sources are malformed relying-party input (e.g.
+      // invalid base64url rejected by Base64.fromUrlSafeString while decoding prf/hmac-secret
+      // salts,
+      // a credBlob, sign keyHandle/tbs, or a largeBlob payload) and malformed authenticator output
+      // (e.g. AuthenticatorData.parseFrom or CBOR decoding).
+      //
+      // Per WebAuthn (https://www.w3.org/TR/webauthn-3/#sctn-extensions, section 9), "ignoring an
+      // extension is never considered a failure", so a malformed *optional* extension must not
+      // abort the whole registration/authentication. We log it and drop only this extension,
+      // letting the ceremony and the remaining extensions proceed. The catch is intentionally
+      // narrowed to IllegalArgumentException so that unrelated programming errors - handled by
+      // the final rethrow - are not masked.
+      logger.warn("Skipping extension that failed during processing", e);
+      return;
+    }
+    throw e;
   }
 
   private int getSafePinRetryCount() {

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredBlobExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredBlobExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Yubico.
+ * Copyright (C) 2024-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,12 +55,18 @@ public class CredBlobExtension extends Extension {
       return null;
     }
 
-    String b64Blob = (String) extensions.get("credBlob");
-    if (b64Blob != null) {
-      byte[] blob = fromUrlSafeString(b64Blob);
-      if (blob.length <= ctap.getCachedInfo().getMaxCredBlobLength()) {
-        return new RegistrationProcessor(pinToken -> Collections.singletonMap(name, blob));
-      }
+    Object value = extensions.get("credBlob");
+    if (value == null) {
+      return null; // not requested
+    }
+    if (!(value instanceof String)) {
+      throw new IllegalArgumentException("credBlob must be a string");
+    }
+    byte[] blob = fromUrlSafeString((String) value);
+    // Per spec, the platform passes credBlob to the authenticator only when it fits within
+    // maxCredBlobLength; otherwise it is ignored.
+    if (blob.length <= ctap.getCachedInfo().getMaxCredBlobLength()) {
+      return new RegistrationProcessor(pinToken -> Collections.singletonMap(name, blob));
     }
 
     return null;
@@ -77,7 +83,11 @@ public class CredBlobExtension extends Extension {
     if (extensions == null) {
       return null;
     }
-    if (isSupported(ctap) && Boolean.TRUE.equals(extensions.get("getCredBlob"))) {
+    Object getCredBlob = extensions.get("getCredBlob");
+    if (getCredBlob != null && !(getCredBlob instanceof Boolean)) {
+      throw new IllegalArgumentException("getCredBlob must be a boolean");
+    }
+    if (isSupported(ctap) && Boolean.TRUE.equals(getCredBlob)) {
       return new AuthenticationProcessor(
           (AuthenticationInput) (selected, pinToken) -> Collections.singletonMap(name, true));
     }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredPropsExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredPropsExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Yubico.
+ * Copyright (C) 2024-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,21 +50,29 @@ public class CredPropsExtension extends Extension {
       return null;
     }
 
-    if (extensions.has(name)) {
-      AuthenticatorSelectionCriteria authenticatorSelection = options.getAuthenticatorSelection();
-      String optionsRk =
-          authenticatorSelection != null ? authenticatorSelection.getResidentKey() : null;
-      Boolean authenticatorRk = (Boolean) ctap.getCachedInfo().getOptions().get("rk");
-      boolean rk =
-          (ResidentKeyRequirement.REQUIRED.equals(optionsRk)
-              || (ResidentKeyRequirement.PREFERRED.equals(optionsRk)
-                  && Boolean.TRUE.equals(authenticatorRk)));
-
-      return new RegistrationProcessor(
-          (attestationObject, pinToken) ->
-              serializationType ->
-                  Collections.singletonMap(name, Collections.singletonMap("rk", rk)));
+    Object value = extensions.get(name);
+    if (value == null) {
+      return null; // not requested
     }
-    return null;
+    if (!(value instanceof Boolean)) {
+      throw new IllegalArgumentException("credProps must be a boolean");
+    }
+    if (!(Boolean) value) {
+      return null; // false = not requested
+    }
+
+    AuthenticatorSelectionCriteria authenticatorSelection = options.getAuthenticatorSelection();
+    String optionsRk =
+        authenticatorSelection != null ? authenticatorSelection.getResidentKey() : null;
+    Boolean authenticatorRk = (Boolean) ctap.getCachedInfo().getOptions().get("rk");
+    boolean rk =
+        (ResidentKeyRequirement.REQUIRED.equals(optionsRk)
+                || ResidentKeyRequirement.PREFERRED.equals(optionsRk))
+            && Boolean.TRUE.equals(authenticatorRk);
+
+    return new RegistrationProcessor(
+        (attestationObject, pinToken) ->
+            serializationType ->
+                Collections.singletonMap(name, Collections.singletonMap("rk", rk)));
   }
 }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtension.java
@@ -54,18 +54,22 @@ public class CredProtectExtension extends Extension {
       return null;
     }
 
-    // Treat malformed input (wrong type or unknown policy) as absent and ignore the extension.
     Object policyValue = extensions.get(POLICY);
-    if (!(policyValue instanceof String)) {
+    if (policyValue == null) {
       return null;
     }
-
-    Integer credProtect = credProtectValue((String) policyValue);
+    Integer credProtect =
+        policyValue instanceof String ? credProtectValue((String) policyValue) : null;
     if (credProtect == null) {
-      return null;
+      throw new IllegalArgumentException(
+          "credentialProtectionPolicy must be a recognized policy value");
     }
 
-    boolean enforce = Boolean.TRUE.equals(extensions.get(ENFORCE));
+    Object enforceValue = extensions.get(ENFORCE);
+    if (enforceValue != null && !(enforceValue instanceof Boolean)) {
+      throw new IllegalArgumentException("enforceCredentialProtectionPolicy must be a boolean");
+    }
+    boolean enforce = Boolean.TRUE.equals(enforceValue);
     if (enforce && !isSupported(ctap) && credProtect > 0x01) {
       throw new ExtensionConfigurationException("No Credential Protection support");
     }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Yubico.
+ * Copyright (C) 2024-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,22 +54,22 @@ public class CredProtectExtension extends Extension {
       return null;
     }
 
-    String credentialProtectionPolicy = (String) extensions.get(POLICY);
-    if (credentialProtectionPolicy == null) {
+    // Treat malformed input (wrong type or unknown policy) as absent and ignore the extension.
+    Object policyValue = extensions.get(POLICY);
+    if (!(policyValue instanceof String)) {
       return null;
     }
 
-    Integer credProtect = credProtectValue(credentialProtectionPolicy);
-    Boolean enforce = (Boolean) extensions.get(ENFORCE);
-    if (Boolean.TRUE.equals(enforce)
-        && !isSupported(ctap)
-        && credProtect != null
-        && credProtect > 0x01) {
-      throw new IllegalArgumentException("No Credential Protection support");
+    Integer credProtect = credProtectValue((String) policyValue);
+    if (credProtect == null) {
+      return null;
     }
-    return credProtect != null
-        ? new RegistrationProcessor(pinToken -> Collections.singletonMap(name, credProtect))
-        : null;
+
+    boolean enforce = Boolean.TRUE.equals(extensions.get(ENFORCE));
+    if (enforce && !isSupported(ctap) && credProtect > 0x01) {
+      throw new ExtensionConfigurationException("No Credential Protection support");
+    }
+    return new RegistrationProcessor(pinToken -> Collections.singletonMap(name, credProtect));
   }
 
   @Nullable

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/Extension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/Extension.java
@@ -31,7 +31,18 @@ import org.jspecify.annotations.Nullable;
 /**
  * Base class for FIDO2 extensions.
  *
- * @see <a href="https://www.w3.org/TR/webauthn-3/#sctn-extensions">Webauthn Extensions</a>
+ * <p>Extension processing methods communicate their outcome with two signals: <b>return {@code
+ * null}</b> when the extension does not apply (not requested, not supported, nothing to evaluate,
+ * an extension with no registered handler, or malformed authenticator output) so it is ignored and
+ * the ceremony continues; <b>throw</b> to abort the ceremony (an {@link
+ * ExtensionConfigurationException} for an unsatisfiable requested capability / spec {@code
+ * NotSupportedError}, or an {@link IllegalArgumentException} for malformed caller input / spec
+ * {@code SyntaxError}). The full error-vs-ignore contract — including how each member kind treats a
+ * wrong type or invalid value — is documented on {@code Ctap2Client#handleExtensionFailure}. Note
+ * that the deferred output providers returned by {@code getOutput} run outside that handler during
+ * serialization and MUST NOT throw.
+ *
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#sctn-extensions">WebAuthn Extensions</a>
  */
 public abstract class Extension {
   protected final String name;

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ExtensionConfigurationException.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ExtensionConfigurationException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import com.yubico.yubikit.fido.client.ClientError;
+
+/**
+ * Thrown by an {@link Extension} when the relying party has explicitly requested a capability that
+ * cannot be satisfied (for example {@code enforceCredentialProtectionPolicy} or {@code largeBlob}
+ * {@code support: "required"} on an authenticator that does not support it).
+ *
+ * <p>Unlike conditions that merely cause an extension to be ignored — which are signalled by
+ * returning {@code null} from the extension's processing methods — this is a <em>hard failure</em>
+ * that must abort the WebAuthn ceremony. The client catches it and surfaces it as a {@link
+ * ClientError} with the carried {@link ClientError.Code}.
+ *
+ * <p>It is unchecked so it can be raised from the extension processing lambdas (whose functional
+ * interfaces do not declare checked exceptions) without changing the {@link Extension} API.
+ *
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#sctn-extensions">WebAuthn Extensions</a>
+ */
+public class ExtensionConfigurationException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
+
+  private final ClientError.Code code;
+
+  public ExtensionConfigurationException(String message) {
+    this(ClientError.Code.CONFIGURATION_UNSUPPORTED, message);
+  }
+
+  public ExtensionConfigurationException(ClientError.Code code, String message) {
+    super(message);
+    this.code = code;
+  }
+
+  /** The {@link ClientError.Code} the client should report when aborting the ceremony. */
+  public ClientError.Code getCode() {
+    return code;
+  }
+}

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtension.java
@@ -107,7 +107,14 @@ public class HmacSecretExtension extends Extension {
     }
 
     boolean prf = extensions.has(PRF);
-    boolean hmac = allowHmacSecret && Boolean.TRUE.equals(extensions.get(HMAC_CREATE_SECRET));
+    boolean hmac = false;
+    if (allowHmacSecret) {
+      Object hmacCreateSecret = extensions.get(HMAC_CREATE_SECRET);
+      if (hmacCreateSecret != null && !(hmacCreateSecret instanceof Boolean)) {
+        throw new IllegalArgumentException("hmacCreateSecret must be a boolean");
+      }
+      hmac = Boolean.TRUE.equals(hmacCreateSecret);
+    }
 
     if (!prf && !hmac) {
       return null;
@@ -117,11 +124,20 @@ public class HmacSecretExtension extends Extension {
     Map<String, Object> extensionInputs = new HashMap<>();
     extensionInputs.put(name, true);
 
+    Inputs inputs = Inputs.fromExtensions(extensions);
+
+    // WebAuthn prf client extension processing (registration): evalByCredential is only valid
+    // during authentication; its presence here is a NotSupportedError. This is checked
+    // unconditionally, independent of hmac-secret-mc support.
+    if (inputs != null && inputs.prf != null && inputs.prf.evalByCredential != null) {
+      throw new ExtensionConfigurationException(
+          "prf evalByCredential is not valid during registration");
+    }
+
     PinUvAuthHelper pinUvAuthHelper = new PinUvAuthHelper(ctap2, pinUvAuthProtocol);
 
     if (ctap2.getCachedInfo().getExtensions().contains(NAME_MC)
         && pinUvAuthHelper.keyAgreement != null) {
-      Inputs inputs = Inputs.fromExtensions(extensions);
       Salts salts = prepareSalts(null, null, inputs);
 
       if (salts != null) {
@@ -139,19 +155,36 @@ public class HmacSecretExtension extends Extension {
 
     return new RegistrationProcessor(
         pinToken -> extensionInputs,
-        (attestationObject, pinToken) ->
-            serializationType -> {
-              Map<String, ?> extResult =
-                  (attestationObject.getAuthenticatorData().getExtensions() != null)
-                      ? attestationObject.getAuthenticatorData().getExtensions()
-                      : Collections.emptyMap();
-              boolean enabled = Boolean.TRUE.equals(extResult.get(name));
-              return formatOutputs(
-                  serializationType,
-                  enabled,
-                  pinUvAuthHelper.decrypt((byte[]) extResult.get(NAME_MC)),
-                  prf);
-            });
+        (attestationObject, pinToken) -> {
+          // Read and decrypt the authenticator's hmac-secret-mc output here, in the synchronous
+          // phase, so the deferred provider returned below does only (non-throwing) formatting and
+          // cannot let an exception escape credential.toMap(). Malformed device output (undecodable
+          // ciphertext, a short decrypted result, or a wrong type) is omitted, not surfaced.
+          try {
+            Map<String, ?> extResult =
+                attestationObject.getAuthenticatorData().getExtensions() != null
+                    ? attestationObject.getAuthenticatorData().getExtensions()
+                    : Collections.emptyMap();
+            boolean enabled = Boolean.TRUE.equals(extResult.get(name));
+            Object mc = extResult.get(NAME_MC);
+            byte[] decrypted = pinUvAuthHelper.decrypt(mc instanceof byte[] ? (byte[]) mc : null);
+            // CTAP hmac-secret-mc output is exactly one or two 32-byte blocks; any other length is
+            // malformed, so the salt results are omitted (the enabled flag is still reported).
+            boolean validLength =
+                decrypted != null
+                    && (decrypted.length == SALT_LEN || decrypted.length == 2 * SALT_LEN);
+            byte[] output1 = validLength ? Arrays.copyOfRange(decrypted, 0, SALT_LEN) : null;
+            byte[] output2 =
+                validLength && decrypted.length == 2 * SALT_LEN
+                    ? Arrays.copyOfRange(decrypted, SALT_LEN, 2 * SALT_LEN)
+                    : null;
+            return serializationType ->
+                formatOutputs(serializationType, enabled, output1, output2, prf);
+          } catch (RuntimeException e) {
+            logger.debug("Ignoring malformed hmac-secret registration output", e);
+            return null;
+          }
+        });
   }
 
   @Override
@@ -194,71 +227,89 @@ public class HmacSecretExtension extends Extension {
 
     final AuthenticationOutput prepareOutput =
         (assertionData, pinToken) -> {
-          AuthenticatorData authenticatorData =
-              AuthenticatorData.parseFrom(ByteBuffer.wrap(assertionData.getAuthenticatorData()));
+          try {
+            AuthenticatorData authenticatorData =
+                AuthenticatorData.parseFrom(ByteBuffer.wrap(assertionData.getAuthenticatorData()));
 
-          Map<String, ?> extensionOutputs = authenticatorData.getExtensions();
-          if (extensionOutputs == null) {
-            return null;
-          }
+            Map<String, ?> extensionOutputs = authenticatorData.getExtensions();
+            if (extensionOutputs == null) {
+              return null;
+            }
 
-          byte[] value = (byte[]) extensionOutputs.get(name);
-          if (value == null) {
-            return null;
-          }
+            Object value = extensionOutputs.get(name);
+            if (!(value instanceof byte[])) {
+              return null;
+            }
 
-          byte[] decrypted = pinUvAuthHelper.decrypt(value);
-          if (decrypted == null) {
-            return null;
-          }
+            byte[] decrypted = pinUvAuthHelper.decrypt((byte[]) value);
+            // CTAP hmac-secret output is exactly one or two 32-byte blocks. Any other length is
+            // malformed authenticator output -> omit the result rather than zero-padding it into a
+            // wrong PRF value.
+            if (decrypted == null
+                || (decrypted.length != SALT_LEN && decrypted.length != 2 * SALT_LEN)) {
+              return null;
+            }
 
-          byte[] output1 = Arrays.copyOf(decrypted, SALT_LEN);
-          byte[] output2 =
-              decrypted.length > SALT_LEN
-                  ? Arrays.copyOfRange(decrypted, SALT_LEN, 2 * SALT_LEN)
-                  : new byte[0];
+            byte[] output1 = Arrays.copyOfRange(decrypted, 0, SALT_LEN);
+            byte[] output2 =
+                decrypted.length == 2 * SALT_LEN
+                    ? Arrays.copyOfRange(decrypted, SALT_LEN, 2 * SALT_LEN)
+                    : null;
 
-          logger.debug("PRF outputs decrypted successfully");
+            logger.debug("PRF outputs decrypted successfully");
 
-          if (inputs.prf != null) {
-            return serializationType -> {
-              Map<String, Object> results = new HashMap<>();
-              results.put(
-                  FIRST,
-                  serializationType == SerializationType.JSON ? toUrlSafeString(output1) : output1);
-              if (output2.length > 0) {
+            if (inputs.prf != null) {
+              return serializationType -> {
+                Map<String, Object> results = new HashMap<>();
                 results.put(
-                    SECOND,
+                    FIRST,
                     serializationType == SerializationType.JSON
-                        ? toUrlSafeString(output2)
-                        : output2);
-              }
-              return Collections.singletonMap(PRF, Collections.singletonMap(RESULTS, results));
-            };
-          } else {
-            return serializationType -> {
-              Map<String, Object> results = new HashMap<>();
-              results.put(
-                  OUTPUT_1,
-                  serializationType == SerializationType.JSON ? toUrlSafeString(output1) : output1);
-              if (output2.length > 0) {
+                        ? toUrlSafeString(output1)
+                        : output1);
+                if (output2 != null) {
+                  results.put(
+                      SECOND,
+                      serializationType == SerializationType.JSON
+                          ? toUrlSafeString(output2)
+                          : output2);
+                }
+                return Collections.singletonMap(PRF, Collections.singletonMap(RESULTS, results));
+              };
+            } else {
+              return serializationType -> {
+                Map<String, Object> results = new HashMap<>();
                 results.put(
-                    OUTPUT_2,
+                    OUTPUT_1,
                     serializationType == SerializationType.JSON
-                        ? toUrlSafeString(output2)
-                        : output2);
-              }
-              return Collections.singletonMap(HMAC_GET_SECRET, results);
-            };
+                        ? toUrlSafeString(output1)
+                        : output1);
+                if (output2 != null) {
+                  results.put(
+                      OUTPUT_2,
+                      serializationType == SerializationType.JSON
+                          ? toUrlSafeString(output2)
+                          : output2);
+                }
+                return Collections.singletonMap(HMAC_GET_SECRET, results);
+              };
+            }
+          } catch (RuntimeException e) {
+            // Authenticator returned malformed hmac-secret output (undecodable authData, wrong
+            // type, or a decrypt failure): omit the result rather than failing the assertion or
+            // misreporting the authenticator's fault as a relying-party error.
+            logger.debug("Ignoring malformed hmac-secret assertion output", e);
+            return null;
           }
         };
 
     return new AuthenticationProcessor(prepareInput, prepareOutput);
   }
 
+  // Package-private (not private) so it can be unit-tested directly: this is a pure function of its
+  // inputs (parsing + SHA-256 salt derivation) with no device I/O, unlike the surrounding
+  // key-agreement path which requires a real authenticator.
   @SuppressWarnings("unchecked")
-  @Nullable
-  private Salts prepareSalts(
+  @Nullable Salts prepareSalts(
       @Nullable List<PublicKeyCredentialDescriptor> allowCredentials,
       @Nullable PublicKeyCredentialDescriptor selected,
       Inputs inputs) {
@@ -268,10 +319,11 @@ public class HmacSecretExtension extends Extension {
       Map<String, Object> prfValues = inputs.prf.eval;
       Map<String, Object> evalByCredential = inputs.prf.evalByCredential;
 
-      if (evalByCredential != null) {
+      if (evalByCredential != null && !evalByCredential.isEmpty()) {
         if (allowCredentials == null || allowCredentials.isEmpty()) {
-          // Invalid input (evalByCredential without an allow list): ignore the extension.
-          return null;
+          // WebAuthn (prf client extension processing): evalByCredential non-empty with an empty
+          // allowCredentials is a NotSupportedError -> CONFIGURATION_UNSUPPORTED.
+          throw new ExtensionConfigurationException("prf evalByCredential requires an allow list");
         }
 
         Set<String> ids = new HashSet<>();
@@ -280,45 +332,50 @@ public class HmacSecretExtension extends Extension {
         }
 
         if (!ids.containsAll(evalByCredential.keySet())) {
-          // Invalid input (unknown credential id): ignore the extension.
-          return null;
+          // WebAuthn (prf): a key not matching an allowCredentials id is a SyntaxError ->
+          // BAD_REQUEST.
+          throw new IllegalArgumentException("prf evalByCredential contains an unknown credential");
         }
 
         if (selected != null) {
           String key = toUrlSafeString(selected.getId());
           if (evalByCredential.containsKey(key)) {
-            prfValues = (Map<String, Object>) inputs.prf.evalByCredential.get(key);
+            prfValues = asMap(inputs.prf.evalByCredential.get(key), "prf.evalByCredential entry");
           }
         }
       }
 
       if (prfValues == null) {
+        // No evaluation was requested for this credential: nothing to do (not an error).
         return null;
       }
 
       logger.debug("Processing PRF inputs");
 
-      String firstInput = (String) prfValues.get(FIRST);
+      String firstInput = asString(prfValues.get(FIRST), "prf eval 'first'");
       if (firstInput == null) {
-        return null;
+        // Malformed input: a prf eval block must contain "first".
+        throw new IllegalArgumentException("prf eval requires 'first'");
       }
 
       byte[] first = prfSalt(fromUrlSafeString(firstInput));
-      byte[] second =
-          prfValues.containsKey(SECOND)
-              ? prfSalt(fromUrlSafeString((String) prfValues.get(SECOND)))
-              : null;
+      // "second" is optional: an absent or null value means no second salt; a wrong-typed value is
+      // malformed input (asString throws IllegalArgumentException -> BAD_REQUEST).
+      String secondInput = asString(prfValues.get(SECOND), "prf eval 'second'");
+      byte[] second = secondInput != null ? prfSalt(fromUrlSafeString(secondInput)) : null;
 
       salts = new Salts(first, second);
     } else {
       if (inputs.hmac == null) {
+        // hmacGetSecret was not requested: nothing to do (not an error).
         return null;
       }
 
       logger.debug("Processing hmacGetSecret inputs");
 
       if (inputs.hmac.salt1 == null) {
-        return null;
+        // Malformed input: hmacGetSecret must contain salt1.
+        throw new IllegalArgumentException("hmacGetSecret requires salt1");
       }
 
       byte[] salt1 = prfSalt(fromUrlSafeString(inputs.hmac.salt1));
@@ -331,8 +388,7 @@ public class HmacSecretExtension extends Extension {
     logger.debug("Salts prepared");
     if (!(salts.salt1.length == SALT_LEN
         && (salts.salt2.length == 0 || salts.salt2.length == SALT_LEN))) {
-      // Invalid salt length: ignore the extension.
-      return null;
+      throw new IllegalArgumentException("Invalid salt length");
     }
 
     return salts;
@@ -341,12 +397,11 @@ public class HmacSecretExtension extends Extension {
   private Map<String, Object> formatOutputs(
       SerializationType serializationType,
       @Nullable Boolean enabled,
-      byte @Nullable [] decrypted,
+      byte @Nullable [] output1,
+      byte @Nullable [] output2,
       boolean prf) {
-    byte[] output1 = decrypted != null ? Arrays.copyOfRange(decrypted, 0, SALT_LEN) : null;
-    byte[] output2 =
-        decrypted != null ? Arrays.copyOfRange(decrypted, SALT_LEN, decrypted.length) : null;
-
+    // Pure formatting: callers slice the decrypted bytes into output1/output2 beforehand, so this
+    // only selects the wire encoding (raw bytes for CBOR, base64url for JSON) and cannot throw.
     Map<String, @Nullable Object> result = new HashMap<>();
     if (prf) {
       result.put(ENABLED, enabled);
@@ -388,7 +443,7 @@ public class HmacSecretExtension extends Extension {
     }
   }
 
-  private static class Salts {
+  static class Salts {
     byte[] salt1;
     byte[] salt2;
 
@@ -418,6 +473,39 @@ public class HmacSecretExtension extends Extension {
     }
   }
 
+  /**
+   * Returns {@code value} as a {@code Map} (a dictionary extension member). Absent values are
+   * ignored ({@code null}); a wrong-typed value is malformed structure and is surfaced as an {@link
+   * IllegalArgumentException} (mapped to {@code BAD_REQUEST}).
+   */
+  @SuppressWarnings("unchecked")
+  @Nullable
+  private static Map<String, Object> asMap(@Nullable Object value, String field) {
+    if (value == null) {
+      return null;
+    }
+    if (!(value instanceof Map)) {
+      throw new IllegalArgumentException(field + " must be an object");
+    }
+    return (Map<String, Object>) value;
+  }
+
+  /**
+   * Returns {@code value} as a {@code String} (a base64url BufferSource member). Absent values are
+   * ignored ({@code null}); a wrong-typed value is malformed structure and is surfaced as an {@link
+   * IllegalArgumentException} (mapped to {@code BAD_REQUEST}).
+   */
+  @Nullable
+  private static String asString(@Nullable Object value, String field) {
+    if (value == null) {
+      return null;
+    }
+    if (!(value instanceof String)) {
+      throw new IllegalArgumentException(field + " must be a string");
+    }
+    return (String) value;
+  }
+
   private static class PrfInputs {
     @Nullable final Map<String, Object> eval;
     @Nullable final Map<String, Object> evalByCredential;
@@ -427,7 +515,6 @@ public class HmacSecretExtension extends Extension {
       this.evalByCredential = evalByCredential;
     }
 
-    @SuppressWarnings("unchecked")
     @Nullable
     static PrfInputs fromMap(@Nullable Map<String, Object> map) {
       if (map == null) {
@@ -435,7 +522,8 @@ public class HmacSecretExtension extends Extension {
       }
 
       return new PrfInputs(
-          (Map<String, Object>) map.get(EVAL), (Map<String, Object>) map.get(EVAL_BY_CREDENTIAL));
+          asMap(map.get(EVAL), "prf.eval"),
+          asMap(map.get(EVAL_BY_CREDENTIAL), "prf.evalByCredential"));
     }
   }
 
@@ -454,12 +542,13 @@ public class HmacSecretExtension extends Extension {
         return null;
       }
 
-      return new HmacInputs((String) map.get(SALT_1), (String) map.get(SALT_2));
+      return new HmacInputs(
+          asString(map.get(SALT_1), "hmacGetSecret.salt1"),
+          asString(map.get(SALT_2), "hmacGetSecret.salt2"));
     }
   }
 
-  @SuppressWarnings("unchecked")
-  private static class Inputs {
+  static class Inputs {
     @Nullable final PrfInputs prf;
     @Nullable final HmacInputs hmac;
 
@@ -475,8 +564,7 @@ public class HmacSecretExtension extends Extension {
       }
 
       return new Inputs(
-          (Map<String, Object>) extensions.get(PRF),
-          (Map<String, Object>) extensions.get(HMAC_GET_SECRET));
+          asMap(extensions.get(PRF), PRF), asMap(extensions.get(HMAC_GET_SECRET), HMAC_GET_SECRET));
     }
   }
 

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtension.java
@@ -270,7 +270,8 @@ public class HmacSecretExtension extends Extension {
 
       if (evalByCredential != null) {
         if (allowCredentials == null || allowCredentials.isEmpty()) {
-          throw new IllegalArgumentException("evalByCredential needs allow list");
+          // Invalid input (evalByCredential without an allow list): ignore the extension.
+          return null;
         }
 
         Set<String> ids = new HashSet<>();
@@ -279,7 +280,8 @@ public class HmacSecretExtension extends Extension {
         }
 
         if (!ids.containsAll(evalByCredential.keySet())) {
-          throw new IllegalArgumentException("evalByCredentials contains invalid key");
+          // Invalid input (unknown credential id): ignore the extension.
+          return null;
         }
 
         if (selected != null) {
@@ -329,7 +331,8 @@ public class HmacSecretExtension extends Extension {
     logger.debug("Salts prepared");
     if (!(salts.salt1.length == SALT_LEN
         && (salts.salt2.length == 0 || salts.salt2.length == SALT_LEN))) {
-      throw new IllegalArgumentException("Invalid salt length");
+      // Invalid salt length: ignore the extension.
+      return null;
     }
 
     return salts;

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
@@ -20,7 +20,6 @@ import static com.yubico.yubikit.core.internal.codec.Base64.fromUrlSafeString;
 import static com.yubico.yubikit.core.internal.codec.Base64.toUrlSafeString;
 
 import com.yubico.yubikit.core.application.CommandException;
-import com.yubico.yubikit.fido.client.ClientError;
 import com.yubico.yubikit.fido.ctap.ClientPin;
 import com.yubico.yubikit.fido.ctap.Ctap2Session;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
@@ -56,6 +55,7 @@ public class LargeBlobExtension extends Extension {
   static final String SUPPORT = "support";
   static final String SUPPORTED = "supported";
   static final String REQUIRED = "required";
+  static final String PREFERRED = "preferred";
   static final String BLOB = "blob";
   static final Logger logger = LoggerFactory.getLogger(LargeBlobExtension.class);
 
@@ -77,9 +77,11 @@ public class LargeBlobExtension extends Extension {
       PinUvAuthProtocol pinUvAuthProtocol) {
     final Inputs inputs = Inputs.fromExtensions(options.getExtensions());
     if (inputs != null) {
+      // WebAuthn largeBlob client processing (registration): read/write are authentication-only;
+      // their presence here is a NotSupportedError.
       if (inputs.read != null || inputs.write != null) {
         throw new ExtensionConfigurationException(
-            ClientError.Code.BAD_REQUEST, "Invalid set of parameters");
+            "largeBlob read/write is not valid during registration");
       }
       if (REQUIRED.equals(inputs.support) && !isSupported(ctap)) {
         throw new ExtensionConfigurationException(
@@ -108,11 +110,25 @@ public class LargeBlobExtension extends Extension {
     if (inputs == null) {
       return null;
     }
+    // WebAuthn largeBlob client processing (authentication). Each condition below is a
+    // NotSupportedError in the spec.
+    if (inputs.support != null) {
+      throw new ExtensionConfigurationException(
+          "largeBlob support is not valid during authentication");
+    }
+    if (inputs.read != null && inputs.write != null) {
+      throw new ExtensionConfigurationException(
+          "largeBlob read and write must not both be present");
+    }
     if (Boolean.TRUE.equals(inputs.read)) {
       return new AuthenticationProcessor(
           (selected, pinToken) -> Collections.singletonMap(LARGE_BLOB_KEY, true),
           (assertionData, pinToken) -> read(assertionData, ctap));
     } else if (inputs.write != null) {
+      if (options.getAllowCredentials().size() != 1) {
+        throw new ExtensionConfigurationException(
+            "largeBlob write requires exactly one allowed credential");
+      }
       return new AuthenticationProcessor(
           (selected, pinToken) -> Collections.singletonMap(LARGE_BLOB_KEY, true),
           (assertionData, pinToken) ->
@@ -135,8 +151,18 @@ public class LargeBlobExtension extends Extension {
       return null;
     }
 
+    LargeBlobs largeBlobs;
     try {
-      LargeBlobs largeBlobs = new LargeBlobs(ctap);
+      largeBlobs = new LargeBlobs(ctap);
+    } catch (IllegalStateException e) {
+      // Authenticator returned a largeBlobKey but does not support the large blob array; this is an
+      // expected, ignorable condition (no blob to read), not a processing failure. Scope this catch
+      // to construction only, so an IllegalStateException from getBlob/serialization is not masked.
+      logger.debug("Large blob storage not supported; skipping largeBlob output", e);
+      return null;
+    }
+
+    try {
       byte[] blob = largeBlobs.getBlob(largeBlobKey);
       return serializationType ->
           Collections.singletonMap(
@@ -146,10 +172,6 @@ public class LargeBlobExtension extends Extension {
                       BLOB,
                       serializationType == SerializationType.JSON ? toUrlSafeString(blob) : blob)
                   : Collections.emptyMap());
-    } catch (IllegalStateException e) {
-      // Authenticator returned a largeBlobKey but does not support the large blob array; this is an
-      // expected, ignorable condition (no blob to read), not a processing failure.
-      logger.debug("Large blob storage not supported; skipping largeBlob output", e);
     } catch (IOException | CommandException e) {
       logger.error("LargeBlob processing failed: ", e);
     }
@@ -169,17 +191,23 @@ public class LargeBlobExtension extends Extension {
       return null;
     }
 
+    LargeBlobs largeBlobs;
     try {
-      LargeBlobs largeBlobs = new LargeBlobs(ctap, pinUvAuthProtocol, pinToken);
+      largeBlobs = new LargeBlobs(ctap, pinUvAuthProtocol, pinToken);
+    } catch (IllegalStateException e) {
+      // Authenticator returned a largeBlobKey but does not support the large blob array; this is an
+      // expected, ignorable condition (nothing to write), not a processing failure. Scope this
+      // catch to construction only, so an IllegalStateException from putBlob is not masked.
+      logger.debug("Large blob storage not supported; skipping largeBlob output", e);
+      return null;
+    }
+
+    try {
       largeBlobs.putBlob(largeBlobKey, bytes);
 
       return serializationType ->
           Collections.singletonMap(LARGE_BLOB, Collections.singletonMap(WRITTEN, true));
 
-    } catch (IllegalStateException e) {
-      // Authenticator returned a largeBlobKey but does not support the large blob array; this is an
-      // expected, ignorable condition (nothing to write), not a processing failure.
-      logger.debug("Large blob storage not supported; skipping largeBlob output", e);
     } catch (IOException | CommandException | GeneralSecurityException e) {
       logger.error("LargeBlob processing failed: ", e);
     }
@@ -204,19 +232,28 @@ public class LargeBlobExtension extends Extension {
         return null;
       }
 
-      // Treat malformed input (wrong types) as absent rather than throwing.
       Object data = extensions.get(LARGE_BLOB);
+      if (data == null) {
+        return null; // not requested
+      }
       if (!(data instanceof Map)) {
-        return null;
+        throw new IllegalArgumentException("largeBlob must be an object");
       }
       Map<?, ?> map = (Map<?, ?>) data;
       Object read = map.get(ACTION_READ);
       Object write = map.get(ACTION_WRITE);
       Object support = map.get(SUPPORT);
-      return new Inputs(
-          read instanceof Boolean ? (Boolean) read : null,
-          write instanceof String ? (String) write : null,
-          support instanceof String ? (String) support : null);
+      if (read != null && !(read instanceof Boolean)) {
+        throw new IllegalArgumentException("largeBlob.read must be a boolean");
+      }
+      if (write != null && !(write instanceof String)) {
+        throw new IllegalArgumentException("largeBlob.write must be a string");
+      }
+      if (support != null && !REQUIRED.equals(support) && !PREFERRED.equals(support)) {
+        throw new IllegalArgumentException(
+            "largeBlob.support must be \"required\" or \"preferred\"");
+      }
+      return new Inputs((Boolean) read, (String) write, (String) support);
     }
   }
 }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Yubico.
+ * Copyright (C) 2024-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static com.yubico.yubikit.core.internal.codec.Base64.fromUrlSafeString;
 import static com.yubico.yubikit.core.internal.codec.Base64.toUrlSafeString;
 
 import com.yubico.yubikit.core.application.CommandException;
+import com.yubico.yubikit.fido.client.ClientError;
 import com.yubico.yubikit.fido.ctap.ClientPin;
 import com.yubico.yubikit.fido.ctap.Ctap2Session;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
@@ -77,10 +78,12 @@ public class LargeBlobExtension extends Extension {
     final Inputs inputs = Inputs.fromExtensions(options.getExtensions());
     if (inputs != null) {
       if (inputs.read != null || inputs.write != null) {
-        throw new IllegalArgumentException("Invalid set of parameters");
+        throw new ExtensionConfigurationException(
+            ClientError.Code.BAD_REQUEST, "Invalid set of parameters");
       }
       if (REQUIRED.equals(inputs.support) && !isSupported(ctap)) {
-        throw new IllegalArgumentException("Authenticator does not support large blob storage");
+        throw new ExtensionConfigurationException(
+            "Authenticator does not support large blob storage");
       }
       return new RegistrationProcessor(
           pinToken -> Collections.singletonMap(LARGE_BLOB_KEY, true),
@@ -143,6 +146,10 @@ public class LargeBlobExtension extends Extension {
                       BLOB,
                       serializationType == SerializationType.JSON ? toUrlSafeString(blob) : blob)
                   : Collections.emptyMap());
+    } catch (IllegalStateException e) {
+      // Authenticator returned a largeBlobKey but does not support the large blob array; this is an
+      // expected, ignorable condition (no blob to read), not a processing failure.
+      logger.debug("Large blob storage not supported; skipping largeBlob output", e);
     } catch (IOException | CommandException e) {
       logger.error("LargeBlob processing failed: ", e);
     }
@@ -169,6 +176,10 @@ public class LargeBlobExtension extends Extension {
       return serializationType ->
           Collections.singletonMap(LARGE_BLOB, Collections.singletonMap(WRITTEN, true));
 
+    } catch (IllegalStateException e) {
+      // Authenticator returned a largeBlobKey but does not support the large blob array; this is an
+      // expected, ignorable condition (nothing to write), not a processing failure.
+      logger.debug("Large blob storage not supported; skipping largeBlob output", e);
     } catch (IOException | CommandException | GeneralSecurityException e) {
       logger.error("LargeBlob processing failed: ", e);
     }
@@ -187,21 +198,25 @@ public class LargeBlobExtension extends Extension {
       this.support = support;
     }
 
-    @SuppressWarnings("unchecked")
     @Nullable
     static Inputs fromExtensions(@Nullable Extensions extensions) {
       if (extensions == null) {
         return null;
       }
 
-      Map<String, Object> data = (Map<String, Object>) extensions.get(LARGE_BLOB);
-      if (data == null) {
+      // Treat malformed input (wrong types) as absent rather than throwing.
+      Object data = extensions.get(LARGE_BLOB);
+      if (!(data instanceof Map)) {
         return null;
       }
+      Map<?, ?> map = (Map<?, ?>) data;
+      Object read = map.get(ACTION_READ);
+      Object write = map.get(ACTION_WRITE);
+      Object support = map.get(SUPPORT);
       return new Inputs(
-          (Boolean) data.get(ACTION_READ),
-          (String) data.get(ACTION_WRITE),
-          (String) data.get(SUPPORT));
+          read instanceof Boolean ? (Boolean) read : null,
+          write instanceof String ? (String) write : null,
+          support instanceof String ? (String) support : null);
     }
   }
 }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/MinPinLengthExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/MinPinLengthExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Yubico.
+ * Copyright (C) 2024-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,11 +58,16 @@ public class MinPinLengthExtension extends Extension {
       return null;
     }
 
-    Boolean input = (Boolean) extensions.get(name);
+    Object input = extensions.get(name);
     if (input == null) {
       return null;
     }
-    return new RegistrationProcessor(
-        pinToken -> Collections.singletonMap(name, Boolean.TRUE.equals(input)));
+    if (!(input instanceof Boolean)) {
+      throw new IllegalArgumentException("minPinLength must be a boolean");
+    }
+    if (!(Boolean) input) {
+      return null;
+    }
+    return new RegistrationProcessor(pinToken -> Collections.singletonMap(name, true));
   }
 }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/SignExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/SignExtension.java
@@ -39,8 +39,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SignExtension extends Extension {
+
+  private static final Logger logger = LoggerFactory.getLogger(SignExtension.class);
 
   static final String SIGN = "previewSign";
   static final String ALGORITHMS = "algorithms";
@@ -196,24 +200,19 @@ public class SignExtension extends Extension {
       Ctap2Session ctap2,
       PublicKeyCredentialCreationOptions options,
       PinUvAuthProtocol pinUvAuthProtocol) {
-    Extensions extensions = options.getExtensions();
-    if (extensions == null) {
-      return null;
-    }
-
-    AuthenticationExtensionsSign extSign =
-        AuthenticationExtensionsSign.fromMap((Map<String, ?>) extensions.get(SIGN));
-
+    AuthenticationExtensionsSign extSign = parseSignInput(options.getExtensions());
     if (extSign == null || !isSupported(ctap2)) {
       return null;
     }
 
     if (extSign.signByCredential != null) {
-      throw new IllegalArgumentException("signByCredential input not allowed");
+      // signByCredential is not valid during registration: ignore the extension.
+      return null;
     }
 
     if (extSign.generateKey == null) {
-      throw new IllegalArgumentException("generateKey input required");
+      // generateKey is required during registration: ignore the extension.
+      return null;
     }
 
     final RegistrationInput prepareInput =
@@ -228,64 +227,99 @@ public class SignExtension extends Extension {
     final RegistrationOutput prepareOutput =
         (attestationObject, pinToken) ->
             serializationType -> {
-              AuthenticatorData authData = attestationObject.getAuthenticatorData();
-              Map<String, ?> unsignedExtOutputs = attestationObject.getUnsignedExtensionOutputs();
-              if (unsignedExtOutputs == null) {
-                throw new IllegalArgumentException("Missing unsigned extension outputs");
+              try {
+                AuthenticatorData authData = attestationObject.getAuthenticatorData();
+                Map<String, ?> unsignedExtOutputs = attestationObject.getUnsignedExtensionOutputs();
+                if (unsignedExtOutputs == null) {
+                  // Authenticator returned no sign output: omit the extension result.
+                  return Collections.emptyMap();
+                }
+
+                Map<Integer, ?> unsignedSignExtData =
+                    (Map<Integer, ?>) unsignedExtOutputs.get(name);
+                if (unsignedSignExtData == null) {
+                  return Collections.emptyMap();
+                }
+
+                Object attObjData = unsignedSignExtData.get(7); // att-obj
+                if (!(attObjData instanceof byte[])) {
+                  return Collections.emptyMap();
+                }
+                Map<Integer, ?> origAttObj = (Map<Integer, ?>) Cbor.decode((byte[]) attObjData);
+                if (origAttObj == null) {
+                  return Collections.emptyMap();
+                }
+
+                Object innerAuthDataBytes = origAttObj.get(2); // authData
+                if (!(innerAuthDataBytes instanceof byte[])) {
+                  return Collections.emptyMap();
+                }
+                AuthenticatorData innerAuthData =
+                    AuthenticatorData.parseFrom(ByteBuffer.wrap((byte[]) innerAuthDataBytes));
+                AttestedCredentialData attestedCredentialData =
+                    innerAuthData.getAttestedCredentialData();
+                if (attestedCredentialData == null) {
+                  return Collections.emptyMap();
+                }
+
+                byte[] pkBytes = Cbor.encode(attestedCredentialData.getCosePublicKey()).clone();
+                byte[] keyHandle = attestedCredentialData.getCredentialId();
+
+                Map<String, ?> authDataExtensions = authData.getExtensions();
+                if (authDataExtensions == null) {
+                  return Collections.emptyMap();
+                }
+
+                Map<Integer, ?> authDataSign = (Map<Integer, ?>) authDataExtensions.get(name);
+                Object alg = authDataSign != null ? authDataSign.get(3) : null;
+                if (alg == null) {
+                  return Collections.emptyMap();
+                }
+
+                Map<String, Object> newAttObj = new HashMap<>();
+                newAttObj.put(FMT, origAttObj.get(1));
+                newAttObj.put(AUTH_DATA, origAttObj.get(2));
+                newAttObj.put(ATT_STMT, origAttObj.get(3));
+
+                AuthenticationExtensionsSignGeneratedKey generatedKey =
+                    new AuthenticationExtensionsSignGeneratedKey(
+                        keyHandle, pkBytes, (int) alg, Cbor.encode(newAttObj));
+
+                return Collections.singletonMap(
+                    SIGN,
+                    new SignExtension.AuthenticationExtensionsSignOutputs(generatedKey, null)
+                        .toMap(serializationType));
+              } catch (ClassCastException e) {
+                // Authenticator returned sign output with unexpected CBOR types: omit the result.
+                logger.debug("Ignoring malformed previewSign registration output", e);
+                return Collections.emptyMap();
               }
-
-              Map<Integer, ?> unsignedSignExtData = (Map<Integer, ?>) unsignedExtOutputs.get(name);
-              if (unsignedSignExtData == null) {
-                throw new IllegalArgumentException("Missing sign unsigned extension outputs");
-              }
-
-              Map<Integer, ?> origAttObj =
-                  (Map<Integer, ?>) Cbor.decode((byte[]) unsignedSignExtData.get(7)); // att-obj
-              if (origAttObj == null) {
-                throw new IllegalArgumentException(
-                    "Missing sign unsigned extension attestation object");
-              }
-
-              AuthenticatorData innerAuthData =
-                  AuthenticatorData.parseFrom(ByteBuffer.wrap((byte[]) origAttObj.get(2)));
-              AttestedCredentialData attestedCredentialData =
-                  innerAuthData.getAttestedCredentialData();
-              if (attestedCredentialData == null) {
-                throw new IllegalArgumentException("Missing CredentialData");
-              }
-
-              byte[] pkBytes = Cbor.encode(attestedCredentialData.getCosePublicKey()).clone();
-              byte[] keyHandle = attestedCredentialData.getCredentialId();
-
-              Map<String, ?> authDataExtensions = authData.getExtensions();
-              if (authDataExtensions == null) {
-                throw new IllegalArgumentException("Missing extensions output");
-              }
-
-              Map<Integer, ?> authDataSign = (Map<Integer, ?>) authDataExtensions.get(name);
-              if (authDataSign == null) {
-                throw new IllegalArgumentException("Missing sign extension output");
-              }
-
-              Map<String, Object> newAttObj = new HashMap<>();
-              newAttObj.put(FMT, origAttObj.get(1));
-              newAttObj.put(AUTH_DATA, origAttObj.get(2));
-              newAttObj.put(ATT_STMT, origAttObj.get(3));
-
-              AuthenticationExtensionsSignGeneratedKey generatedKey =
-                  new AuthenticationExtensionsSignGeneratedKey(
-                      keyHandle,
-                      pkBytes,
-                      (int) authDataSign.get(3), // alg
-                      Cbor.encode(newAttObj));
-
-              return Collections.singletonMap(
-                  SIGN,
-                  new SignExtension.AuthenticationExtensionsSignOutputs(generatedKey, null)
-                      .toMap(serializationType));
             };
 
     return new RegistrationProcessor(prepareInput, prepareOutput);
+  }
+
+  /**
+   * Safely parses the {@code previewSign} extension input. Malformed relying-party input (wrong
+   * types, missing keys, or invalid base64url) is treated as "not applicable" and yields {@code
+   * null} so the extension is ignored rather than aborting the ceremony.
+   */
+  @SuppressWarnings("unchecked")
+  @Nullable
+  private static AuthenticationExtensionsSign parseSignInput(@Nullable Extensions extensions) {
+    if (extensions == null) {
+      return null;
+    }
+    Object signInput = extensions.get(SIGN);
+    if (!(signInput instanceof Map)) {
+      return null;
+    }
+    try {
+      return AuthenticationExtensionsSign.fromMap((Map<String, ?>) signInput);
+    } catch (RuntimeException e) {
+      logger.debug("Ignoring malformed previewSign input", e);
+      return null;
+    }
   }
 
   private int getCreateFlags(PublicKeyCredentialCreationOptions options) {
@@ -307,25 +341,21 @@ public class SignExtension extends Extension {
       PublicKeyCredentialRequestOptions options,
       PinUvAuthProtocol pinUvAuthProtocol) {
 
-    Extensions extensions = options.getExtensions();
-    if (extensions == null) {
-      return null;
-    }
-    Map<String, Object> inputs = (Map<String, Object>) extensions.get(SIGN);
-
-    AuthenticationExtensionsSign extSign = AuthenticationExtensionsSign.fromMap(inputs);
+    AuthenticationExtensionsSign extSign = parseSignInput(options.getExtensions());
     if (extSign == null || !isSupported(ctap)) {
       return null;
     }
 
     if (extSign.signByCredential == null || extSign.generateKey != null) {
-      throw new IllegalArgumentException("Invalid inputs");
+      // Invalid input for authentication (expects signByCredential, not generateKey): ignore.
+      return null;
     }
 
     Map<String, AuthenticationExtensionsSignSign> byCreds = extSign.signByCredential;
     List<PublicKeyCredentialDescriptor> allowList = options.getAllowCredentials();
     if (allowList.isEmpty()) {
-      throw new IllegalArgumentException("sign requires allow_list");
+      // sign requires an allow list: ignore the extension.
+      return null;
     }
 
     List<String> ids =
@@ -333,13 +363,15 @@ public class SignExtension extends Extension {
 
     ids.removeAll(byCreds.keySet());
     if (!ids.isEmpty()) {
-      throw new IllegalArgumentException("signByCredential not valid");
+      // signByCredential references credentials outside the allow list: ignore the extension.
+      return null;
     }
 
     final AuthenticationInput prepareInput =
         (selected, pinToken) -> {
           if (selected == null) {
-            throw new IllegalArgumentException("Invalid allowList data");
+            // No credential was selected: nothing to sign.
+            return null;
           }
 
           AuthenticationExtensionsSignSign credInputs =
@@ -355,21 +387,31 @@ public class SignExtension extends Extension {
 
     final AuthenticationOutput prepareOutput =
         (assertionData, pinToken) -> {
-          AuthenticatorData authData =
-              AuthenticatorData.parseFrom(ByteBuffer.wrap(assertionData.getAuthenticatorData()));
+          try {
+            AuthenticatorData authData =
+                AuthenticatorData.parseFrom(ByteBuffer.wrap(assertionData.getAuthenticatorData()));
 
-          Map<String, ?> extensionResults = authData.getExtensions();
-          if (extensionResults == null) {
+            Map<String, ?> extensionResults = authData.getExtensions();
+            if (extensionResults == null) {
+              return null;
+            }
+
+            Map<Integer, Object> signResults = (Map<Integer, Object>) extensionResults.get(name);
+            Object signature = signResults != null ? signResults.get(6) : null; // sig
+            if (!(signature instanceof byte[])) {
+              return null;
+            }
+            byte[] sig = (byte[]) signature;
+            return serializationType ->
+                Collections.singletonMap(
+                    SIGN,
+                    new SignExtension.AuthenticationExtensionsSignOutputs(null, sig)
+                        .toMap(serializationType));
+          } catch (ClassCastException e) {
+            // Authenticator returned sign output with unexpected CBOR types: omit the result.
+            logger.debug("Ignoring malformed previewSign assertion output", e);
             return null;
           }
-
-          Map<Integer, Object> signResults = (Map<Integer, Object>) extensionResults.get(name);
-          return serializationType ->
-              Collections.singletonMap(
-                  SIGN,
-                  new SignExtension.AuthenticationExtensionsSignOutputs(
-                          null, (byte[]) signResults.get(6)) // sig
-                      .toMap(serializationType));
         };
 
     return new AuthenticationProcessor(prepareInput, prepareOutput);

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/SignExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/SignExtension.java
@@ -205,14 +205,13 @@ public class SignExtension extends Extension {
       return null;
     }
 
-    if (extSign.signByCredential != null) {
-      // signByCredential is not valid during registration: ignore the extension.
-      return null;
-    }
-
+    // WebAuthn previewSign client processing (registration); both are NotSupportedError.
     if (extSign.generateKey == null) {
-      // generateKey is required during registration: ignore the extension.
-      return null;
+      throw new ExtensionConfigurationException("generateKey is required during registration");
+    }
+    if (extSign.signByCredential != null) {
+      throw new ExtensionConfigurationException(
+          "signByCredential is not valid during registration");
     }
 
     final RegistrationInput prepareInput =
@@ -289,8 +288,11 @@ public class SignExtension extends Extension {
                     SIGN,
                     new SignExtension.AuthenticationExtensionsSignOutputs(generatedKey, null)
                         .toMap(serializationType));
-              } catch (ClassCastException e) {
-                // Authenticator returned sign output with unexpected CBOR types: omit the result.
+              } catch (RuntimeException e) {
+                // Authenticator returned malformed sign output (wrong CBOR types, or an
+                // undecodable att-obj/authData from Cbor.decode/parseFrom): omit the result rather
+                // than failing. This runs in the deferred provider, so an uncaught exception here
+                // would escape credential.toMap() entirely.
                 logger.debug("Ignoring malformed previewSign registration output", e);
                 return Collections.emptyMap();
               }
@@ -300,9 +302,10 @@ public class SignExtension extends Extension {
   }
 
   /**
-   * Safely parses the {@code previewSign} extension input. Malformed relying-party input (wrong
-   * types, missing keys, or invalid base64url) is treated as "not applicable" and yields {@code
-   * null} so the extension is ignored rather than aborting the ceremony.
+   * Parses the {@code previewSign} extension input. Returns {@code null} when the extension is not
+   * requested; throws {@link IllegalArgumentException} when it is present but malformed (wrong
+   * types, missing required keys, or invalid base64url) so the client reports it as a bad request
+   * rather than silently dropping it.
    */
   @SuppressWarnings("unchecked")
   @Nullable
@@ -311,14 +314,18 @@ public class SignExtension extends Extension {
       return null;
     }
     Object signInput = extensions.get(SIGN);
+    if (signInput == null) {
+      return null; // not requested
+    }
     if (!(signInput instanceof Map)) {
-      return null;
+      throw new IllegalArgumentException("previewSign must be an object");
     }
     try {
       return AuthenticationExtensionsSign.fromMap((Map<String, ?>) signInput);
     } catch (RuntimeException e) {
-      logger.debug("Ignoring malformed previewSign input", e);
-      return null;
+      // fromMap uses unchecked casts / requireNonNull; surface any malformed structure as bad
+      // input.
+      throw new IllegalArgumentException("Malformed previewSign input", e);
     }
   }
 
@@ -346,16 +353,21 @@ public class SignExtension extends Extension {
       return null;
     }
 
+    // WebAuthn previewSign client processing (authentication). The presence/empty/size conditions
+    // are NotSupportedError; a missing per-credential entry is a SyntaxError.
     if (extSign.signByCredential == null || extSign.generateKey != null) {
-      // Invalid input for authentication (expects signByCredential, not generateKey): ignore.
-      return null;
+      throw new ExtensionConfigurationException(
+          "authentication requires signByCredential and not generateKey");
     }
 
     Map<String, AuthenticationExtensionsSignSign> byCreds = extSign.signByCredential;
     List<PublicKeyCredentialDescriptor> allowList = options.getAllowCredentials();
     if (allowList.isEmpty()) {
-      // sign requires an allow list: ignore the extension.
-      return null;
+      throw new ExtensionConfigurationException("signByCredential requires an allow list");
+    }
+    if (byCreds.size() != allowList.size()) {
+      throw new ExtensionConfigurationException(
+          "signByCredential must have exactly one entry per allowed credential");
     }
 
     List<String> ids =
@@ -363,8 +375,9 @@ public class SignExtension extends Extension {
 
     ids.removeAll(byCreds.keySet());
     if (!ids.isEmpty()) {
-      // signByCredential references credentials outside the allow list: ignore the extension.
-      return null;
+      // SyntaxError: an allowed credential has no signByCredential entry.
+      throw new IllegalArgumentException(
+          "signByCredential is missing an entry for an allowed credential");
     }
 
     final AuthenticationInput prepareInput =
@@ -407,8 +420,10 @@ public class SignExtension extends Extension {
                     SIGN,
                     new SignExtension.AuthenticationExtensionsSignOutputs(null, sig)
                         .toMap(serializationType));
-          } catch (ClassCastException e) {
-            // Authenticator returned sign output with unexpected CBOR types: omit the result.
+          } catch (RuntimeException e) {
+            // Authenticator returned malformed sign output (wrong CBOR types, or an undecodable
+            // authData from parseFrom): omit the result rather than failing the assertion or
+            // misreporting the authenticator's fault as a relying-party error.
             logger.debug("Ignoring malformed previewSign assertion output", e);
             return null;
           }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Yubico.
+ * Copyright (C) 2025-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,18 +93,30 @@ public class ThirdPartyPaymentExtension extends Extension {
     return new AuthenticationProcessor(prepareInput);
   }
 
-  @SuppressWarnings("unchecked")
   @Nullable
   private Boolean getIsPayment(@Nullable Extensions extensions) {
     if (extensions == null) {
       return null;
     }
 
-    Map<String, ?> payment = (Map<String, ?>) extensions.get(PAYMENT);
-    if (payment == null) {
+    Object paymentValue = extensions.get(PAYMENT);
+    if (paymentValue == null) {
       return null;
     }
-
-    return (Boolean) payment.get(IS_PAYMENT);
+    if (!(paymentValue instanceof Map)) {
+      throw new IllegalArgumentException("payment must be an object");
+    }
+    // CTAP leaves the client input platform-defined; this SDK uses payment.isPayment as the flag.
+    Object isPayment = ((Map<?, ?>) paymentValue).get(IS_PAYMENT);
+    if (isPayment == null) {
+      return null;
+    }
+    if (!(isPayment instanceof Boolean)) {
+      throw new IllegalArgumentException("payment.isPayment must be a boolean");
+    }
+    if (!(Boolean) isPayment) {
+      return null;
+    }
+    return Boolean.TRUE;
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredBlobExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredBlobExtensionTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import com.yubico.yubikit.core.internal.codec.Base64;
@@ -61,6 +62,19 @@ public class CredBlobExtensionTest {
   }
 
   @Test
+  public void malformedCredBlobTypeThrows() {
+    // credBlob is a BufferSource: a non-string is malformed structure and is surfaced
+    // (BAD_REQUEST), not allowed to crash on the cast.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.makeCredential(
+                session(Collections.singletonList(NAME), Collections.emptyMap(), 32),
+                creation(Collections.singletonMap(NAME, 123)),
+                pinUvAuth));
+  }
+
+  @Test
   public void notSupportedReturnsNull() {
     assertNull(
         extension.makeCredential(
@@ -83,5 +97,23 @@ public class CredBlobExtensionTest {
   @Test
   public void getAssertionWithoutRequestReturnsNull() {
     assertNull(extension.getAssertion(session(NAME), request(Collections.emptyMap()), pinUvAuth));
+  }
+
+  @Test
+  public void getAssertionFalseGetCredBlobReturnsNull() {
+    // getCredBlob is a boolean request flag: false means "not requested" and is ignored.
+    assertNull(
+        extension.getAssertion(
+            session(NAME), request(Collections.singletonMap("getCredBlob", false)), pinUvAuth));
+  }
+
+  @Test
+  public void getAssertionNonBooleanGetCredBlobThrows() {
+    // A non-boolean getCredBlob is malformed caller input -> BAD_REQUEST.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.getAssertion(
+                session(NAME), request(Collections.singletonMap("getCredBlob", 1)), pinUvAuth));
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredBlobExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredBlobExtensionTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.request;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.session;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import com.yubico.yubikit.core.internal.codec.Base64;
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+
+public class CredBlobExtensionTest {
+
+  private static final String NAME = "credBlob";
+  private final CredBlobExtension extension = new CredBlobExtension();
+  private final PinUvAuthProtocol pinUvAuth = mock(PinUvAuthProtocol.class);
+
+  @Test
+  public void happyPathSendsBlob() {
+    byte[] blob = {1, 2, 3};
+    Extension.RegistrationProcessor processor =
+        extension.makeCredential(
+            session(Collections.singletonList(NAME), Collections.emptyMap(), 32),
+            creation(Collections.singletonMap(NAME, Base64.toUrlSafeString(blob))),
+            pinUvAuth);
+
+    assertNotNull(processor);
+    assertArrayEquals(blob, (byte[]) processor.getInput(null).get(NAME));
+  }
+
+  @Test
+  public void blobTooLongIsIgnored() {
+    Extension.RegistrationProcessor processor =
+        extension.makeCredential(
+            session(Collections.singletonList(NAME), Collections.emptyMap(), 1),
+            creation(Collections.singletonMap(NAME, Base64.toUrlSafeString(new byte[] {1, 2, 3}))),
+            pinUvAuth);
+    assertNull(processor);
+  }
+
+  @Test
+  public void notSupportedReturnsNull() {
+    assertNull(
+        extension.makeCredential(
+            session(),
+            creation(Collections.singletonMap(NAME, Base64.toUrlSafeString(new byte[] {1}))),
+            pinUvAuth));
+  }
+
+  @Test
+  public void getAssertionHappyPathRequestsBlob() {
+    Extension.AuthenticationProcessor processor =
+        extension.getAssertion(
+            session(NAME), request(Collections.singletonMap("getCredBlob", true)), pinUvAuth);
+
+    assertNotNull(processor);
+    Map<String, Object> input = processor.getInput(null, null);
+    assertEquals(Boolean.TRUE, input.get(NAME));
+  }
+
+  @Test
+  public void getAssertionWithoutRequestReturnsNull() {
+    assertNull(extension.getAssertion(session(NAME), request(Collections.emptyMap()), pinUvAuth));
+  }
+}

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredPropsExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredPropsExtensionTest.java
@@ -17,12 +17,15 @@
 package com.yubico.yubikit.fido.client.extensions;
 
 import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.rkSession;
 import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.session;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
+import com.yubico.yubikit.fido.ctap.Ctap2Session;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
 import com.yubico.yubikit.fido.webauthn.AttestationObject;
 import com.yubico.yubikit.fido.webauthn.AuthenticatorSelectionCriteria;
@@ -30,6 +33,7 @@ import com.yubico.yubikit.fido.webauthn.ResidentKeyRequirement;
 import com.yubico.yubikit.fido.webauthn.SerializationType;
 import java.util.Collections;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.junit.Test;
 
 public class CredPropsExtensionTest {
@@ -44,7 +48,9 @@ public class CredPropsExtensionTest {
 
     Extension.RegistrationProcessor processor =
         extension.makeCredential(
-            session(), creation(Collections.singletonMap("credProps", true), selection), pinUvAuth);
+            rkSession(),
+            creation(Collections.singletonMap("credProps", true), selection),
+            pinUvAuth);
 
     assertNotNull(processor);
     Map<String, Object> output =
@@ -55,8 +61,76 @@ public class CredPropsExtensionTest {
   }
 
   @Test
+  public void preferredWithSupportReportsTrue() {
+    assertEquals(Boolean.TRUE, reportedRk(rkSession(), ResidentKeyRequirement.PREFERRED));
+  }
+
+  @Test
+  public void preferredWithoutSupportReportsFalse() {
+    assertEquals(Boolean.FALSE, reportedRk(session(), ResidentKeyRequirement.PREFERRED));
+  }
+
+  @Test
+  public void requiredWithoutSupportReportsFalse() {
+    // rk reflects whether a discoverable credential was actually created: it cannot be if the
+    // authenticator does not support resident keys, even when the RP required one.
+    assertEquals(Boolean.FALSE, reportedRk(session(), ResidentKeyRequirement.REQUIRED));
+  }
+
+  @Test
+  public void discouragedReportsFalse() {
+    assertEquals(Boolean.FALSE, reportedRk(rkSession(), ResidentKeyRequirement.DISCOURAGED));
+  }
+
+  @Test
+  public void noSelectionReportsFalse() {
+    assertEquals(Boolean.FALSE, reportedRk(rkSession(), null));
+  }
+
+  @Test
   public void noExtensionInputReturnsNull() {
     assertNull(extension.makeCredential(session(), creation(null), pinUvAuth));
     assertNull(extension.makeCredential(session(), creation(Collections.emptyMap()), pinUvAuth));
+  }
+
+  @Test
+  public void falseIsIgnored() {
+    // credProps is a boolean request flag: false means "not requested" and is ignored.
+    assertNull(
+        extension.makeCredential(
+            session(), creation(Collections.singletonMap("credProps", false)), pinUvAuth));
+  }
+
+  @Test
+  public void nonBooleanThrows() {
+    // A non-boolean credProps is malformed caller input -> BAD_REQUEST.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.makeCredential(
+                session(), creation(Collections.singletonMap("credProps", "yes")), pinUvAuth));
+  }
+
+  /**
+   * Requests credProps against the given session and residentKey requirement, returning the
+   * reported "rk" value (or {@code null} if the extension opts out).
+   */
+  @Nullable
+  private Boolean reportedRk(Ctap2Session session, @Nullable String residentKey) {
+    AuthenticatorSelectionCriteria selection =
+        residentKey == null ? null : new AuthenticatorSelectionCriteria(null, residentKey, null);
+    Extension.RegistrationProcessor processor =
+        extension.makeCredential(
+            session, creation(Collections.singletonMap("credProps", true), selection), pinUvAuth);
+    if (processor == null) {
+      return null;
+    }
+    Map<String, Object> output =
+        processor
+            .getOutput(mock(AttestationObject.class), null)
+            .getClientExtensionResult(SerializationType.CBOR);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> credProps = (Map<String, Object>) output.get("credProps");
+    return (Boolean) credProps.get("rk");
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredPropsExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredPropsExtensionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.session;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import com.yubico.yubikit.fido.webauthn.AttestationObject;
+import com.yubico.yubikit.fido.webauthn.AuthenticatorSelectionCriteria;
+import com.yubico.yubikit.fido.webauthn.ResidentKeyRequirement;
+import com.yubico.yubikit.fido.webauthn.SerializationType;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+
+public class CredPropsExtensionTest {
+
+  private final CredPropsExtension extension = new CredPropsExtension();
+  private final PinUvAuthProtocol pinUvAuth = mock(PinUvAuthProtocol.class);
+
+  @Test
+  public void happyPathReportsResidentKey() {
+    AuthenticatorSelectionCriteria selection =
+        new AuthenticatorSelectionCriteria(null, ResidentKeyRequirement.REQUIRED, null);
+
+    Extension.RegistrationProcessor processor =
+        extension.makeCredential(
+            session(), creation(Collections.singletonMap("credProps", true), selection), pinUvAuth);
+
+    assertNotNull(processor);
+    Map<String, Object> output =
+        processor
+            .getOutput(mock(AttestationObject.class), null)
+            .getClientExtensionResult(SerializationType.CBOR);
+    assertEquals(Collections.singletonMap("rk", true), output.get("credProps"));
+  }
+
+  @Test
+  public void noExtensionInputReturnsNull() {
+    assertNull(extension.makeCredential(session(), creation(null), pinUvAuth));
+    assertNull(extension.makeCredential(session(), creation(Collections.emptyMap()), pinUvAuth));
+  }
+}

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtensionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.session;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import java.util.Collections;
+import org.junit.Test;
+
+/**
+ * Input-mapping tests for {@link CredProtectExtension}. The hard-fail (enforce + unsupported) case
+ * is covered by {@link ExtensionHardFailTest}.
+ */
+public class CredProtectExtensionTest {
+
+  private static final String POLICY = "credentialProtectionPolicy";
+  private static final String NAME = "credProtect";
+  private final CredProtectExtension extension = new CredProtectExtension();
+  private final PinUvAuthProtocol pinUvAuth = mock(PinUvAuthProtocol.class);
+
+  private int credProtectInput(String policy) {
+    Extension.RegistrationProcessor processor =
+        extension.makeCredential(
+            session(NAME), creation(Collections.singletonMap(POLICY, policy)), pinUvAuth);
+    assertNotNull("Expected a processor for policy " + policy, processor);
+    return (Integer) processor.getInput(null).get(NAME);
+  }
+
+  @Test
+  public void happyPathMapsPolicyToValue() {
+    assertEquals(0x01, credProtectInput("userVerificationOptional"));
+    assertEquals(0x02, credProtectInput("userVerificationOptionalWithCredentialIDList"));
+    assertEquals(0x03, credProtectInput("userVerificationRequired"));
+  }
+
+  @Test
+  public void unknownPolicyIsIgnored() {
+    assertNull(
+        extension.makeCredential(
+            session(NAME), creation(Collections.singletonMap(POLICY, "bogus")), pinUvAuth));
+  }
+
+  @Test
+  public void noPolicyReturnsNull() {
+    assertNull(extension.makeCredential(session(NAME), creation(null), pinUvAuth));
+    assertNull(
+        extension.makeCredential(session(NAME), creation(Collections.emptyMap()), pinUvAuth));
+  }
+
+  @Test
+  public void malformedPolicyTypeIsIgnored() {
+    // Non-String policy must be treated as absent, not throw ClassCastException.
+    assertNull(
+        extension.makeCredential(
+            session(NAME), creation(Collections.singletonMap(POLICY, 123)), pinUvAuth));
+  }
+}

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtensionTest.java
@@ -21,10 +21,13 @@ import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.sess
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 
 /**
@@ -54,10 +57,14 @@ public class CredProtectExtensionTest {
   }
 
   @Test
-  public void unknownPolicyIsIgnored() {
-    assertNull(
-        extension.makeCredential(
-            session(NAME), creation(Collections.singletonMap(POLICY, "bogus")), pinUvAuth));
+  public void unknownPolicyValueThrows() {
+    // credentialProtectionPolicy must be one of the defined policy strings: an unrecognized string
+    // is malformed caller input -> BAD_REQUEST.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.makeCredential(
+                session(NAME), creation(Collections.singletonMap(POLICY, "bogus")), pinUvAuth));
   }
 
   @Test
@@ -68,10 +75,24 @@ public class CredProtectExtensionTest {
   }
 
   @Test
-  public void malformedPolicyTypeIsIgnored() {
-    // Non-String policy must be treated as absent, not throw ClassCastException.
-    assertNull(
-        extension.makeCredential(
-            session(NAME), creation(Collections.singletonMap(POLICY, 123)), pinUvAuth));
+  public void malformedPolicyTypeThrows() {
+    // A present non-string policy is an invalid value -> BAD_REQUEST (not coerced or ignored).
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.makeCredential(
+                session(NAME), creation(Collections.singletonMap(POLICY, 123)), pinUvAuth));
+  }
+
+  @Test
+  public void nonBooleanEnforceThrows() {
+    // enforceCredentialProtectionPolicy is a boolean: a non-boolean value is malformed caller input
+    // -> BAD_REQUEST, rather than coercing to false and dropping the requested enforcement.
+    Map<String, Object> ext = new HashMap<>();
+    ext.put(POLICY, "userVerificationRequired");
+    ext.put("enforceCredentialProtectionPolicy", "yes");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extension.makeCredential(session(NAME), creation(ext), pinUvAuth));
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionHardFailTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionHardFailTest.java
@@ -94,7 +94,9 @@ public class ExtensionHardFailTest {
   }
 
   @Test
-  public void largeBlobReadWriteInMakeCredentialThrowsBadRequest() {
+  public void largeBlobReadInMakeCredentialThrowsConfigurationUnsupported() {
+    // Spec: read/write are authentication-only; their presence during registration is a
+    // NotSupportedError -> CONFIGURATION_UNSUPPORTED.
     Map<String, Object> largeBlob = new HashMap<>();
     largeBlob.put(LargeBlobExtension.ACTION_READ, true);
     Map<String, Object> ext = new HashMap<>();
@@ -107,6 +109,6 @@ public class ExtensionHardFailTest {
                 new LargeBlobExtension()
                     .makeCredential(
                         sessionWithout(), optionsWith(ext), mock(PinUvAuthProtocol.class)));
-    assertEquals(ClientError.Code.BAD_REQUEST, error.getCode());
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, error.getCode());
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionHardFailTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionHardFailTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yubico.yubikit.fido.client.ClientError;
+import com.yubico.yubikit.fido.ctap.Ctap2Session;
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import com.yubico.yubikit.fido.webauthn.Extensions;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialCreationOptions;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Verifies that extensions which represent unsatisfiable, relying-party-requested requirements
+ * raise an {@link ExtensionConfigurationException} (hard-fail) carrying the {@link
+ * ClientError.Code} the client should report, rather than being silently ignored. Ignorable
+ * conditions instead return {@code null}; see the extensions themselves.
+ *
+ * @see <a href="https://www.w3.org/TR/webauthn-3/#sctn-extensions">WebAuthn Extensions</a>
+ */
+public class ExtensionHardFailTest {
+
+  /** A Ctap2Session whose authenticator advertises no extensions or options. */
+  private static Ctap2Session sessionWithout() {
+    Ctap2Session.InfoData info = mock(Ctap2Session.InfoData.class);
+    when(info.getExtensions()).thenReturn(Collections.emptyList());
+    // Keep the "no capabilities" authenticator valid even if an isSupported() check reaches
+    // getOptions() (currently short-circuited by the empty extensions list).
+    doReturn(Collections.emptyMap()).when(info).getOptions();
+    Ctap2Session ctap = mock(Ctap2Session.class);
+    when(ctap.getCachedInfo()).thenReturn(info);
+    return ctap;
+  }
+
+  private static PublicKeyCredentialCreationOptions optionsWith(Map<String, Object> extensions) {
+    PublicKeyCredentialCreationOptions options = mock(PublicKeyCredentialCreationOptions.class);
+    when(options.getExtensions()).thenReturn(Extensions.fromMap(extensions));
+    return options;
+  }
+
+  @Test
+  public void credProtectEnforceUnsupportedThrowsConfigurationUnsupported() {
+    Map<String, Object> ext = new HashMap<>();
+    ext.put(CredProtectExtension.POLICY, CredProtectExtension.REQUIRED);
+    ext.put(CredProtectExtension.ENFORCE, true);
+
+    ExtensionConfigurationException error =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () ->
+                new CredProtectExtension()
+                    .makeCredential(
+                        sessionWithout(), optionsWith(ext), mock(PinUvAuthProtocol.class)));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, error.getCode());
+  }
+
+  @Test
+  public void largeBlobRequiredUnsupportedThrowsConfigurationUnsupported() {
+    Map<String, Object> largeBlob = new HashMap<>();
+    largeBlob.put(LargeBlobExtension.SUPPORT, LargeBlobExtension.REQUIRED);
+    Map<String, Object> ext = new HashMap<>();
+    ext.put(LargeBlobExtension.LARGE_BLOB, largeBlob);
+
+    ExtensionConfigurationException error =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () ->
+                new LargeBlobExtension()
+                    .makeCredential(
+                        sessionWithout(), optionsWith(ext), mock(PinUvAuthProtocol.class)));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, error.getCode());
+  }
+
+  @Test
+  public void largeBlobReadWriteInMakeCredentialThrowsBadRequest() {
+    Map<String, Object> largeBlob = new HashMap<>();
+    largeBlob.put(LargeBlobExtension.ACTION_READ, true);
+    Map<String, Object> ext = new HashMap<>();
+    ext.put(LargeBlobExtension.LARGE_BLOB, largeBlob);
+
+    ExtensionConfigurationException error =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () ->
+                new LargeBlobExtension()
+                    .makeCredential(
+                        sessionWithout(), optionsWith(ext), mock(PinUvAuthProtocol.class)));
+    assertEquals(ClientError.Code.BAD_REQUEST, error.getCode());
+  }
+}

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionTestHelper.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionTestHelper.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yubico.yubikit.fido.ctap.Ctap2Session;
+import com.yubico.yubikit.fido.webauthn.AuthenticatorSelectionCriteria;
+import com.yubico.yubikit.fido.webauthn.Extensions;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialCreationOptions;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialDescriptor;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialRequestOptions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Shared Mockito helpers for testing {@link Extension} implementations without a real
+ * authenticator.
+ *
+ * <p>Extensions interact with the authenticator only through {@link Ctap2Session#getCachedInfo()}
+ * (to discover supported extensions/options), so mocking that is enough to drive their input/output
+ * logic.
+ */
+final class ExtensionTestHelper {
+
+  private ExtensionTestHelper() {}
+
+  /** A session whose authenticator advertises the given extensions, options and credBlob length. */
+  static Ctap2Session session(
+      List<String> extensions, Map<String, Object> options, int maxCredBlobLength) {
+    Ctap2Session.InfoData info = mock(Ctap2Session.InfoData.class);
+    when(info.getExtensions()).thenReturn(extensions);
+    doReturn(options).when(info).getOptions();
+    when(info.getMaxCredBlobLength()).thenReturn(maxCredBlobLength);
+    Ctap2Session ctap = mock(Ctap2Session.class);
+    when(ctap.getCachedInfo()).thenReturn(info);
+    return ctap;
+  }
+
+  /** A session advertising just the given extension names (no options). */
+  static Ctap2Session session(String... extensions) {
+    return session(Arrays.asList(extensions), Collections.emptyMap(), 32);
+  }
+
+  static PublicKeyCredentialCreationOptions creation(@Nullable Map<String, ?> extensions) {
+    return creation(extensions, null);
+  }
+
+  static PublicKeyCredentialCreationOptions creation(
+      @Nullable Map<String, ?> extensions, @Nullable AuthenticatorSelectionCriteria selection) {
+    PublicKeyCredentialCreationOptions options = mock(PublicKeyCredentialCreationOptions.class);
+    when(options.getExtensions()).thenReturn(Extensions.fromMap(extensions));
+    when(options.getAuthenticatorSelection()).thenReturn(selection);
+    return options;
+  }
+
+  static PublicKeyCredentialRequestOptions request(@Nullable Map<String, ?> extensions) {
+    return request(extensions, Collections.emptyList());
+  }
+
+  static PublicKeyCredentialRequestOptions request(
+      @Nullable Map<String, ?> extensions, List<PublicKeyCredentialDescriptor> allowCredentials) {
+    PublicKeyCredentialRequestOptions options = mock(PublicKeyCredentialRequestOptions.class);
+    when(options.getExtensions()).thenReturn(Extensions.fromMap(extensions));
+    when(options.getAllowCredentials()).thenReturn(allowCredentials);
+    return options;
+  }
+}

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionTestHelper.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionTestHelper.java
@@ -61,6 +61,11 @@ final class ExtensionTestHelper {
     return session(Arrays.asList(extensions), Collections.emptyMap(), 32);
   }
 
+  /** A session whose authenticator advertises support for resident keys (the "rk" option). */
+  static Ctap2Session rkSession() {
+    return session(Collections.emptyList(), Collections.singletonMap("rk", true), 32);
+  }
+
   static PublicKeyCredentialCreationOptions creation(@Nullable Map<String, ?> extensions) {
     return creation(extensions, null);
   }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtensionTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.request;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.session;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import java.util.Collections;
+import org.junit.Test;
+
+/**
+ * Tests for {@link HmacSecretExtension} input gating.
+ *
+ * <p>Only the "ignore" paths are unit-tested here: the happy path builds a shared secret with the
+ * authenticator (key agreement / ECDH), which requires a real device and is covered by the {@code
+ * testing} module's {@code PrfExtensionTests} / {@code HmacSecretExtensionTests}.
+ */
+public class HmacSecretExtensionTest {
+
+  private static final String NAME = "hmac-secret";
+  private final HmacSecretExtension extension = new HmacSecretExtension();
+  private final PinUvAuthProtocol pinUvAuth = mock(PinUvAuthProtocol.class);
+
+  @Test
+  public void makeCredentialNotSupportedReturnsNull() {
+    assertNull(
+        extension.makeCredential(
+            session(),
+            creation(Collections.singletonMap("prf", Collections.emptyMap())),
+            pinUvAuth));
+  }
+
+  @Test
+  public void makeCredentialWithoutPrfOrHmacReturnsNull() {
+    assertNull(
+        extension.makeCredential(session(NAME), creation(Collections.emptyMap()), pinUvAuth));
+  }
+
+  @Test
+  public void getAssertionNotSupportedReturnsNull() {
+    assertNull(
+        extension.getAssertion(
+            session(),
+            request(Collections.singletonMap("prf", Collections.emptyMap())),
+            pinUvAuth));
+  }
+}

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtensionTest.java
@@ -19,11 +19,19 @@ package com.yubico.yubikit.fido.client.extensions;
 import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
 import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.request;
 import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.session;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
+import com.yubico.yubikit.fido.client.ClientError;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import com.yubico.yubikit.fido.webauthn.Extensions;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import org.junit.Test;
 
 /**
@@ -55,11 +63,117 @@ public class HmacSecretExtensionTest {
   }
 
   @Test
+  public void makeCredentialNonBooleanHmacCreateSecretThrows() {
+    // When hmac-secret is allowed, hmacCreateSecret is a boolean flag: a non-boolean value is
+    // malformed caller input -> BAD_REQUEST.
+    HmacSecretExtension hmacAllowed = new HmacSecretExtension(true);
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            hmacAllowed.makeCredential(
+                session(NAME),
+                creation(Collections.singletonMap("hmacCreateSecret", "yes")),
+                pinUvAuth));
+  }
+
+  @Test
   public void getAssertionNotSupportedReturnsNull() {
     assertNull(
         extension.getAssertion(
             session(),
             request(Collections.singletonMap("prf", Collections.emptyMap())),
             pinUvAuth));
+  }
+
+  @Test
+  public void makeCredentialMalformedPrfThrows() {
+    // prf is a dictionary: a non-object value is malformed structure -> BAD_REQUEST.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.makeCredential(
+                session(NAME),
+                creation(Collections.singletonMap("prf", "not-an-object")),
+                pinUvAuth));
+  }
+
+  @Test
+  public void makeCredentialMalformedEvalThrows() {
+    // prf.eval is a dictionary: a non-object value is malformed structure -> BAD_REQUEST.
+    Map<String, Object> prf = Collections.singletonMap("eval", "not-an-object");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.makeCredential(
+                session(NAME), creation(Collections.singletonMap("prf", prf)), pinUvAuth));
+  }
+
+  @Test
+  public void makeCredentialEvalByCredentialThrows() {
+    // WebAuthn prf (registration): evalByCredential is authentication-only -> NotSupportedError.
+    Map<String, Object> prf =
+        Collections.singletonMap(
+            "evalByCredential",
+            Collections.singletonMap("AA", Collections.singletonMap("first", "AA")));
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () ->
+                extension.makeCredential(
+                    session(NAME), creation(Collections.singletonMap("prf", prf)), pinUvAuth));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
+  }
+
+  @Test
+  public void prepareSaltsIgnoresNullSecond() {
+    // Regression: an RP sending prf.eval with "second": null (key present, null value) must not
+    // crash the ceremony (previously an NPE from Base64.fromUrlSafeString(null)); the null second
+    // is treated as absent, yielding first-only salts.
+    Map<String, Object> eval = new HashMap<>();
+    eval.put("first", "abba");
+    eval.put("second", null);
+    HmacSecretExtension.Salts salts = extension.prepareSalts(null, null, prfEval(eval));
+    assertNotNull(salts);
+    assertEquals(32, salts.salt1.length);
+    assertEquals(0, salts.salt2.length);
+  }
+
+  @Test
+  public void prepareSaltsProcessesFirstAndSecond() {
+    Map<String, Object> eval = new HashMap<>();
+    eval.put("first", "abba");
+    eval.put("second", "bebe");
+    HmacSecretExtension.Salts salts = extension.prepareSalts(null, null, prfEval(eval));
+    assertNotNull(salts);
+    assertEquals(32, salts.salt1.length);
+    assertEquals(32, salts.salt2.length);
+  }
+
+  @Test
+  public void prepareSaltsRejectsWrongTypedSecond() {
+    // A non-string "second" is malformed input -> IllegalArgumentException (mapped to BAD_REQUEST),
+    // not a crash.
+    Map<String, Object> eval = new HashMap<>();
+    eval.put("first", "abba");
+    eval.put("second", 123);
+    assertThrows(
+        IllegalArgumentException.class, () -> extension.prepareSalts(null, null, prfEval(eval)));
+  }
+
+  @Test
+  public void prepareSaltsRequiresFirst() {
+    // A prf eval block missing "first" is malformed input -> IllegalArgumentException.
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extension.prepareSalts(null, null, prfEval(new HashMap<>())));
+  }
+
+  /**
+   * Builds parsed extension {@link HmacSecretExtension.Inputs} for {@code prf: { eval: <eval> }}.
+   */
+  private static HmacSecretExtension.Inputs prfEval(Map<String, Object> eval) {
+    Extensions extensions =
+        Extensions.fromMap(Collections.singletonMap("prf", Collections.singletonMap("eval", eval)));
+    return Objects.requireNonNull(HmacSecretExtension.Inputs.fromExtensions(extensions));
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtensionTest.java
@@ -22,14 +22,17 @@ import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.sess
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.yubico.yubikit.fido.client.ClientError;
 import com.yubico.yubikit.fido.ctap.Ctap2Session;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
 import com.yubico.yubikit.fido.webauthn.SerializationType;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
@@ -107,10 +110,116 @@ public class LargeBlobExtensionTest {
   }
 
   @Test
-  public void malformedLargeBlobTypeIsIgnored() {
-    // A non-Map largeBlob value must be treated as absent, not throw ClassCastException.
+  public void getAssertionSupportPresentThrows() {
+    // Spec: support is registration-only -> NotSupportedError during authentication.
+    Map<String, ?> ext =
+        Collections.singletonMap(LARGE_BLOB, Collections.singletonMap("support", "preferred"));
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () -> extension.getAssertion(session(), request(ext), pinUvAuth));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
+  }
+
+  @Test
+  public void getAssertionReadAndWriteThrows() {
+    // Spec: read and write must not both be present -> NotSupportedError.
+    Map<String, Object> largeBlob = new HashMap<>();
+    largeBlob.put("read", true);
+    largeBlob.put("write", "AQ");
+    Map<String, ?> ext = Collections.singletonMap(LARGE_BLOB, largeBlob);
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () -> extension.getAssertion(session(), request(ext), pinUvAuth));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
+  }
+
+  @Test
+  public void getAssertionReadFalseAndWriteThrows() {
+    // "Both present" is about member presence, not read's value: read:false + write still fails.
+    Map<String, Object> largeBlob = new HashMap<>();
+    largeBlob.put("read", false);
+    largeBlob.put("write", "AQ");
+    Map<String, ?> ext = Collections.singletonMap(LARGE_BLOB, largeBlob);
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () -> extension.getAssertion(session(), request(ext), pinUvAuth));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
+  }
+
+  @Test
+  public void getAssertionWriteRequiresExactlyOneAllowedCredential() {
+    // Spec: write requires allowCredentials to contain exactly one element -> NotSupportedError.
+    Map<String, ?> ext =
+        Collections.singletonMap(LARGE_BLOB, Collections.singletonMap("write", "AQ"));
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () -> extension.getAssertion(session(), request(ext), pinUvAuth));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
+  }
+
+  @Test
+  public void malformedLargeBlobTypeThrows() {
+    // A non-Map largeBlob value is malformed input and must be surfaced, not silently dropped.
     Map<String, ?> ext = Collections.singletonMap(LARGE_BLOB, "not-a-map");
-    assertNull(extension.makeCredential(session(), creation(ext), pinUvAuth));
-    assertNull(extension.getAssertion(session(), request(ext), pinUvAuth));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extension.makeCredential(session(), creation(ext), pinUvAuth));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extension.getAssertion(session(), request(ext), pinUvAuth));
+  }
+
+  @Test
+  public void malformedWriteTypeThrows() {
+    // write is a BufferSource: a non-string value is a wrong-type error (surfaced as BAD_REQUEST).
+    Map<String, ?> ext =
+        Collections.singletonMap(LARGE_BLOB, Collections.singletonMap("write", 123));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extension.getAssertion(session(), request(ext), pinUvAuth));
+  }
+
+  @Test
+  public void wrongTypedReadThrows() {
+    // read is a boolean member: a wrong-typed value is malformed caller input -> BAD_REQUEST.
+    Map<String, ?> ext =
+        Collections.singletonMap(LARGE_BLOB, Collections.singletonMap("read", "yes"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extension.getAssertion(session(), request(ext), pinUvAuth));
+  }
+
+  @Test
+  public void wrongTypedSupportThrows() {
+    // support is an enum string: a wrong-typed value is malformed caller input -> BAD_REQUEST.
+    Map<String, ?> ext =
+        Collections.singletonMap(LARGE_BLOB, Collections.singletonMap("support", 1));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extension.getAssertion(session(), request(ext), pinUvAuth));
+  }
+
+  @Test
+  public void unknownSupportValueThrows() {
+    // support must be "required" or "preferred": an unrecognized value -> BAD_REQUEST.
+    Map<String, ?> ext =
+        Collections.singletonMap(LARGE_BLOB, Collections.singletonMap("support", "bogus"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extension.makeCredential(session(), creation(ext), pinUvAuth));
+  }
+
+  @Test
+  public void wrongTypedSupportAtRegistrationThrows() {
+    // A wrong-typed support at registration is malformed caller input -> BAD_REQUEST.
+    Map<String, ?> ext =
+        Collections.singletonMap(LARGE_BLOB, Collections.singletonMap("support", 1));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extension.makeCredential(session(), creation(ext), pinUvAuth));
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtensionTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.request;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.session;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yubico.yubikit.fido.ctap.Ctap2Session;
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import com.yubico.yubikit.fido.webauthn.SerializationType;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Input-mapping tests for {@link LargeBlobExtension}. The hard-fail cases (read/write during
+ * registration, and {@code support:"required"} unsupported) are covered by {@link
+ * ExtensionHardFailTest}.
+ */
+public class LargeBlobExtensionTest {
+
+  private static final String LARGE_BLOB = "largeBlob";
+  private static final String LARGE_BLOB_KEY = "largeBlobKey";
+  private final LargeBlobExtension extension = new LargeBlobExtension();
+  private final PinUvAuthProtocol pinUvAuth = mock(PinUvAuthProtocol.class);
+
+  @Test
+  public void makeCredentialPreferredRequestsKey() {
+    Extension.RegistrationProcessor processor =
+        extension.makeCredential(
+            session(),
+            creation(
+                Collections.singletonMap(
+                    LARGE_BLOB, Collections.singletonMap("support", "preferred"))),
+            pinUvAuth);
+
+    assertNotNull(processor);
+    assertEquals(Boolean.TRUE, processor.getInput(null).get(LARGE_BLOB_KEY));
+  }
+
+  @Test
+  public void makeCredentialWithoutInputReturnsNull() {
+    assertNull(extension.makeCredential(session(), creation(null), pinUvAuth));
+    assertNull(extension.makeCredential(session(), creation(Collections.emptyMap()), pinUvAuth));
+  }
+
+  @Test
+  public void getAssertionReadRequestsKey() {
+    Extension.AuthenticationProcessor processor =
+        extension.getAssertion(
+            session(),
+            request(Collections.singletonMap(LARGE_BLOB, Collections.singletonMap("read", true))),
+            pinUvAuth);
+
+    assertNotNull(processor);
+    assertEquals(Boolean.TRUE, processor.getInput(null, null).get(LARGE_BLOB_KEY));
+  }
+
+  @Test
+  public void getAssertionWithoutInputReturnsNull() {
+    assertNull(extension.getAssertion(session(), request(null), pinUvAuth));
+    assertNull(extension.getAssertion(session(), request(Collections.emptyMap()), pinUvAuth));
+  }
+
+  /**
+   * A read on an authenticator that returns a largeBlobKey but does not support the large-blob
+   * array makes {@code new LargeBlobs(...)} throw {@link IllegalStateException}; the extension must
+   * swallow it and yield no result rather than aborting the ceremony.
+   */
+  @Test
+  public void getAssertionReadOnUnsupportedAuthenticatorIsIgnored() {
+    Ctap2Session ctap = session(); // advertises no "largeBlobs" option
+    Extension.AuthenticationProcessor processor =
+        extension.getAssertion(
+            ctap,
+            request(Collections.singletonMap(LARGE_BLOB, Collections.singletonMap("read", true))),
+            pinUvAuth);
+    assertNotNull(processor);
+
+    Ctap2Session.AssertionData assertionData = mock(Ctap2Session.AssertionData.class);
+    when(assertionData.getLargeBlobKey()).thenReturn(new byte[] {1, 2, 3});
+
+    Map<String, Object> output =
+        processor.getOutput(assertionData, null).getClientExtensionResult(SerializationType.CBOR);
+    assertTrue(output.isEmpty());
+  }
+
+  @Test
+  public void malformedLargeBlobTypeIsIgnored() {
+    // A non-Map largeBlob value must be treated as absent, not throw ClassCastException.
+    Map<String, ?> ext = Collections.singletonMap(LARGE_BLOB, "not-a-map");
+    assertNull(extension.makeCredential(session(), creation(ext), pinUvAuth));
+    assertNull(extension.getAssertion(session(), request(ext), pinUvAuth));
+  }
+}

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/MinPinLengthExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/MinPinLengthExtensionTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.session;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+
+public class MinPinLengthExtensionTest {
+
+  private static final String NAME = "minPinLength";
+  private final MinPinLengthExtension extension = new MinPinLengthExtension();
+  private final PinUvAuthProtocol pinUvAuth = mock(PinUvAuthProtocol.class);
+
+  /** A session that supports minPinLength (extension advertised AND setMinPINLength option). */
+  private com.yubico.yubikit.fido.ctap.Ctap2Session supportingSession() {
+    return session(
+        Collections.singletonList(NAME), Collections.singletonMap("setMinPINLength", true), 32);
+  }
+
+  @Test
+  public void happyPathRequestsMinPinLength() {
+    Extension.RegistrationProcessor processor =
+        extension.makeCredential(
+            supportingSession(), creation(Collections.singletonMap(NAME, true)), pinUvAuth);
+
+    assertNotNull(processor);
+    Map<String, Object> input = processor.getInput(null);
+    assertEquals(Boolean.TRUE, input.get(NAME));
+  }
+
+  @Test
+  public void notSupportedReturnsNull() {
+    // Extension advertised but setMinPINLength option missing.
+    assertNull(
+        extension.makeCredential(
+            session(NAME), creation(Collections.singletonMap(NAME, true)), pinUvAuth));
+  }
+
+  @Test
+  public void noInputReturnsNull() {
+    assertNull(extension.makeCredential(supportingSession(), creation(null), pinUvAuth));
+    assertNull(
+        extension.makeCredential(supportingSession(), creation(Collections.emptyMap()), pinUvAuth));
+  }
+}

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/MinPinLengthExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/MinPinLengthExtensionTest.java
@@ -21,6 +21,7 @@ import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.sess
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
@@ -64,5 +65,25 @@ public class MinPinLengthExtensionTest {
     assertNull(extension.makeCredential(supportingSession(), creation(null), pinUvAuth));
     assertNull(
         extension.makeCredential(supportingSession(), creation(Collections.emptyMap()), pinUvAuth));
+  }
+
+  @Test
+  public void nonBooleanInputThrows() {
+    // minPinLength's client input is a boolean flag, so a non-boolean present value is malformed
+    // caller input -> BAD_REQUEST (not silently coerced).
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.makeCredential(
+                supportingSession(), creation(Collections.singletonMap(NAME, 1)), pinUvAuth));
+  }
+
+  @Test
+  public void falseInputIsIgnored() {
+    // The boolean flag indicates whether the extension is requested: false means "not requested",
+    // so it is ignored (no authenticator input), not surfaced.
+    assertNull(
+        extension.makeCredential(
+            supportingSession(), creation(Collections.singletonMap(NAME, false)), pinUvAuth));
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/SignExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/SignExtensionTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.request;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.session;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.yubico.yubikit.core.internal.codec.Base64;
+import com.yubico.yubikit.fido.Cbor;
+import com.yubico.yubikit.fido.ctap.Ctap2Session;
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialDescriptor;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialType;
+import com.yubico.yubikit.fido.webauthn.SerializationType;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class SignExtensionTest {
+
+  private static final String NAME = "previewSign";
+  private final SignExtension extension = new SignExtension();
+  private final PinUvAuthProtocol pinUvAuth = mock(PinUvAuthProtocol.class);
+
+  private static Map<String, ?> signInput(Map<String, ?> value) {
+    return Collections.singletonMap(NAME, value);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void makeCredentialHappyPath() {
+    Map<String, ?> generateKey =
+        Collections.singletonMap(
+            "generateKey", Collections.singletonMap("algorithms", Collections.singletonList(-7)));
+
+    Extension.RegistrationProcessor processor =
+        extension.makeCredential(session(NAME), creation(signInput(generateKey)), pinUvAuth);
+
+    assertNotNull(processor);
+    Map<Integer, Object> sign = (Map<Integer, Object>) processor.getInput(null).get(NAME);
+    assertEquals(Collections.singletonList(-7), sign.get(3)); // algorithms
+    assertEquals(0b001, sign.get(4)); // flags (no UV)
+  }
+
+  @Test
+  public void makeCredentialSignByCredentialIsIgnored() {
+    Map<String, ?> input =
+        signInput(Collections.singletonMap("signByCredential", Collections.emptyMap()));
+    assertNull(extension.makeCredential(session(NAME), creation(input), pinUvAuth));
+  }
+
+  @Test
+  public void makeCredentialWithoutGenerateKeyIsIgnored() {
+    assertNull(
+        extension.makeCredential(
+            session(NAME), creation(signInput(Collections.emptyMap())), pinUvAuth));
+  }
+
+  @Test
+  public void makeCredentialNotSupportedReturnsNull() {
+    Map<String, ?> generateKey =
+        Collections.singletonMap(
+            "generateKey", Collections.singletonMap("algorithms", Collections.singletonList(-7)));
+    assertNull(extension.makeCredential(session(), creation(signInput(generateKey)), pinUvAuth));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void getAssertionHappyPath() {
+    byte[] id = {9, 9};
+    byte[] keyHandle = {1};
+    byte[] tbs = {2};
+    Map<String, Object> credEntry = new HashMap<>();
+    credEntry.put("keyHandle", Base64.toUrlSafeString(keyHandle));
+    credEntry.put("tbs", Base64.toUrlSafeString(tbs));
+    Map<String, ?> input =
+        signInput(
+            Collections.singletonMap(
+                "signByCredential",
+                Collections.singletonMap(Base64.toUrlSafeString(id), credEntry)));
+
+    PublicKeyCredentialDescriptor descriptor =
+        new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, id);
+
+    Extension.AuthenticationProcessor processor =
+        extension.getAssertion(
+            session(NAME), request(input, Collections.singletonList(descriptor)), pinUvAuth);
+
+    assertNotNull(processor);
+    Map<Integer, Object> sign =
+        (Map<Integer, Object>) processor.getInput(descriptor, null).get(NAME);
+    assertArrayEquals(keyHandle, (byte[]) sign.get(2));
+    assertArrayEquals(tbs, (byte[]) sign.get(6));
+  }
+
+  @Test
+  public void getAssertionWithGenerateKeyIsIgnored() {
+    Map<String, ?> input =
+        signInput(
+            Collections.singletonMap(
+                "generateKey",
+                Collections.singletonMap("algorithms", Collections.singletonList(-7))));
+    assertNull(extension.getAssertion(session(NAME), request(input), pinUvAuth));
+  }
+
+  /**
+   * When the authenticator returns assertion extension outputs without the sign result, the output
+   * processor must produce no result instead of dereferencing null.
+   */
+  @Test
+  public void getAssertionMissingSignOutputProducesNoResult() {
+    byte[] id = {9, 9};
+    Map<String, Object> credEntry = new HashMap<>();
+    credEntry.put("keyHandle", Base64.toUrlSafeString(new byte[] {1}));
+    credEntry.put("tbs", Base64.toUrlSafeString(new byte[] {2}));
+    Map<String, ?> input =
+        signInput(
+            Collections.singletonMap(
+                "signByCredential",
+                Collections.singletonMap(Base64.toUrlSafeString(id), credEntry)));
+    PublicKeyCredentialDescriptor descriptor =
+        new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, id);
+
+    Extension.AuthenticationProcessor processor =
+        extension.getAssertion(
+            session(NAME), request(input, Collections.singletonList(descriptor)), pinUvAuth);
+    assertNotNull(processor);
+
+    Ctap2Session.AssertionData assertionData = mock(Ctap2Session.AssertionData.class);
+    when(assertionData.getAuthenticatorData()).thenReturn(authenticatorDataWithEmptyExtensions());
+
+    Map<String, Object> output =
+        processor.getOutput(assertionData, null).getClientExtensionResult(SerializationType.CBOR);
+    assertTrue(output.isEmpty());
+  }
+
+  @Test
+  public void malformedSignInputIsIgnored() {
+    // previewSign value is not a map.
+    assertNull(
+        extension.makeCredential(
+            session(NAME), creation(Collections.singletonMap(NAME, "not-a-map")), pinUvAuth));
+    // Nested wrong type (algorithms is not a list) must be ignored, not abort.
+    Map<String, ?> badGenerateKey =
+        signInput(
+            Collections.singletonMap(
+                "generateKey", Collections.singletonMap("algorithms", "not-a-list")));
+    assertNull(extension.makeCredential(session(NAME), creation(badGenerateKey), pinUvAuth));
+  }
+
+  /** Minimal authenticator data: rpIdHash + ED flag + signCount + an empty CBOR extensions map. */
+  private static byte[] authenticatorDataWithEmptyExtensions() {
+    byte[] extensions = Cbor.encode(new HashMap<String, Object>());
+    return ByteBuffer.allocate(32 + 1 + 4 + extensions.length)
+        .put(new byte[32]) // rpIdHash
+        .put((byte) 0x80) // ED flag (bit 7) set, AT clear
+        .putInt(0) // signCount
+        .put(extensions)
+        .array();
+  }
+}

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/SignExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/SignExtensionTest.java
@@ -23,18 +23,21 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.yubico.yubikit.core.internal.codec.Base64;
 import com.yubico.yubikit.fido.Cbor;
+import com.yubico.yubikit.fido.client.ClientError;
 import com.yubico.yubikit.fido.ctap.Ctap2Session;
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
 import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialDescriptor;
 import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialType;
 import com.yubico.yubikit.fido.webauthn.SerializationType;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,6 +51,25 @@ public class SignExtensionTest {
 
   private static Map<String, ?> signInput(Map<String, ?> value) {
     return Collections.singletonMap(NAME, value);
+  }
+
+  private static Map<String, Object> credEntry() {
+    Map<String, Object> entry = new HashMap<>();
+    entry.put("keyHandle", Base64.toUrlSafeString(new byte[] {1}));
+    entry.put("tbs", Base64.toUrlSafeString(new byte[] {2}));
+    return entry;
+  }
+
+  private static Map<String, ?> signByCredential(byte[]... ids) {
+    Map<String, Object> byCred = new HashMap<>();
+    for (byte[] id : ids) {
+      byCred.put(Base64.toUrlSafeString(id), credEntry());
+    }
+    return signInput(Collections.singletonMap("signByCredential", byCred));
+  }
+
+  private static PublicKeyCredentialDescriptor descriptor(byte[] id) {
+    return new PublicKeyCredentialDescriptor(PublicKeyCredentialType.PUBLIC_KEY, id);
   }
 
   @Test
@@ -67,17 +89,28 @@ public class SignExtensionTest {
   }
 
   @Test
-  public void makeCredentialSignByCredentialIsIgnored() {
-    Map<String, ?> input =
-        signInput(Collections.singletonMap("signByCredential", Collections.emptyMap()));
-    assertNull(extension.makeCredential(session(NAME), creation(input), pinUvAuth));
+  public void makeCredentialSignByCredentialThrows() {
+    Map<String, Object> withBoth = new HashMap<>();
+    withBoth.put(
+        "generateKey", Collections.singletonMap("algorithms", Collections.singletonList(-7)));
+    withBoth.put("signByCredential", Collections.emptyMap());
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () ->
+                extension.makeCredential(session(NAME), creation(signInput(withBoth)), pinUvAuth));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
   }
 
   @Test
-  public void makeCredentialWithoutGenerateKeyIsIgnored() {
-    assertNull(
-        extension.makeCredential(
-            session(NAME), creation(signInput(Collections.emptyMap())), pinUvAuth));
+  public void makeCredentialWithoutGenerateKeyThrows() {
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () ->
+                extension.makeCredential(
+                    session(NAME), creation(signInput(Collections.emptyMap())), pinUvAuth));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
   }
 
   @Test
@@ -118,13 +151,60 @@ public class SignExtensionTest {
   }
 
   @Test
-  public void getAssertionWithGenerateKeyIsIgnored() {
+  public void getAssertionWithGenerateKeyThrows() {
     Map<String, ?> input =
         signInput(
             Collections.singletonMap(
                 "generateKey",
                 Collections.singletonMap("algorithms", Collections.singletonList(-7))));
-    assertNull(extension.getAssertion(session(NAME), request(input), pinUvAuth));
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () -> extension.getAssertion(session(NAME), request(input), pinUvAuth));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
+  }
+
+  @Test
+  public void getAssertionEmptyAllowListThrows() {
+    // Spec: empty allowCredentials with signByCredential -> NotSupportedError.
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () ->
+                extension.getAssertion(
+                    session(NAME), request(signByCredential(new byte[] {9})), pinUvAuth));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
+  }
+
+  @Test
+  public void getAssertionSizeMismatchThrows() {
+    // Spec: signByCredential size must equal allowCredentials size -> NotSupportedError.
+    byte[] id1 = {1};
+    byte[] id2 = {2};
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () ->
+                extension.getAssertion(
+                    session(NAME),
+                    request(signByCredential(id1), Arrays.asList(descriptor(id1), descriptor(id2))),
+                    pinUvAuth));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
+  }
+
+  @Test
+  public void getAssertionMissingEntryThrows() {
+    // Spec: an allowed credential with no signByCredential entry -> SyntaxError (BAD_REQUEST).
+    byte[] withEntry = {1};
+    byte[] missing = {2};
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.getAssertion(
+                session(NAME),
+                request(
+                    signByCredential(withEntry), Collections.singletonList(descriptor(missing))),
+                pinUvAuth));
   }
 
   /**
@@ -159,17 +239,45 @@ public class SignExtensionTest {
   }
 
   @Test
-  public void malformedSignInputIsIgnored() {
+  public void malformedSignInputThrows() {
     // previewSign value is not a map.
-    assertNull(
-        extension.makeCredential(
-            session(NAME), creation(Collections.singletonMap(NAME, "not-a-map")), pinUvAuth));
-    // Nested wrong type (algorithms is not a list) must be ignored, not abort.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.makeCredential(
+                session(NAME), creation(Collections.singletonMap(NAME, "not-a-map")), pinUvAuth));
+    // Nested wrong type (algorithms is not a list) must be surfaced, not silently dropped.
     Map<String, ?> badGenerateKey =
         signInput(
             Collections.singletonMap(
                 "generateKey", Collections.singletonMap("algorithms", "not-a-list")));
-    assertNull(extension.makeCredential(session(NAME), creation(badGenerateKey), pinUvAuth));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extension.makeCredential(session(NAME), creation(badGenerateKey), pinUvAuth));
+  }
+
+  /**
+   * When the authenticator returns malformed authenticatorData (here, the ED flag is set but no
+   * extensions bytes follow, so AuthenticatorData.parseFrom throws), the output processor must
+   * degrade to no result rather than letting the exception escape (and be misreported as a
+   * relying-party error).
+   */
+  @Test
+  public void getAssertionMalformedAuthOutputProducesNoResult() {
+    byte[] id = {9, 9};
+    Extension.AuthenticationProcessor processor =
+        extension.getAssertion(
+            session(NAME),
+            request(signByCredential(id), Collections.singletonList(descriptor(id))),
+            pinUvAuth);
+    assertNotNull(processor);
+
+    Ctap2Session.AssertionData assertionData = mock(Ctap2Session.AssertionData.class);
+    when(assertionData.getAuthenticatorData()).thenReturn(malformedAuthenticatorData());
+
+    Map<String, Object> output =
+        processor.getOutput(assertionData, null).getClientExtensionResult(SerializationType.CBOR);
+    assertTrue(output.isEmpty());
   }
 
   /** Minimal authenticator data: rpIdHash + ED flag + signCount + an empty CBOR extensions map. */
@@ -180,6 +288,15 @@ public class SignExtensionTest {
         .put((byte) 0x80) // ED flag (bit 7) set, AT clear
         .putInt(0) // signCount
         .put(extensions)
+        .array();
+  }
+
+  /** Malformed authenticator data: ED flag set but no extensions bytes -> parseFrom throws. */
+  private static byte[] malformedAuthenticatorData() {
+    return ByteBuffer.allocate(32 + 1 + 4)
+        .put(new byte[32]) // rpIdHash
+        .put((byte) 0x80) // ED flag set, but no extensions data follows
+        .putInt(0) // signCount
         .array();
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtensionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.request;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.session;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+
+public class ThirdPartyPaymentExtensionTest {
+
+  private static final String NAME = "thirdPartyPayment";
+  private final ThirdPartyPaymentExtension extension = new ThirdPartyPaymentExtension();
+  private final PinUvAuthProtocol pinUvAuth = mock(PinUvAuthProtocol.class);
+
+  private static Map<String, ?> paymentInput(boolean isPayment) {
+    return Collections.singletonMap("payment", Collections.singletonMap("isPayment", isPayment));
+  }
+
+  @Test
+  public void makeCredentialHappyPath() {
+    Extension.RegistrationProcessor processor =
+        extension.makeCredential(session(NAME), creation(paymentInput(true)), pinUvAuth);
+    assertNotNull(processor);
+    assertEquals(Boolean.TRUE, processor.getInput(null).get(NAME));
+  }
+
+  @Test
+  public void getAssertionHappyPath() {
+    Extension.AuthenticationProcessor processor =
+        extension.getAssertion(session(NAME), request(paymentInput(true)), pinUvAuth);
+    assertNotNull(processor);
+    assertEquals(Boolean.TRUE, processor.getInput(null, null).get(NAME));
+  }
+
+  @Test
+  public void notSupportedReturnsNull() {
+    assertNull(extension.makeCredential(session(), creation(paymentInput(true)), pinUvAuth));
+    assertNull(extension.getAssertion(session(), request(paymentInput(true)), pinUvAuth));
+  }
+
+  @Test
+  public void missingPaymentDataReturnsNull() {
+    assertNull(extension.makeCredential(session(NAME), creation(null), pinUvAuth));
+    assertNull(
+        extension.makeCredential(session(NAME), creation(Collections.emptyMap()), pinUvAuth));
+    // payment present but isPayment missing
+    assertNull(
+        extension.makeCredential(
+            session(NAME),
+            creation(Collections.singletonMap("payment", Collections.emptyMap())),
+            pinUvAuth));
+  }
+}

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtensionTest.java
@@ -22,6 +22,7 @@ import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.sess
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
@@ -59,6 +60,42 @@ public class ThirdPartyPaymentExtensionTest {
   public void notSupportedReturnsNull() {
     assertNull(extension.makeCredential(session(), creation(paymentInput(true)), pinUvAuth));
     assertNull(extension.getAssertion(session(), request(paymentInput(true)), pinUvAuth));
+  }
+
+  @Test
+  public void malformedPaymentTypeThrows() {
+    // payment is a dictionary: a non-object value is malformed structure -> BAD_REQUEST.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.makeCredential(
+                session(NAME), creation(Collections.singletonMap("payment", "nope")), pinUvAuth));
+  }
+
+  @Test
+  public void nonBooleanIsPaymentThrows() {
+    // isPayment is a boolean request flag, so a non-boolean present value is malformed caller
+    // input -> BAD_REQUEST.
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            extension.makeCredential(
+                session(NAME),
+                creation(
+                    Collections.singletonMap("payment", Collections.singletonMap("isPayment", 1))),
+                pinUvAuth));
+  }
+
+  @Test
+  public void falseIsPaymentIsIgnored() {
+    // The boolean flag indicates whether the extension is requested: false means "not requested",
+    // so it is ignored (no authenticator input), not surfaced.
+    assertNull(
+        extension.makeCredential(
+            session(NAME),
+            creation(
+                Collections.singletonMap("payment", Collections.singletonMap("isPayment", false))),
+            pinUvAuth));
   }
 
   @Test

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/fido/client/extensions/ExtensionsInstrumentedTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/fido/client/extensions/ExtensionsInstrumentedTests.java
@@ -92,6 +92,11 @@ public class ExtensionsInstrumentedTests {
     public void testThirdPartyPaymentExtension() throws Throwable {
       withDevice(ThirdPartyPaymentExtensionTests::test);
     }
+
+    @Test
+    public void testExtensionFailureHandling() throws Throwable {
+      withDevice(ExtensionFailureTests::test);
+    }
   }
 
   @Category(PinUvAuthProtocolV1Test.class)

--- a/testing-desktop/src/integrationTest/java/com/yubico/yubikit/fido/client/extensions/ExtensionsInstrumentedTests.java
+++ b/testing-desktop/src/integrationTest/java/com/yubico/yubikit/fido/client/extensions/ExtensionsInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Yubico.
+ * Copyright (C) 2025-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing-desktop/src/integrationTest/java/com/yubico/yubikit/fido/client/extensions/ExtensionsInstrumentedTests.java
+++ b/testing-desktop/src/integrationTest/java/com/yubico/yubikit/fido/client/extensions/ExtensionsInstrumentedTests.java
@@ -91,6 +91,11 @@ public class ExtensionsInstrumentedTests {
     public void testThirdPartyPaymentExtension() throws Throwable {
       withDevice(ThirdPartyPaymentExtensionTests::test);
     }
+
+    @Test
+    public void testExtensionFailureHandling() throws Throwable {
+      withDevice(ExtensionFailureTests::test);
+    }
   }
 
   @Category(PinUvAuthProtocolV1Test.class)

--- a/testing/src/main/java/com/yubico/yubikit/fido/client/extensions/ExtensionFailureTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/fido/client/extensions/ExtensionFailureTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static org.junit.Assert.assertThrows;
+
+import com.yubico.yubikit.fido.FidoTestState;
+import com.yubico.yubikit.fido.client.ClientError;
+import com.yubico.yubikit.fido.ctap.Ctap2Session;
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
+import com.yubico.yubikit.fido.utils.ClientHelper;
+import com.yubico.yubikit.fido.utils.CreationOptionsBuilder;
+import com.yubico.yubikit.fido.webauthn.ClientExtensionResults;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredential;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialCreationOptions;
+import com.yubico.yubikit.fido.webauthn.SerializationType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.junit.Assert;
+
+/**
+ * Device tests for how the WebAuthn client handles extension processing failures.
+ *
+ * <p>These exercise the loop logic in {@code Ctap2Client} directly by injecting fake extensions, so
+ * they do not depend on any particular authenticator capability:
+ *
+ * <ul>
+ *   <li>an extension that fails in an ignorable way is skipped without aborting the ceremony or
+ *       suppressing other extensions;
+ *   <li>an extension that raises {@link ExtensionConfigurationException} aborts the ceremony with a
+ *       {@link ClientError};
+ *   <li>a relying-party misconfiguration ({@code largeBlob} read/write during registration) is
+ *       reported as {@link ClientError.Code#BAD_REQUEST}.
+ * </ul>
+ */
+public class ExtensionFailureTests {
+
+  private static final String GOOD_RESULT_KEY = "testGoodResult";
+
+  public static void test(FidoTestState state) throws Throwable {
+    ExtensionFailureTests extTest = new ExtensionFailureTests();
+    extTest.testIgnorableFailureDoesNotSuppressSiblings(state);
+    extTest.testHardFailureAbortsWithClientError(state);
+    extTest.testLargeBlobReadWriteInMakeCredentialIsBadRequest(state);
+  }
+
+  private ExtensionFailureTests() {}
+
+  /** A failing extension must not prevent a sibling extension from producing its result. */
+  private void testIgnorableFailureDoesNotSuppressSiblings(FidoTestState state) throws Throwable {
+    state.withCtap2(
+        session -> {
+          ClientHelper client =
+              new ClientHelper(
+                  session, Arrays.asList(new IgnorableFailingExtension(), new GoodExtension()));
+
+          PublicKeyCredential cred = client.makeCredential(new CreationOptionsBuilder().build());
+
+          ClientExtensionResults results = cred.getClientExtensionResults();
+          Assert.assertNotNull("Expected client extension results", results);
+          Map<String, ?> resultMap = results.toMap(SerializationType.CBOR);
+          Assert.assertEquals(
+              "Sibling extension result was suppressed by a failing extension",
+              Boolean.TRUE,
+              resultMap.get(GOOD_RESULT_KEY));
+        });
+  }
+
+  /** A hard-fail extension must abort the ceremony with the carried {@link ClientError.Code}. */
+  private void testHardFailureAbortsWithClientError(FidoTestState state) throws Throwable {
+    state.withCtap2(
+        session -> {
+          ClientHelper client =
+              new ClientHelper(session, Collections.singletonList(new HardFailingExtension()));
+
+          ClientError error =
+              assertThrows(
+                  ClientError.class,
+                  () -> client.makeCredential(new CreationOptionsBuilder().build()));
+          Assert.assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, error.getErrorCode());
+        });
+  }
+
+  /** Requesting largeBlob read/write during registration is a malformed request. */
+  private void testLargeBlobReadWriteInMakeCredentialIsBadRequest(FidoTestState state)
+      throws Throwable {
+    state.withCtap2(
+        session -> {
+          ClientHelper client = new ClientHelper(session);
+
+          ClientError error =
+              assertThrows(
+                  ClientError.class,
+                  () ->
+                      client.makeCredential(
+                          new CreationOptionsBuilder()
+                              .extensions(
+                                  Collections.singletonMap(
+                                      "largeBlob", Collections.singletonMap("read", true)))
+                              .build()));
+          Assert.assertEquals(ClientError.Code.BAD_REQUEST, error.getErrorCode());
+        });
+  }
+
+  /** Fails in an ignorable way during the build phase; the client should skip it. */
+  private static class IgnorableFailingExtension extends Extension {
+    IgnorableFailingExtension() {
+      super("test-ignorable-failing");
+    }
+
+    @Nullable
+    @Override
+    public RegistrationProcessor makeCredential(
+        @NonNull Ctap2Session ctap,
+        @NonNull PublicKeyCredentialCreationOptions options,
+        @NonNull PinUvAuthProtocol pinUvAuthProtocol) {
+      throw new IllegalArgumentException("ignorable failure");
+    }
+  }
+
+  /** Produces a client extension result but no authenticator input, so it is hardware-agnostic. */
+  private static class GoodExtension extends Extension {
+    GoodExtension() {
+      super("test-good");
+    }
+
+    @Nullable
+    @Override
+    public RegistrationProcessor makeCredential(
+        @NonNull Ctap2Session ctap,
+        @NonNull PublicKeyCredentialCreationOptions options,
+        @NonNull PinUvAuthProtocol pinUvAuthProtocol) {
+      return new RegistrationProcessor(
+          (attestationObject, pinToken) ->
+              serializationType -> Collections.singletonMap(GOOD_RESULT_KEY, true));
+    }
+  }
+
+  /** Signals a hard failure that must abort the ceremony. */
+  private static class HardFailingExtension extends Extension {
+    HardFailingExtension() {
+      super("test-hard-failing");
+    }
+
+    @Nullable
+    @Override
+    public RegistrationProcessor makeCredential(
+        @NonNull Ctap2Session ctap,
+        @NonNull PublicKeyCredentialCreationOptions options,
+        @NonNull PinUvAuthProtocol pinUvAuthProtocol) {
+      throw new ExtensionConfigurationException(
+          ClientError.Code.CONFIGURATION_UNSUPPORTED, "hard failure");
+    }
+  }
+}

--- a/testing/src/main/java/com/yubico/yubikit/fido/client/extensions/ExtensionFailureTests.java
+++ b/testing/src/main/java/com/yubico/yubikit/fido/client/extensions/ExtensionFailureTests.java
@@ -36,18 +36,18 @@ import org.jspecify.annotations.Nullable;
 import org.junit.Assert;
 
 /**
- * Device tests for how the WebAuthn client handles extension processing failures.
- *
- * <p>These exercise the loop logic in {@code Ctap2Client} directly by injecting fake extensions, so
- * they do not depend on any particular authenticator capability:
+ * Device tests for how the WebAuthn client handles extension processing failures. These inject fake
+ * extensions, so they do not depend on any particular authenticator capability:
  *
  * <ul>
- *   <li>an extension that fails in an ignorable way is skipped without aborting the ceremony or
- *       suppressing other extensions;
- *   <li>an extension that raises {@link ExtensionConfigurationException} aborts the ceremony with a
- *       {@link ClientError};
- *   <li>a relying-party misconfiguration ({@code largeBlob} read/write during registration) is
- *       reported as {@link ClientError.Code#BAD_REQUEST}.
+ *   <li>an extension that is not applicable (returns {@code null}) does not suppress other
+ *       extensions' results;
+ *   <li>malformed extension input (an {@link IllegalArgumentException}) aborts the ceremony as
+ *       {@link ClientError.Code#BAD_REQUEST};
+ *   <li>an {@link ExtensionConfigurationException} aborts with the carried {@link
+ *       ClientError.Code};
+ *   <li>a spec-named condition ({@code largeBlob} read during registration, a {@code
+ *       NotSupportedError}) is reported as {@link ClientError.Code#CONFIGURATION_UNSUPPORTED}.
  * </ul>
  */
 public class ExtensionFailureTests {
@@ -56,20 +56,22 @@ public class ExtensionFailureTests {
 
   public static void test(FidoTestState state) throws Throwable {
     ExtensionFailureTests extTest = new ExtensionFailureTests();
-    extTest.testIgnorableFailureDoesNotSuppressSiblings(state);
+    extTest.testNotApplicableExtensionDoesNotSuppressSiblings(state);
+    extTest.testMalformedInputIsBadRequest(state);
     extTest.testHardFailureAbortsWithClientError(state);
-    extTest.testLargeBlobReadWriteInMakeCredentialIsBadRequest(state);
+    extTest.testLargeBlobReadInMakeCredentialIsUnsupported(state);
   }
 
   private ExtensionFailureTests() {}
 
-  /** A failing extension must not prevent a sibling extension from producing its result. */
-  private void testIgnorableFailureDoesNotSuppressSiblings(FidoTestState state) throws Throwable {
+  /** A not-applicable extension (returns null) must not prevent a sibling from producing output. */
+  private void testNotApplicableExtensionDoesNotSuppressSiblings(FidoTestState state)
+      throws Throwable {
     state.withCtap2(
         session -> {
           ClientHelper client =
               new ClientHelper(
-                  session, Arrays.asList(new IgnorableFailingExtension(), new GoodExtension()));
+                  session, Arrays.asList(new NotApplicableExtension(), new GoodExtension()));
 
           PublicKeyCredential cred = client.makeCredential(new CreationOptionsBuilder().build());
 
@@ -77,9 +79,24 @@ public class ExtensionFailureTests {
           Assert.assertNotNull("Expected client extension results", results);
           Map<String, ?> resultMap = results.toMap(SerializationType.CBOR);
           Assert.assertEquals(
-              "Sibling extension result was suppressed by a failing extension",
+              "Sibling extension result was suppressed",
               Boolean.TRUE,
               resultMap.get(GOOD_RESULT_KEY));
+        });
+  }
+
+  /** Malformed extension input must abort the ceremony as a BAD_REQUEST ClientError. */
+  private void testMalformedInputIsBadRequest(FidoTestState state) throws Throwable {
+    state.withCtap2(
+        session -> {
+          ClientHelper client =
+              new ClientHelper(session, Collections.singletonList(new MalformedInputExtension()));
+
+          ClientError error =
+              assertThrows(
+                  ClientError.class,
+                  () -> client.makeCredential(new CreationOptionsBuilder().build()));
+          Assert.assertEquals(ClientError.Code.BAD_REQUEST, error.getErrorCode());
         });
   }
 
@@ -98,8 +115,8 @@ public class ExtensionFailureTests {
         });
   }
 
-  /** Requesting largeBlob read/write during registration is a malformed request. */
-  private void testLargeBlobReadWriteInMakeCredentialIsBadRequest(FidoTestState state)
+  /** Requesting largeBlob read during registration is a NotSupportedError. */
+  private void testLargeBlobReadInMakeCredentialIsUnsupported(FidoTestState state)
       throws Throwable {
     state.withCtap2(
         session -> {
@@ -115,14 +132,14 @@ public class ExtensionFailureTests {
                                   Collections.singletonMap(
                                       "largeBlob", Collections.singletonMap("read", true)))
                               .build()));
-          Assert.assertEquals(ClientError.Code.BAD_REQUEST, error.getErrorCode());
+          Assert.assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, error.getErrorCode());
         });
   }
 
-  /** Fails in an ignorable way during the build phase; the client should skip it. */
-  private static class IgnorableFailingExtension extends Extension {
-    IgnorableFailingExtension() {
-      super("test-ignorable-failing");
+  /** Not applicable for this request: returns null so the client skips it. */
+  private static class NotApplicableExtension extends Extension {
+    NotApplicableExtension() {
+      super("test-not-applicable");
     }
 
     @Nullable
@@ -131,7 +148,7 @@ public class ExtensionFailureTests {
         @NonNull Ctap2Session ctap,
         @NonNull PublicKeyCredentialCreationOptions options,
         @NonNull PinUvAuthProtocol pinUvAuthProtocol) {
-      throw new IllegalArgumentException("ignorable failure");
+      return null;
     }
   }
 
@@ -150,6 +167,22 @@ public class ExtensionFailureTests {
       return new RegistrationProcessor(
           (attestationObject, pinToken) ->
               serializationType -> Collections.singletonMap(GOOD_RESULT_KEY, true));
+    }
+  }
+
+  /** Simulates malformed relying-party input (raised by decode/validation helpers). */
+  private static class MalformedInputExtension extends Extension {
+    MalformedInputExtension() {
+      super("test-malformed-input");
+    }
+
+    @Nullable
+    @Override
+    public RegistrationProcessor makeCredential(
+        @NonNull Ctap2Session ctap,
+        @NonNull PublicKeyCredentialCreationOptions options,
+        @NonNull PinUvAuthProtocol pinUvAuthProtocol) {
+      throw new IllegalArgumentException("malformed input");
     }
   }
 


### PR DESCRIPTION
## Problem

Client extensions were processed in unguarded loops in `Ctap2Client`. If one extension threw during processing, it aborted the whole loop — skipping every remaining extension — and leaked a raw unchecked exception (`IllegalArgumentException` from validation, or `ClassCastException` from unchecked casts of RP-supplied input) out of `makeCredential`/`getAssertion`, which are declared to throw only `IOException`, `CommandException`, and `ClientError`. Behavior was also order-dependent on the extension list.

WebAuthn is explicit about how a client should treat extension data: [§10](https://www.w3.org/TR/webauthn-3/#sctn-defined-extensions) names specific conditions that must be reported as a `NotSupportedError` or `SyntaxError` `DOMException`, and [§9.3](https://www.w3.org/TR/webauthn-3/#sctn-extensions) additionally says clients *SHOULD* ignore unsupported extensions and *SHOULD* ignore extensions with an invalid client extension input. The old code did none of this consistently — it crashed or aborted with a raw unchecked exception.

This change makes the handling deliberate and typed. Unsupported / not-applicable extensions are ignored (skipped, ceremony continues). For **malformed relying-party input**, however, we deliberately depart from §9.3's *SHOULD*-ignore and fail fast with `BAD_REQUEST`: silently dropping a requested extension because its input was the wrong type (or otherwise structurally invalid) would let a credential be created with parameters that differ from what the relying party asked for — a worse outcome than aborting. It is safer to abort the ceremony than to mint a passkey configured differently from the caller's intent because an extension was mis-specified in the creation options. §9.3 is a *SHOULD*, so this is a spec-permitted choice, not a violation.

## Changes

Every exception raised while processing an extension is now funneled through a single policy (`Ctap2Client#handleExtensionFailure`) that maps it to a typed, order-independent outcome instead of leaking a raw unchecked exception. "Isolating" the failure means containing *how* it surfaces, not letting the ceremony continue past it: a genuine extension error still aborts the whole ceremony, just cleanly and with a typed `ClientError` rather than a raw crash. Only the two non-error outcomes below — not-applicable and degrade — allow the ceremony to proceed.

Outcomes that abort — mapped by what the extension throws:

- **`ExtensionConfigurationException` → `ClientError.Code.CONFIGURATION_UNSUPPORTED`.** A spec-named `NotSupportedError` condition, or a capability the relying party explicitly requested that the authenticator cannot satisfy.
- **`IllegalArgumentException` → `ClientError.Code.BAD_REQUEST`.** Malformed caller input for a requested extension (wrong type, invalid value, missing required member, undecodable `BufferSource`), or a spec-defined `SyntaxError`. This replaces the raw `ClassCastException`/`IllegalArgumentException` that used to escape.
- **Anything else → propagate.** Any other unchecked exception is rethrown so genuine defects aren’t masked.

Outcomes that do not abort:

- **Return `null` → not applicable.** The extension does nothing (not requested, not supported, nothing to evaluate, or an extension this client has no handler for) and is skipped; the remaining extensions are processed normally.
- **Malformed authenticator output → degrade.** This is the one place a problem is tolerated rather than surfaced: undecodable/ill-typed *authenticator* output is handled inside the extension (its deferred output provider returns an empty result rather than throwing), so that extension’s result is omitted while the credential/assertion and every other extension’s result still succeed — instead of throwing at response serialization after the credential/assertion already exists.

Every extension was updated to **explicitly validate its client extension input** — type, enum, and required-member checks — up front, so bad input surfaces deterministically as `BAD_REQUEST` (per the contract above) rather than leaking a raw `ClassCastException` or being silently coerced. Hardening was applied across `credProtect`, `credBlob`, `prf`/`hmac-secret`, `largeBlob`, `previewSign`, `minPinLength`, `credProps`, and `thirdPartyPayment`. No public API signature change. The attestation object is parsed once per `makeCredential` and shared across extension-output processing.

Additionally, `credProps` now derives its `rk` output from the residentKey requirement **and** the authenticator's resident-key support, rather than assuming a `required` residentKey always yields a discoverable credential. It reports `rk=false` when the authenticator cannot store a discoverable credential, so the output reflects whether one was actually created.

## Testing

- Hardware-free unit tests for every extension, asserting the extension-level result: happy path, ignored cases (return `null`), malformed input (`IllegalArgumentException`), and named/capability conditions (`ExtensionConfigurationException` carrying the expected `ClientError.Code`).
- A unit test that malformed authenticator output degrades to no result instead of throwing.
- Device tests (`ExtensionFailureTests`) using injected fake extensions, hardware-agnostic: a not-applicable (`null`) extension does not suppress a sibling's result; malformed input aborts as `ClientError.Code.BAD_REQUEST`; a hard-fail aborts with the carried `ClientError.Code.CONFIGURATION_UNSUPPORTED`; and `largeBlob` read at registration is reported as a `NotSupportedError` (`CONFIGURATION_UNSUPPORTED`).
- Ran the extension instrumented test suite on device — all passing.
- `./gradlew spotlessApply test spotbugs build` green.
