### PR TITLE
feat(fido): typed extension errors with device-free pre-validation

### DIFF
--- a/fido-android-ui/js/fido.js
+++ b/fido-android-ui/js/fido.js
@@ -49,7 +49,7 @@ JAVASCRIPT_BRIDGE.onmessage = function(event) {
         promise.resolve(result)
     } else if (data.type === 'reject') {
         console.log('Promise rejected:', promise.method, uuid, data.message)
-        promise.reject(new DOMException(data.message, 'NotAllowedError'))
+        promise.reject(new DOMException(data.message, data.errorName || 'NotAllowedError'))
     } else {
         console.error('FIDO bridge: unknown response type:', data.type)
         promise.reject(new DOMException('The operation failed', 'NotAllowedError'))

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/WebAuthnClientException.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/WebAuthnClientException.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.android.ui
+
+/**
+ * A terminal WebAuthn client error returned by [FidoClient] when a request cannot be satisfied and
+ * retrying would not help — e.g. an unsupported extension request (`largeBlob` write with more than
+ * one allowed credential). Distinct from a [kotlin.coroutines.cancellation.CancellationException],
+ * which signals the user dismissing the flow: this carries the actual reason so the caller can react
+ * to it (a WebView bridge, for instance, rejects the page's promise with a `DOMException` of
+ * [webAuthnError]).
+ *
+ * @property webAuthnError the WebAuthn `DOMException` name for this failure, e.g. `"NotSupportedError"`
+ *   (spec `NotSupportedError`) or `"SyntaxError"` (malformed request input).
+ */
+public class WebAuthnClientException(
+    public val webAuthnError: String,
+    message: String?,
+) : Exception(message)

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoActivity.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoActivity.kt
@@ -53,6 +53,7 @@ import com.yubico.yubikit.android.transport.nfc.NfcNotAvailable
 import com.yubico.yubikit.android.transport.usb.UsbConfiguration
 import com.yubico.yubikit.fido.android.ui.FidoConfigManager
 import com.yubico.yubikit.fido.android.ui.Origin
+import com.yubico.yubikit.fido.android.ui.internal.ui.Error
 import com.yubico.yubikit.fido.android.ui.internal.ui.State
 import com.yubico.yubikit.fido.android.ui.internal.ui.components.FidoPresentation
 import com.yubico.yubikit.fido.android.ui.internal.ui.components.FidoUiHost
@@ -67,6 +68,9 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 internal const val RESULT_KEY_REMOVED = 10000
+internal const val RESULT_ERROR = 10001
+internal const val EXTRA_ERROR_NAME = "errorName"
+internal const val EXTRA_ERROR_MESSAGE = "errorMessage"
 
 internal class YubiKitFidoActivity : ComponentActivity() {
     internal companion object {
@@ -152,10 +156,26 @@ internal class YubiKitFidoActivity : ComponentActivity() {
                     // success path hides the sheet, which fires onDismissRequest here
                     // and would otherwise overwrite RESULT_OK.
                     if (!isFinishing && !credentialDelivered) {
-                        logger.debug("FidoActivity finishWithCancel")
-                        setResult(
-                            RESULT_CANCELED,
-                        )
+                        // Dismissing a terminal error (a deterministic request-level failure)
+                        // returns the real error to the caller, not a cancellation — so the RP's
+                        // page rejects with the correct DOMException instead of "user cancelled".
+                        val terminal =
+                            (viewModel.state.value as? State.OperationError)
+                                ?.error as? Error.Terminal
+                        if (terminal != null) {
+                            logger.debug("FidoActivity finishWithError {}", terminal.webAuthnError)
+                            setResult(
+                                RESULT_ERROR,
+                                Intent()
+                                    .putExtra(EXTRA_ERROR_NAME, terminal.webAuthnError)
+                                    .putExtra(EXTRA_ERROR_MESSAGE, terminal.message),
+                            )
+                        } else {
+                            logger.debug("FidoActivity finishWithCancel")
+                            setResult(
+                                RESULT_CANCELED,
+                            )
+                        }
                     }
                     finishActivity()
                 }

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoClientImpl.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoClientImpl.kt
@@ -147,42 +147,52 @@ internal class FidoClientImpl : FidoClient {
             putExtra("callerLabel", input.callerLabel)
         }
 
-        @Suppress("IntroduceWhenSubject")
         override fun parseResult(
             resultCode: Int,
             intent: Intent?,
-        ): Result<String> = when {
-            resultCode == Activity.RESULT_OK && intent != null -> {
-                intent.getStringExtra("credential")?.let { credentialJson ->
-                    Result.success(credentialJson)
-                }
-                    ?: Result.failure(IllegalStateException("Credential missing in Intent result"))
-            }
+        ): Result<String> = parseFidoActivityResult(resultCode, intent)
+    }
+}
 
-            resultCode == Activity.RESULT_CANCELED -> {
-                Result.failure(CancellationException("User cancelled FIDO operation"))
-            }
-
-            resultCode == RESULT_KEY_REMOVED -> {
-                Result.failure(CancellationException("Key was removed"))
-            }
-
-            resultCode == RESULT_ERROR -> {
-                // A terminal, request-level failure: return the real error (with its WebAuthn
-                // DOMException name) rather than a cancellation, so the caller can react to it.
-                Result.failure(
-                    WebAuthnClientException(
-                        webAuthnError =
-                        intent?.getStringExtra(EXTRA_ERROR_NAME)
-                            ?: "NotSupportedError",
-                        message = intent?.getStringExtra(EXTRA_ERROR_MESSAGE),
-                    ),
-                )
-            }
-
-            else -> {
-                Result.failure(IllegalStateException("Unknown error occurred (resultCode: $resultCode)"))
-            }
+/**
+ * Maps a [YubiKitFidoActivity] result into the [Result] the FIDO API returns. Extracted from the
+ * [ActivityResultContract] so the mapping — in particular the terminal [RESULT_ERROR] path that
+ * carries a WebAuthn `DOMException` name — is unit-testable without an Activity.
+ */
+@Suppress("IntroduceWhenSubject")
+internal fun parseFidoActivityResult(
+    resultCode: Int,
+    intent: Intent?,
+): Result<String> = when {
+    resultCode == Activity.RESULT_OK && intent != null -> {
+        intent.getStringExtra("credential")?.let { credentialJson ->
+            Result.success(credentialJson)
         }
+            ?: Result.failure(IllegalStateException("Credential missing in Intent result"))
+    }
+
+    resultCode == Activity.RESULT_CANCELED -> {
+        Result.failure(CancellationException("User cancelled FIDO operation"))
+    }
+
+    resultCode == RESULT_KEY_REMOVED -> {
+        Result.failure(CancellationException("Key was removed"))
+    }
+
+    resultCode == RESULT_ERROR -> {
+        // A terminal, request-level failure: return the real error (with its WebAuthn
+        // DOMException name) rather than a cancellation, so the caller can react to it.
+        Result.failure(
+            WebAuthnClientException(
+                webAuthnError =
+                intent?.getStringExtra(EXTRA_ERROR_NAME)
+                    ?: "NotSupportedError",
+                message = intent?.getStringExtra(EXTRA_ERROR_MESSAGE),
+            ),
+        )
+    }
+
+    else -> {
+        Result.failure(IllegalStateException("Unknown error occurred (resultCode: $resultCode)"))
     }
 }

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoClientImpl.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoClientImpl.kt
@@ -28,6 +28,7 @@ import androidx.fragment.app.Fragment
 import com.yubico.yubikit.fido.android.ui.FidoClient
 import com.yubico.yubikit.fido.android.ui.FidoConfigManager
 import com.yubico.yubikit.fido.android.ui.Origin
+import com.yubico.yubikit.fido.android.ui.WebAuthnClientException
 import com.yubico.yubikit.fido.client.extensions.Extension
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
@@ -164,6 +165,19 @@ internal class FidoClientImpl : FidoClient {
 
             resultCode == RESULT_KEY_REMOVED -> {
                 Result.failure(CancellationException("Key was removed"))
+            }
+
+            resultCode == RESULT_ERROR -> {
+                // A terminal, request-level failure: return the real error (with its WebAuthn
+                // DOMException name) rather than a cancellation, so the caller can react to it.
+                Result.failure(
+                    WebAuthnClientException(
+                        webAuthnError =
+                        intent?.getStringExtra(EXTRA_ERROR_NAME)
+                            ?: "NotSupportedError",
+                        message = intent?.getStringExtra(EXTRA_ERROR_MESSAGE),
+                    ),
+                )
             }
 
             else -> {

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoClientService.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoClientService.kt
@@ -18,6 +18,7 @@ package com.yubico.yubikit.fido.android.ui.internal
 
 import com.yubico.yubikit.core.application.CommandState
 import com.yubico.yubikit.core.fido.CtapException
+import com.yubico.yubikit.fido.android.ui.FidoConfigManager
 import com.yubico.yubikit.fido.android.ui.Origin
 import com.yubico.yubikit.fido.android.ui.internal.util.toMap
 import com.yubico.yubikit.fido.client.ClientError
@@ -39,6 +40,35 @@ internal class FidoClientService(
     private val commandState = CommandState()
 
     internal fun cancelOngoingOperation() = commandState.cancel()
+
+    /**
+     * Device-independent pre-validation of the request's extension inputs. Throws the same
+     * [ClientError] [performOperation] would for a request that can never succeed, but without a
+     * key — letting the caller fail fast before connecting/prompting. Only covers request-shape
+     * checks (see [Ctap2Client.validateExtensionInputs]); capability checks that need the key are
+     * not performed here.
+     */
+    // Single parse path for the request JSON, shared by pre-validation and the actual operation so
+    // the two cannot parse the request differently.
+    private fun parseRequest(request: String): Map<String, *> = JSONObject(request).toMap()
+
+    internal fun validateRequest(operation: Operation, request: String) {
+        val requestJson = parseRequest(request)
+        val extensions = FidoConfigManager.current.fidoExtensions
+        when (operation) {
+            Operation.MAKE_CREDENTIAL ->
+                Ctap2Client.validateExtensionInputs(
+                    PublicKeyCredentialCreationOptions.fromMap(requestJson),
+                    extensions,
+                )
+
+            Operation.GET_ASSERTION ->
+                Ctap2Client.validateExtensionInputs(
+                    PublicKeyCredentialRequestOptions.fromMap(requestJson),
+                    extensions,
+                )
+        }
+    }
 
     internal suspend fun performOperation(
         pin: CharArray?,
@@ -109,7 +139,7 @@ internal class FidoClientService(
             }
         }
 
-        val requestJson = JSONObject(request).toMap()
+        val requestJson = parseRequest(request)
 
         val publicKeyCredentialCreationOptions =
             PublicKeyCredentialCreationOptions.fromMap(requestJson)
@@ -154,7 +184,7 @@ internal class FidoClientService(
                 )
             }
         }
-        val requestJson = JSONObject(request).toMap()
+        val requestJson = parseRequest(request)
 
         val clientData =
             clientDataHash?.let { ClientDataProvider.fromHash(it) }

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoJs.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoJs.kt
@@ -39,7 +39,7 @@ var result = __decode__credentials(data.result)
 promise.resolve(result)
 } else if (data.type === 'reject') {
 console.log('Promise rejected:', promise.method, uuid, data.message)
-promise.reject(new DOMException(data.message, 'NotAllowedError'))
+promise.reject(new DOMException(data.message, data.errorName || 'NotAllowedError'))
 } else {
 console.error('FIDO bridge: unknown response type:', data.type)
 promise.reject(new DOMException('The operation failed', 'NotAllowedError'))

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoMessageBridge.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoMessageBridge.kt
@@ -68,6 +68,27 @@ internal class FidoMessageBridge(
         private const val TYPE_REJECT = "reject"
         private const val METHOD_CREATE = "create"
         private const val METHOD_GET = "get"
+
+        /**
+         * Creates a JSON error response string for delivery back to JavaScript. When [errorName] is
+         * present the page rejects with a `DOMException` of that name (see fido.js); otherwise it
+         * falls back to the generic `NotAllowedError`.
+         */
+        internal fun errorResponseJson(
+            promiseUuid: String?,
+            message: String,
+            errorName: String? = null,
+        ): String = JSONObject()
+            .apply {
+                put(KEY_TYPE, TYPE_REJECT)
+                if (promiseUuid != null) {
+                    put(KEY_PROMISE_UUID, promiseUuid)
+                }
+                put(KEY_MESSAGE, message)
+                if (errorName != null) {
+                    put(KEY_ERROR_NAME, errorName)
+                }
+            }.toString()
     }
 
     override fun onPostMessage(
@@ -237,22 +258,5 @@ internal class FidoMessageBridge(
             put(KEY_TYPE, TYPE_RESOLVE)
             put(KEY_PROMISE_UUID, promiseUuid)
             put(KEY_RESULT, JSONObject(result))
-        }.toString()
-
-    /** Creates a JSON error response string for delivery back to JavaScript. */
-    private fun errorResponseJson(
-        promiseUuid: String?,
-        message: String,
-        errorName: String? = null,
-    ): String = JSONObject()
-        .apply {
-            put(KEY_TYPE, TYPE_REJECT)
-            if (promiseUuid != null) {
-                put(KEY_PROMISE_UUID, promiseUuid)
-            }
-            put(KEY_MESSAGE, message)
-            if (errorName != null) {
-                put(KEY_ERROR_NAME, errorName)
-            }
         }.toString()
 }

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoMessageBridge.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoMessageBridge.kt
@@ -24,6 +24,7 @@ import androidx.webkit.WebMessageCompat
 import androidx.webkit.WebViewCompat
 import com.yubico.yubikit.fido.android.ui.FidoClient
 import com.yubico.yubikit.fido.android.ui.Origin
+import com.yubico.yubikit.fido.android.ui.WebAuthnClientException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.json.JSONObject
@@ -60,6 +61,7 @@ internal class FidoMessageBridge(
         private const val KEY_TYPE = "type"
         private const val KEY_RESULT = "result"
         private const val KEY_MESSAGE = "message"
+        private const val KEY_ERROR_NAME = "errorName"
 
         // Protocol values
         private const val TYPE_RESOLVE = "resolve"
@@ -197,8 +199,17 @@ internal class FidoMessageBridge(
                 replyProxy.postMessage(successResponseJson(promiseUuid, result))
             } catch (t: Throwable) {
                 logger.error("FIDO operation failed", t)
+                // A terminal request-level failure carries the WebAuthn DOMException name so the
+                // page rejects with the correct error; anything else stays the generic default
+                // (rejected as NotAllowedError by the polyfill).
+                val errorName = (t as? WebAuthnClientException)?.webAuthnError
+                val message = (t as? WebAuthnClientException)?.message ?: "The operation failed"
                 replyProxy.postMessage(
-                    errorResponseJson(promiseUuid = promiseUuid, message = "The operation failed"),
+                    errorResponseJson(
+                        promiseUuid = promiseUuid,
+                        message = message,
+                        errorName = errorName,
+                    ),
                 )
             }
         }
@@ -232,6 +243,7 @@ internal class FidoMessageBridge(
     private fun errorResponseJson(
         promiseUuid: String?,
         message: String,
+        errorName: String? = null,
     ): String = JSONObject()
         .apply {
             put(KEY_TYPE, TYPE_REJECT)
@@ -239,5 +251,8 @@ internal class FidoMessageBridge(
                 put(KEY_PROMISE_UUID, promiseUuid)
             }
             put(KEY_MESSAGE, message)
+            if (errorName != null) {
+                put(KEY_ERROR_NAME, errorName)
+            }
         }.toString()
 }

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/MainViewModel.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/MainViewModel.kt
@@ -38,6 +38,8 @@ import com.yubico.yubikit.fido.client.Ctap2Client
 import com.yubico.yubikit.fido.client.MultipleAssertionsAvailable
 import com.yubico.yubikit.fido.client.PinRequiredClientError
 import com.yubico.yubikit.fido.client.WebAuthnClient
+import com.yubico.yubikit.fido.client.extensions.ExtensionConfigurationException
+import com.yubico.yubikit.fido.client.extensions.ExtensionNotSupportedException
 import com.yubico.yubikit.fido.ctap.BioEnrollment
 import com.yubico.yubikit.fido.ctap.Ctap2Session
 import com.yubico.yubikit.fido.webauthn.PublicKeyCredential
@@ -284,6 +286,84 @@ internal open class MainViewModel(
         )
     }
 
+    /**
+     * Maps a FIDO operation failure to a UI [Error]. Extracted so the same mapping serves both the
+     * post-connection failure path and device-free pre-validation.
+     */
+    private fun mapError(error: Throwable): Error = when (error) {
+        is PinRequiredClientError -> Error.PinRequiredError
+
+        is AuthInvalidClientError -> {
+            when (error.authType) {
+                AuthInvalidClientError.AuthType.PIN -> Error.IncorrectPinError(error.retries)
+                AuthInvalidClientError.AuthType.UV -> Error.IncorrectUvError(error.retries)
+            }
+        }
+
+        is ClientError -> {
+            // Extension-request failures (hard-config or malformed input) always arrive with an
+            // ExtensionConfigurationException cause. Intercept them first, so they never fall
+            // into the "Set a PIN" (DeviceNotConfigured) path below and we never match
+            // human-readable messages. The one distinction that changes the outcome is carried
+            // by the type: ExtensionNotSupportedException means the key lacks a required
+            // capability (ineligible); anything else is an unsupported/malformed request.
+            val extensionCause = error.cause as? ExtensionConfigurationException
+            val ctapError = (error.cause as? CtapException)?.ctapError
+            when {
+                extensionCause is ExtensionNotSupportedException -> Error.DeviceIneligibleError
+
+                extensionCause != null ->
+                    Error.ExtensionUnsupportedError(
+                        webAuthnError = extensionCause.webAuthnErrorName,
+                        message = extensionCause.message,
+                    )
+
+                error.errorCode == ClientError.Code.CONFIGURATION_UNSUPPORTED -> {
+                    when (ctapError) {
+                        CtapException.ERR_KEY_STORE_FULL -> Error.OperationError(error.cause)
+
+                        CtapException.ERR_UNSUPPORTED_EXTENSION,
+                        CtapException.ERR_UNSUPPORTED_OPTION,
+                        CtapException.ERR_UNSUPPORTED_ALGORITHM,
+                        -> Error.DeviceIneligibleError
+
+                        else -> Error.DeviceNotConfiguredError
+                    }
+                }
+
+                else -> {
+                    when (ctapError) {
+                        CtapException.ERR_PIN_BLOCKED -> Error.PinBlockedError
+
+                        CtapException.ERR_PIN_AUTH_BLOCKED -> Error.PinAuthBlockedError
+
+                        CtapException.ERR_PIN_NOT_SET -> Error.PinNotSetError
+
+                        CtapException.ERR_PIN_POLICY_VIOLATION -> {
+                            when (info?.forcePinChange) {
+                                true -> Error.ForcePinChangeError(null)
+                                else -> Error.IncorrectPinError(null)
+                            }
+                        }
+
+                        CtapException.ERR_UV_BLOCKED,
+                        CtapException.ERR_PUAT_REQUIRED,
+                        -> Error.UvBlockedError
+
+                        else -> Error.OperationError(error.cause)
+                    }
+                }
+            }
+        }
+
+        is TagLostException -> Error.TagLostError
+
+        else -> {
+            logger.error("Unexpected error during FIDO operation: ", error)
+            Error.UnknownError
+        }
+    }
+
     fun startFidoOperation(
         fidoClientService: FidoClientService,
         operation: FidoClientService.Operation,
@@ -302,6 +382,21 @@ internal open class MainViewModel(
 
         viewModelScope.launch {
             try {
+                // Device-free fail-fast: reject a request whose extension inputs can never be
+                // satisfied before connecting to / prompting for a key (matching a browser's
+                // synchronous NotSupportedError). Only short-circuit on ClientError — the exact
+                // errors this is meant to catch; any other throw is ignored so the normal path
+                // still surfaces it with full context. The same checks also run inside
+                // performOperation, so skipping this changes nothing but the timing.
+                val prevalidationError =
+                    runCatching { fidoClientService.validateRequest(operation, request) }
+                        .exceptionOrNull()
+                if (prevalidationError is ClientError) {
+                    cancelUiStateTimer()
+                    _state.value = State.OperationError(mapError(prevalidationError))
+                    return@launch
+                }
+
                 result?.let {
                     deliverResult(it, onResult)
                     return@launch
@@ -462,103 +557,7 @@ internal open class MainViewModel(
                             return@launch
                         }
 
-                        val errorState =
-                            when (error) {
-                                is PinRequiredClientError -> {
-                                    Error.PinRequiredError
-                                }
-
-                                is AuthInvalidClientError -> {
-                                    when (error.authType) {
-                                        AuthInvalidClientError.AuthType.PIN -> {
-                                            Error.IncorrectPinError(
-                                                error.retries,
-                                            )
-                                        }
-
-                                        AuthInvalidClientError.AuthType.UV -> {
-                                            Error.IncorrectUvError(
-                                                error.retries,
-                                            )
-                                        }
-                                    }
-                                }
-
-                                is ClientError -> {
-                                    when (error.errorCode) {
-                                        ClientError.Code.CONFIGURATION_UNSUPPORTED -> {
-                                            when ((error.cause as? CtapException)?.ctapError) {
-                                                CtapException.ERR_KEY_STORE_FULL -> {
-                                                    Error.OperationError(
-                                                        error.cause,
-                                                    )
-                                                }
-
-                                                CtapException.ERR_UNSUPPORTED_EXTENSION,
-                                                CtapException.ERR_UNSUPPORTED_OPTION,
-                                                CtapException.ERR_UNSUPPORTED_ALGORITHM,
-                                                -> Error.DeviceIneligibleError
-
-                                                else -> Error.DeviceNotConfiguredError
-                                            }
-                                        }
-
-                                        else -> {
-                                            when ((error.cause as? CtapException)?.ctapError) {
-                                                CtapException.ERR_PIN_BLOCKED -> {
-                                                    Error.PinBlockedError
-                                                }
-
-                                                CtapException.ERR_PIN_AUTH_BLOCKED -> {
-                                                    Error.PinAuthBlockedError
-                                                }
-
-                                                CtapException.ERR_PIN_NOT_SET -> {
-                                                    Error.PinNotSetError
-                                                }
-
-                                                CtapException.ERR_PIN_POLICY_VIOLATION -> {
-                                                    when (info?.forcePinChange) {
-                                                        true -> Error.ForcePinChangeError(null)
-                                                        else -> Error.IncorrectPinError(null)
-                                                    }
-                                                }
-
-                                                CtapException.ERR_UV_BLOCKED,
-                                                CtapException.ERR_PUAT_REQUIRED,
-                                                -> {
-                                                    Error.UvBlockedError
-                                                }
-
-                                                else -> {
-                                                    Error.OperationError(error.cause)
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-
-                                is TagLostException -> {
-                                    Error.TagLostError
-                                }
-
-                                is IllegalArgumentException ->
-                                    when (error.message) {
-                                        "No Credential Protection support",
-                                        "Authenticator does not support large blob storage",
-                                        -> Error.DeviceIneligibleError
-
-                                        else -> {
-                                            logger.error("Unexpected error during FIDO operation: ", error)
-                                            Error.UnknownError
-                                        }
-                                    }
-
-                                else -> {
-                                    logger.error("Unexpected error during FIDO operation: ", error)
-                                    Error.UnknownError
-                                }
-                            }
+                        val errorState = mapError(error)
                         // handle the error by advancing to the next UI state
                         _state.value =
                             when (errorState) {

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/ui/Error.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/ui/Error.kt
@@ -17,6 +17,22 @@
 package com.yubico.yubikit.fido.android.ui.internal.ui
 
 internal sealed class Error {
+    /**
+     * A terminal error: a deterministic, request-level rejection where retrying can never succeed.
+     * The UI offers a single dismiss (not "Retry"), and the caller receives the real error — a
+     * [com.yubico.yubikit.fido.android.ui.WebAuthnClientException] carrying [webAuthnError] — rather
+     * than a cancellation. Every terminal [Error] implements this so the UI button ([isTerminal]),
+     * the activity result code, and the returned exception all key off one type; add a new terminal
+     * error by implementing this interface and nothing else needs to change.
+     *
+     * @property webAuthnError the WebAuthn `DOMException` name (e.g. `"NotSupportedError"`).
+     * @property message the client's human-readable detail, for logging.
+     */
+    interface Terminal {
+        val webAuthnError: String
+        val message: String?
+    }
+
     data object PinRequiredError : Error()
 
     data object PinComplexityError : Error()
@@ -32,6 +48,34 @@ internal sealed class Error {
     data object DeviceNotConfiguredError : Error()
 
     data object DeviceIneligibleError : Error()
+
+    /**
+     * The relying party requested an extension configuration that cannot be satisfied (a WebAuthn
+     * `NotSupportedError`/`SyntaxError` raised during client extension processing), e.g. a
+     * `largeBlob` write with more than one allowed credential. Distinct from
+     * [DeviceNotConfiguredError]: nothing is wrong with the key, the request itself is unsupported.
+     * The capability-missing subset (credProtect/largeBlob required-but-unsupported) maps to
+     * [DeviceIneligibleError] instead.
+     *
+     * This is a **terminal** error (see [isTerminal]): retrying can never succeed, so the UI offers
+     * a single dismiss and the caller receives a [com.yubico.yubikit.fido.android.ui.WebAuthnClientException]
+     * carrying [webAuthnError] rather than a cancellation.
+     *
+     * @property webAuthnError the WebAuthn `DOMException` name (`"NotSupportedError"` or `"SyntaxError"`).
+     * @property message the client's human-readable detail, for logging.
+     */
+    data class ExtensionUnsupportedError(
+        override val webAuthnError: String,
+        override val message: String?,
+    ) : Error(),
+        Terminal
+
+    /**
+     * Whether retrying this error could plausibly succeed. Terminal errors (a deterministic,
+     * request-level rejection) offer a single dismiss instead of "Retry", and are returned to the
+     * caller as their real error rather than a cancellation.
+     */
+    fun isTerminal(): Boolean = this is Terminal
 
     data class IncorrectPinError(val remainingAttempts: Int?) : Error()
 

--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/ui/screens/ResultScreen.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/ui/screens/ResultScreen.kt
@@ -164,20 +164,33 @@ internal fun ErrorView(
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            if (isDialog && onCloseButtonClick != null) {
-                TextButton(
+            if (error?.isTerminal() == true && onCloseButtonClick != null) {
+                // Retrying a request-level failure can never succeed; offer a single dismiss that
+                // returns the real error (not a cancellation) to the caller. Guarded on a non-null
+                // handler so the Close button is never rendered inert (production always supplies
+                // one; see FidoClientScreen).
+                Button(
                     onClick = onCloseButtonClick,
-                    modifier = Modifier.testTag("cancel_button"),
+                    modifier = Modifier.testTag("close_button"),
                 ) {
-                    Text(stringResource(R.string.yk_fido_cancel))
+                    Text(stringResource(R.string.yk_fido_close))
                 }
-                Spacer(modifier = Modifier.width(8.dp))
-            }
-            Button(
-                onClick = onRetry,
-                modifier = Modifier.testTag("retry_button"),
-            ) {
-                Text(stringResource(R.string.yk_fido_retry))
+            } else {
+                if (isDialog && onCloseButtonClick != null) {
+                    TextButton(
+                        onClick = onCloseButtonClick,
+                        modifier = Modifier.testTag("cancel_button"),
+                    ) {
+                        Text(stringResource(R.string.yk_fido_cancel))
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Button(
+                    onClick = onRetry,
+                    modifier = Modifier.testTag("retry_button"),
+                ) {
+                    Text(stringResource(R.string.yk_fido_retry))
+                }
             }
         }
     }
@@ -216,6 +229,8 @@ private fun resolveErrorText(error: Error?, rpId: String): String = when (error)
     }
 
     is Error.DeviceIneligibleError -> stringResource(R.string.yk_fido_device_ineligible)
+
+    is Error.ExtensionUnsupportedError -> stringResource(R.string.yk_fido_request_not_supported)
 
     is Error.DeviceNotConfiguredError -> stringResource(R.string.yk_fido_device_not_configured)
 
@@ -257,6 +272,23 @@ internal fun OperationErrorViewPreview() {
             operation = FidoClientService.Operation.GET_ASSERTION,
             rpId = "example.com",
             error = Error.OperationError(CtapException(CtapException.ERR_KEY_STORE_FULL)),
+            onRetry = {},
+        )
+    }
+}
+
+@DefaultPreview
+@Composable
+internal fun ExtensionUnsupportedErrorViewPreview() {
+    FidoAndroidTheme {
+        ErrorView(
+            operation = FidoClientService.Operation.GET_ASSERTION,
+            rpId = "example.com",
+            error = Error.ExtensionUnsupportedError(
+                "NotSupportedError",
+                "largeBlob write requires exactly one allowed credential",
+            ),
+            onCloseButtonClick = {},
             onRetry = {},
         )
     }

--- a/fido-android-ui/src/main/res/values/strings.xml
+++ b/fido-android-ui/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="yk_fido_unknown_error">Unknown error</string>
     <string name="yk_fido_device_not_configured">Set a PIN on your security key to continue.</string>
     <string name="yk_fido_device_ineligible">Your security key cannot be used for this site/app.</string>
+    <string name="yk_fido_request_not_supported">This request isn\'t supported.</string>
+    <string name="yk_fido_close">Close</string>
     <string name="yk_fido_select_passkey_title">Select a passkey</string>
     <string name="yk_fido_select_passkey">Select a passkey to login (%1$d available)</string>
     <string name="yk_fido_retry">Retry</string>

--- a/fido-android-ui/src/test/kotlin/com/yubico/yubikit/fido/android/ui/MainViewModelTest.kt
+++ b/fido-android-ui/src/test/kotlin/com/yubico/yubikit/fido/android/ui/MainViewModelTest.kt
@@ -17,11 +17,21 @@
 package com.yubico.yubikit.fido.android.ui
 
 import app.cash.turbine.test
+import com.yubico.yubikit.core.fido.CtapException
+import com.yubico.yubikit.fido.android.ui.Origin
+import com.yubico.yubikit.fido.android.ui.internal.FidoClientService
 import com.yubico.yubikit.fido.android.ui.internal.MainViewModel
+import com.yubico.yubikit.fido.android.ui.internal.ui.Error
 import com.yubico.yubikit.fido.android.ui.internal.ui.State
+import com.yubico.yubikit.fido.client.ClientError
+import com.yubico.yubikit.fido.client.extensions.ExtensionConfigurationException
+import com.yubico.yubikit.fido.client.extensions.ExtensionNotSupportedException
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredential
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -31,6 +41,13 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verifyBlocking
 
 /**
  * Unit tests for MainViewModel.
@@ -104,5 +121,104 @@ class MainViewModelTest {
     @Test
     fun `cancelUiStateTimer does not throw when no timer active`() {
         viewModel.cancelUiStateTimer()
+    }
+
+    /**
+     * Drives [MainViewModel.runFidoOperation] with a [FidoClientService] whose operation fails with
+     * [failure], and returns the resulting terminal [State].
+     */
+    private suspend fun TestScope.stateAfterOperationFailure(failure: Throwable): State {
+        val service =
+            mock<FidoClientService> {
+                onBlocking {
+                    performOperation(anyOrNull(), any(), any(), anyOrNull(), any(), any())
+                } doReturn Result.failure(failure)
+            }
+        viewModel.lastFidoClientService = service
+        viewModel.lastOperation = FidoClientService.Operation.GET_ASSERTION
+        viewModel.lastOrigin = Origin("https://example.com")
+        viewModel.lastRequest = "{}"
+        viewModel.lastClientDataHash = null
+        viewModel.lastOnResult = {}
+
+        viewModel.runFidoOperation()
+        advanceUntilIdle()
+        return viewModel.state.value
+    }
+
+    @Test
+    fun `extension configuration error surfaces ExtensionUnsupportedError not device-not-configured`() = runTest {
+        // Regression: a ClientError whose (base) ExtensionConfigurationException cause must not
+        // fall through to DeviceNotConfiguredError ("Set a PIN"); it is an unsupported request.
+        val cause =
+            ExtensionConfigurationException(
+                ClientError.Code.CONFIGURATION_UNSUPPORTED,
+                "largeBlob write requires exactly one allowed credential",
+            )
+        val error =
+            ClientError(ClientError.Code.CONFIGURATION_UNSUPPORTED, "message", cause)
+
+        val state = stateAfterOperationFailure(error)
+
+        assertTrue(state is State.OperationError)
+        assertTrue((state as State.OperationError).error is Error.ExtensionUnsupportedError)
+    }
+
+    @Test
+    fun `credProtect-unsupported extension error surfaces DeviceIneligibleError`() = runTest {
+        // Regression guard for the merge interaction: a missing required capability
+        // (ExtensionNotSupportedException) must map back to DeviceIneligibleError, not
+        // DeviceNotConfiguredError.
+        val cause = ExtensionNotSupportedException("No Credential Protection support")
+        val error = ClientError(ClientError.Code.CONFIGURATION_UNSUPPORTED, "message", cause)
+
+        val state = stateAfterOperationFailure(error)
+
+        assertTrue(state is State.OperationError)
+        assertEquals(Error.DeviceIneligibleError, (state as State.OperationError).error)
+    }
+
+    @Test
+    fun `prevalidation failure short-circuits to OperationError without connecting`() = runTest {
+        // A doomed extension request must fail before the key is ever contacted: no WaitingForKey,
+        // and performOperation is never invoked.
+        val cause =
+            ExtensionConfigurationException(
+                ClientError.Code.CONFIGURATION_UNSUPPORTED,
+                "largeBlob write requires exactly one allowed credential",
+            )
+        val clientError = ClientError(ClientError.Code.CONFIGURATION_UNSUPPORTED, "message", cause)
+        val service =
+            mock<FidoClientService> {
+                on { validateRequest(any(), any()) } doAnswer { throw clientError }
+            }
+        viewModel.lastFidoClientService = service
+        viewModel.lastOperation = FidoClientService.Operation.GET_ASSERTION
+        viewModel.lastOrigin = Origin("https://example.com")
+        viewModel.lastRequest = "{}"
+        viewModel.lastClientDataHash = null
+        viewModel.lastOnResult = {}
+
+        viewModel.runFidoOperation()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertTrue(state is State.OperationError)
+        assertTrue((state as State.OperationError).error is Error.ExtensionUnsupportedError)
+        verifyBlocking(service, never()) {
+            performOperation(anyOrNull(), any(), any(), anyOrNull(), any(), any())
+        }
+    }
+
+    @Test
+    fun `configuration-unsupported without extension cause still maps to DeviceNotConfiguredError`() = runTest {
+        // The genuine "UV not configured" case (no cause) must keep its "Set a PIN" mapping.
+        val error =
+            ClientError(ClientError.Code.CONFIGURATION_UNSUPPORTED, "User verification not configured")
+
+        val state = stateAfterOperationFailure(error)
+
+        assertTrue(state is State.OperationError)
+        assertEquals(Error.DeviceNotConfiguredError, (state as State.OperationError).error)
     }
 }

--- a/fido-android-ui/src/test/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoClientImplTest.kt
+++ b/fido-android-ui/src/test/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoClientImplTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.android.ui.internal
+
+import android.app.Activity
+import android.content.Intent
+import com.yubico.yubikit.fido.android.ui.WebAuthnClientException
+import kotlinx.coroutines.CancellationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/** Unit tests for [parseFidoActivityResult] — the activity-result to [Result] mapping. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class FidoClientImplTest {
+
+    @Test
+    fun `RESULT_ERROR returns WebAuthnClientException carrying name and message`() {
+        val intent = Intent()
+            .putExtra(EXTRA_ERROR_NAME, "NotSupportedError")
+            .putExtra(EXTRA_ERROR_MESSAGE, "largeBlob write requires exactly one allowed credential")
+
+        val error = parseFidoActivityResult(RESULT_ERROR, intent).exceptionOrNull()
+
+        assertTrue(error is WebAuthnClientException)
+        error as WebAuthnClientException
+        assertEquals("NotSupportedError", error.webAuthnError)
+        assertEquals("largeBlob write requires exactly one allowed credential", error.message)
+    }
+
+    @Test
+    fun `RESULT_ERROR without a name falls back to NotSupportedError`() {
+        val error = parseFidoActivityResult(RESULT_ERROR, Intent()).exceptionOrNull()
+
+        assertTrue(error is WebAuthnClientException)
+        assertEquals("NotSupportedError", (error as WebAuthnClientException).webAuthnError)
+        assertNull(error.message)
+    }
+
+    @Test
+    fun `RESULT_CANCELED is a cancellation, not a WebAuthnClientException`() {
+        val error = parseFidoActivityResult(Activity.RESULT_CANCELED, null).exceptionOrNull()
+
+        assertTrue(error is CancellationException)
+    }
+
+    @Test
+    fun `RESULT_OK returns the credential JSON`() {
+        val intent = Intent().putExtra("credential", "{\"id\":\"abc\"}")
+
+        val result = parseFidoActivityResult(Activity.RESULT_OK, intent)
+
+        assertEquals("{\"id\":\"abc\"}", result.getOrNull())
+    }
+}

--- a/fido-android-ui/src/test/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoMessageBridgeTest.kt
+++ b/fido-android-ui/src/test/kotlin/com/yubico/yubikit/fido/android/ui/internal/FidoMessageBridgeTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.android.ui.internal
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/** Unit tests for the reject-response JSON contract shared with fido.js. */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class FidoMessageBridgeTest {
+
+    @Test
+    fun `error response carries the errorName when provided`() {
+        val json = JSONObject(
+            FidoMessageBridge.errorResponseJson(
+                promiseUuid = "uuid-1",
+                message = "This request isn't supported.",
+                errorName = "NotSupportedError",
+            ),
+        )
+
+        assertEquals("reject", json.getString("type"))
+        assertEquals("uuid-1", json.getString("promiseUuid"))
+        assertEquals("This request isn't supported.", json.getString("message"))
+        // fido.js reads data.errorName to pick the DOMException name.
+        assertEquals("NotSupportedError", json.getString("errorName"))
+    }
+
+    @Test
+    fun `error response omits errorName when absent`() {
+        val json = JSONObject(
+            FidoMessageBridge.errorResponseJson(
+                promiseUuid = "uuid-1",
+                message = "The operation failed",
+            ),
+        )
+
+        // No errorName -> fido.js defaults to NotAllowedError.
+        assertFalse(json.has("errorName"))
+    }
+}

--- a/fido-android-ui/src/test/kotlin/com/yubico/yubikit/fido/android/ui/screens/ResultScreenTest.kt
+++ b/fido-android-ui/src/test/kotlin/com/yubico/yubikit/fido/android/ui/screens/ResultScreenTest.kt
@@ -16,6 +16,7 @@
 
 package com.yubico.yubikit.fido.android.ui.screens
 
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -160,6 +161,47 @@ class ResultScreenTest {
         }
 
         composeTestRule.onNodeWithTag("error_message_text").assertExists()
+    }
+
+    @Test
+    fun `errorView shows request-not-supported message for ExtensionUnsupportedError`() {
+        composeTestRule.setContent {
+            FidoAndroidTheme {
+                ErrorView(
+                    operation = FidoClientService.Operation.GET_ASSERTION,
+                    rpId = testOrigin,
+                    error = Error.ExtensionUnsupportedError(
+                        "NotSupportedError",
+                        "largeBlob write requires exactly one allowed credential",
+                    ),
+                    onRetry = {},
+                )
+            }
+        }
+
+        // Renders the generic "request not supported" message, not the "Set a PIN" one, and does
+        // not blame the key.
+        composeTestRule
+            .onNodeWithTag("error_message_text")
+            .assertTextEquals("This request isn't supported.")
+    }
+
+    @Test
+    fun `errorView shows Close and not Retry for a terminal error`() {
+        composeTestRule.setContent {
+            FidoAndroidTheme {
+                ErrorView(
+                    operation = FidoClientService.Operation.GET_ASSERTION,
+                    rpId = testOrigin,
+                    error = Error.ExtensionUnsupportedError("NotSupportedError", "unsupported"),
+                    onCloseButtonClick = {},
+                    onRetry = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("close_button").assertExists()
+        composeTestRule.onNodeWithTag("retry_button").assertDoesNotExist()
     }
 
     @Test

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
@@ -28,6 +28,7 @@ import com.yubico.yubikit.fido.client.extensions.CredPropsExtension;
 import com.yubico.yubikit.fido.client.extensions.CredProtectExtension;
 import com.yubico.yubikit.fido.client.extensions.Extension;
 import com.yubico.yubikit.fido.client.extensions.ExtensionConfigurationException;
+import com.yubico.yubikit.fido.client.extensions.ExtensionNotSupportedException;
 import com.yubico.yubikit.fido.client.extensions.HmacSecretExtension;
 import com.yubico.yubikit.fido.client.extensions.LargeBlobExtension;
 import com.yubico.yubikit.fido.client.extensions.MinPinLengthExtension;
@@ -954,7 +955,10 @@ public class Ctap2Client implements WebAuthnClient {
    *       enforceCredentialProtectionPolicy}, {@code largeBlob} {@code support:"required"} on an
    *       unsupported authenticator, or {@code prf} {@code evalByCredential} during registration).
    *       Surfaced as a {@link ClientError} carrying the {@link ClientError.Code} the extension
-   *       chose (defaulting to {@link ClientError.Code#CONFIGURATION_UNSUPPORTED}).
+   *       chose (defaulting to {@link ClientError.Code#CONFIGURATION_UNSUPPORTED}) with the
+   *       exception itself as the {@code ClientError} cause. When the authenticator lacks a
+   *       required capability the exception is the subtype {@link ExtensionNotSupportedException},
+   *       which a caller can test for with {@code instanceof}.
    *   <li><b>{@link IllegalArgumentException} — abort as {@link ClientError.Code#BAD_REQUEST}.</b>
    *       Malformed caller input for a requested extension: a missing required member, a wrong type
    *       on a dictionary/{@code BufferSource} member, an invalid base64url value, or a
@@ -962,13 +966,16 @@ public class Ctap2Client implements WebAuthnClient {
    *       does not match an allowed credential). This is surfaced regardless of whether the
    *       authenticator supports the extension, since several extensions validate their input
    *       before checking support (e.g. {@code largeBlob}, {@code previewSign}). Distinct from the
-   *       {@code null} "not applicable" path.
+   *       {@code null} "not applicable" path. Wrapped into an {@link
+   *       ExtensionConfigurationException} (original exception preserved as its cause) so the
+   *       {@code ClientError} cause is always an {@code ExtensionConfigurationException} for any
+   *       extension failure.
    *   <li><b>Anything else — rethrow.</b> Any other unchecked exception (e.g. {@link
    *       NullPointerException}, {@link ClassCastException}, {@link IllegalStateException}) is
    *       treated as a genuine defect and propagated unchanged rather than silently swallowed.
    * </ul>
    */
-  private void handleExtensionFailure(RuntimeException e) throws ClientError {
+  private static void handleExtensionFailure(RuntimeException e) throws ClientError {
     if (e instanceof ExtensionConfigurationException) {
       ExtensionConfigurationException configError = (ExtensionConfigurationException) e;
       String message =
@@ -981,8 +988,16 @@ public class Ctap2Client implements WebAuthnClient {
       // validate input before checking support. Surfaced as BAD_REQUEST rather than silently
       // dropped, which would mask a relying-party bug. Genuine programming defects (other unchecked
       // exceptions) are not masked: they fall through to the final rethrow.
+      //
+      // Wrapped into an ExtensionConfigurationException carrier so the ClientError cause is always
+      // an ExtensionConfigurationException for any extension failure (hard-config or malformed
+      // input): a caller can test for "an extension request failed" with a single instanceof rather
+      // than guessing from the shared BAD_REQUEST code. The original IllegalArgumentException is
+      // preserved as the carrier's cause.
       String message = e.getMessage() != null ? e.getMessage() : e.toString();
-      throw new ClientError(ClientError.Code.BAD_REQUEST, message, e);
+      ExtensionConfigurationException carrier =
+          new ExtensionConfigurationException(ClientError.Code.BAD_REQUEST, message, e);
+      throw new ClientError(ClientError.Code.BAD_REQUEST, message, carrier);
     }
     throw e;
   }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/Ctap2Client.java
@@ -1002,6 +1002,65 @@ public class Ctap2Client implements WebAuthnClient {
     throw e;
   }
 
+  /**
+   * Validate the device-independent client extension inputs of a registration request, without a
+   * key.
+   *
+   * <p>Runs each extension's {@link Extension#validateCreateInputs} and surfaces any failure as the
+   * same {@link ClientError} {@link #makeCredential} would throw for it. This lets a caller reject
+   * a request that can never succeed <em>before</em> connecting to (or prompting for) an
+   * authenticator — matching a browser's synchronous {@code NotSupportedError}/{@code SyntaxError}.
+   *
+   * <p>This is an optional fast-path: the same checks run inside {@link #makeCredential}, so a
+   * caller that skips this still gets identical errors, just later. It only covers request-shape
+   * checks; capability checks that need the authenticator's {@code info} (e.g. {@code largeBlob}
+   * {@code support:"required"}, {@code credProtect} enforce) are not performed here.
+   *
+   * <p>Coverage is per-extension: only extensions that override {@link
+   * Extension#validateCreateInputs}/{@link Extension#validateGetInputs} participate (currently
+   * {@code largeBlob}). An extension whose hard-failures are only raised once the authenticator's
+   * support is known (e.g. {@code prf}/{@code hmac-secret}, whose {@code evalByCredential} checks
+   * sit behind a support gate in {@link #makeCredential}/{@link #getAssertion}) is intentionally
+   * <em>not</em> pre-validated here — doing so would reject a request the device path would accept
+   * by ignoring the extension. Such requests still surface their error on the device path.
+   *
+   * @param options the registration request to validate
+   * @param extensions the extensions to check, or {@code null} for the default set
+   * @throws ClientError if a requested extension input cannot be satisfied
+   */
+  public static void validateExtensionInputs(
+      PublicKeyCredentialCreationOptions options, @Nullable List<Extension> extensions)
+      throws ClientError {
+    for (Extension extension : extensions != null ? extensions : defaultExtensions) {
+      try {
+        extension.validateCreateInputs(options);
+      } catch (RuntimeException e) {
+        handleExtensionFailure(e);
+      }
+    }
+  }
+
+  /**
+   * Validate the device-independent client extension inputs of an authentication request, without a
+   * key. The authentication counterpart of {@link #validateExtensionInputs(
+   * PublicKeyCredentialCreationOptions, List)}; see it for semantics.
+   *
+   * @param options the authentication request to validate
+   * @param extensions the extensions to check, or {@code null} for the default set
+   * @throws ClientError if a requested extension input cannot be satisfied
+   */
+  public static void validateExtensionInputs(
+      PublicKeyCredentialRequestOptions options, @Nullable List<Extension> extensions)
+      throws ClientError {
+    for (Extension extension : extensions != null ? extensions : defaultExtensions) {
+      try {
+        extension.validateGetInputs(options);
+      } catch (RuntimeException e) {
+        handleExtensionFailure(e);
+      }
+    }
+  }
+
   private int getSafePinRetryCount() {
     try {
       return clientPin.getPinRetries().getCount();

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredBlobExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredBlobExtension.java
@@ -55,14 +55,11 @@ public class CredBlobExtension extends Extension {
       return null;
     }
 
-    Object value = extensions.get("credBlob");
+    String value = asString(extensions.get("credBlob"), "credBlob");
     if (value == null) {
       return null; // not requested
     }
-    if (!(value instanceof String)) {
-      throw new IllegalArgumentException("credBlob must be a string");
-    }
-    byte[] blob = fromUrlSafeString((String) value);
+    byte[] blob = fromUrlSafeString(value);
     // Per spec, the platform passes credBlob to the authenticator only when it fits within
     // maxCredBlobLength; otherwise it is ignored.
     if (blob.length <= ctap.getCachedInfo().getMaxCredBlobLength()) {
@@ -83,10 +80,7 @@ public class CredBlobExtension extends Extension {
     if (extensions == null) {
       return null;
     }
-    Object getCredBlob = extensions.get("getCredBlob");
-    if (getCredBlob != null && !(getCredBlob instanceof Boolean)) {
-      throw new IllegalArgumentException("getCredBlob must be a boolean");
-    }
+    Boolean getCredBlob = asBoolean(extensions.get("getCredBlob"), "getCredBlob");
     if (isSupported(ctap) && Boolean.TRUE.equals(getCredBlob)) {
       return new AuthenticationProcessor(
           (AuthenticationInput) (selected, pinToken) -> Collections.singletonMap(name, true));

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredPropsExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredPropsExtension.java
@@ -50,15 +50,8 @@ public class CredPropsExtension extends Extension {
       return null;
     }
 
-    Object value = extensions.get(name);
-    if (value == null) {
-      return null; // not requested
-    }
-    if (!(value instanceof Boolean)) {
-      throw new IllegalArgumentException("credProps must be a boolean");
-    }
-    if (!(Boolean) value) {
-      return null; // false = not requested
+    if (!Boolean.TRUE.equals(asBoolean(extensions.get(name), "credProps"))) {
+      return null; // not requested, or explicitly false
     }
 
     AuthenticatorSelectionCriteria authenticatorSelection = options.getAuthenticatorSelection();

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtension.java
@@ -65,11 +65,7 @@ public class CredProtectExtension extends Extension {
           "credentialProtectionPolicy must be a recognized policy value");
     }
 
-    Object enforceValue = extensions.get(ENFORCE);
-    if (enforceValue != null && !(enforceValue instanceof Boolean)) {
-      throw new IllegalArgumentException("enforceCredentialProtectionPolicy must be a boolean");
-    }
-    boolean enforce = Boolean.TRUE.equals(enforceValue);
+    boolean enforce = Boolean.TRUE.equals(asBoolean(extensions.get(ENFORCE), ENFORCE));
     if (enforce && !isSupported(ctap) && credProtect > 0x01) {
       throw new ExtensionConfigurationException("No Credential Protection support");
     }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/CredProtectExtension.java
@@ -67,7 +67,7 @@ public class CredProtectExtension extends Extension {
 
     boolean enforce = Boolean.TRUE.equals(asBoolean(extensions.get(ENFORCE), ENFORCE));
     if (enforce && !isSupported(ctap) && credProtect > 0x01) {
-      throw new ExtensionConfigurationException("No Credential Protection support");
+      throw new ExtensionNotSupportedException("No Credential Protection support");
     }
     return new RegistrationProcessor(pinToken -> Collections.singletonMap(name, credProtect));
   }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/Extension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/Extension.java
@@ -55,6 +55,56 @@ public abstract class Extension {
     return ctap.getCachedInfo().getExtensions().contains(name);
   }
 
+  /**
+   * Returns {@code value} as a {@code Boolean}, or {@code null} if the member is absent. A
+   * wrong-typed value is malformed caller input, surfaced as an {@link IllegalArgumentException}
+   * (spec {@code SyntaxError} / {@code BAD_REQUEST}); {@code field} names the offending member in
+   * the message.
+   */
+  @Nullable
+  protected static Boolean asBoolean(@Nullable Object value, String field) {
+    if (value == null) {
+      return null;
+    }
+    if (!(value instanceof Boolean)) {
+      throw new IllegalArgumentException(field + " must be a boolean");
+    }
+    return (Boolean) value;
+  }
+
+  /**
+   * Returns {@code value} as a {@code String}, or {@code null} if the member is absent. A
+   * wrong-typed value is surfaced as an {@link IllegalArgumentException}; see {@link
+   * #asBoolean(Object, String)}.
+   */
+  @Nullable
+  protected static String asString(@Nullable Object value, String field) {
+    if (value == null) {
+      return null;
+    }
+    if (!(value instanceof String)) {
+      throw new IllegalArgumentException(field + " must be a string");
+    }
+    return (String) value;
+  }
+
+  /**
+   * Returns {@code value} as a {@code Map}, or {@code null} if the member is absent. A wrong-typed
+   * value is surfaced as an {@link IllegalArgumentException}; see {@link #asBoolean(Object,
+   * String)}.
+   */
+  @SuppressWarnings("unchecked")
+  @Nullable
+  protected static Map<String, Object> asMap(@Nullable Object value, String field) {
+    if (value == null) {
+      return null;
+    }
+    if (!(value instanceof Map)) {
+      throw new IllegalArgumentException(field + " must be an object");
+    }
+    return (Map<String, Object>) value;
+  }
+
   @Nullable
   public RegistrationProcessor makeCredential(
       Ctap2Session ctap,

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/Extension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/Extension.java
@@ -56,6 +56,31 @@ public abstract class Extension {
   }
 
   /**
+   * Device-independent validation of this extension's client inputs for a registration request — a
+   * pure function of {@code options}, with no authenticator interaction. Mirrors a browser's
+   * synchronous WebAuthn client-extension checks: it throws the same {@link
+   * ExtensionConfigurationException} / {@link IllegalArgumentException} that {@link
+   * #makeCredential} would for a request that can never succeed, letting a client fail fast before
+   * connecting to (or prompting for) a key.
+   *
+   * <p>Only checks that depend solely on the request belong here; capability checks that need the
+   * authenticator's {@code info} (e.g. {@code largeBlob} {@code support:"required"}, {@code
+   * credProtect} enforce) are <em>not</em> performed here and remain in {@link #makeCredential}. An
+   * implementation that overrides this should invoke it at the start of its own {@link
+   * #makeCredential} so pre-validation and the device path apply the same request-shape checks
+   * rather than diverging. Default: no-op.
+   */
+  public void validateCreateInputs(PublicKeyCredentialCreationOptions options) {}
+
+  /**
+   * Device-independent validation of this extension's client inputs for an authentication request.
+   * The authentication counterpart of {@link #validateCreateInputs}; an implementation that
+   * overrides this should invoke it at the start of its own {@link #getAssertion} so pre-validation
+   * and the device path stay in sync. Default: no-op.
+   */
+  public void validateGetInputs(PublicKeyCredentialRequestOptions options) {}
+
+  /**
    * Returns {@code value} as a {@code Boolean}, or {@code null} if the member is absent. A
    * wrong-typed value is malformed caller input, surfaced as an {@link IllegalArgumentException}
    * (spec {@code SyntaxError} / {@code BAD_REQUEST}); {@code field} names the offending member in

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ExtensionConfigurationException.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ExtensionConfigurationException.java
@@ -19,18 +19,27 @@ package com.yubico.yubikit.fido.client.extensions;
 import com.yubico.yubikit.fido.client.ClientError;
 
 /**
- * Thrown by an {@link Extension} when the relying party has explicitly requested a capability that
- * cannot be satisfied (for example {@code enforceCredentialProtectionPolicy} or {@code largeBlob}
- * {@code support: "required"} on an authenticator that does not support it).
+ * Thrown by an {@link Extension} when a relying-party extension request cannot be processed and the
+ * WebAuthn ceremony must be aborted — for example an unsatisfiable request shape ({@code largeBlob}
+ * {@code write} with more than one allowed credential) or malformed extension input.
  *
  * <p>Unlike conditions that merely cause an extension to be ignored — which are signalled by
- * returning {@code null} from the extension's processing methods — this is a <em>hard failure</em>
- * that must abort the WebAuthn ceremony. The client catches it and surfaces it as a {@link
- * ClientError} with the carried {@link ClientError.Code}.
+ * returning {@code null} from the extension's processing methods — this is a <em>hard failure</em>.
+ * The client catches it and surfaces it as a {@link ClientError} carrying {@link #getCode()}, with
+ * this exception preserved as the {@code ClientError} cause.
+ *
+ * <p>This is the common supertype for every extension hard failure, so a caller can test for "an
+ * extension request failed" with a single {@code instanceof} check. The one case that needs to be
+ * distinguished — the authenticator lacking a capability the relying party explicitly required — is
+ * the subtype {@link ExtensionNotSupportedException}; everything else (request-shape and malformed
+ * input, told apart by {@link #getCode()}: {@link ClientError.Code#CONFIGURATION_UNSUPPORTED} ≙
+ * {@code NotSupportedError}, {@link ClientError.Code#BAD_REQUEST} ≙ {@code SyntaxError}) carries
+ * its human-readable detail in the message.
  *
  * <p>It is unchecked so it can be raised from the extension processing lambdas (whose functional
  * interfaces do not declare checked exceptions) without changing the {@link Extension} API.
  *
+ * @see ExtensionNotSupportedException
  * @see <a href="https://www.w3.org/TR/webauthn-3/#sctn-extensions">WebAuthn Extensions</a>
  */
 public class ExtensionConfigurationException extends RuntimeException {
@@ -47,8 +56,24 @@ public class ExtensionConfigurationException extends RuntimeException {
     this.code = code;
   }
 
+  public ExtensionConfigurationException(ClientError.Code code, String message, Throwable cause) {
+    super(message, cause);
+    this.code = code;
+  }
+
   /** The {@link ClientError.Code} the client should report when aborting the ceremony. */
   public ClientError.Code getCode() {
     return code;
+  }
+
+  /**
+   * The WebAuthn {@code DOMException} name a client should reject the ceremony with for this
+   * failure: {@code "SyntaxError"} for {@link ClientError.Code#BAD_REQUEST} (malformed input),
+   * {@code "NotSupportedError"} otherwise (an unsatisfiable/unsupported request). Kept here, next
+   * to {@link #getCode()}, so the {@code Code}-to-spec-name mapping lives in one place rather than
+   * being re-derived by each caller.
+   */
+  public String getWebAuthnErrorName() {
+    return code == ClientError.Code.BAD_REQUEST ? "SyntaxError" : "NotSupportedError";
   }
 }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ExtensionNotSupportedException.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ExtensionNotSupportedException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import com.yubico.yubikit.fido.client.ClientError;
+
+/**
+ * Raised when the relying party explicitly <em>required</em> an extension capability that this
+ * authenticator does not support, so the ceremony must abort — currently {@code credProtect} with
+ * {@code enforceCredentialProtectionPolicy}, and {@code largeBlob} {@code support: "required"} on a
+ * key without large-blob storage.
+ *
+ * <p>This is the one extension hard failure that means "this authenticator is ineligible for the
+ * request" rather than "the request itself is malformed/unsatisfiable". It is a distinct type (not
+ * a flag on {@link ExtensionConfigurationException}) so a caller can react to it — e.g. tell the
+ * user their security key can't be used for this site — with a plain {@code instanceof} check,
+ * without inspecting messages. All other extension failures are the base {@link
+ * ExtensionConfigurationException}; a caller that does not care about the distinction can catch the
+ * supertype and treat every extension failure uniformly.
+ *
+ * <p>Note this is a WebAuthn {@code NotSupportedError} (hence {@link
+ * ClientError.Code#CONFIGURATION_UNSUPPORTED}); the "ineligible" framing is a client/UI concern,
+ * not a change to the spec error class.
+ *
+ * @see ExtensionConfigurationException
+ */
+public class ExtensionNotSupportedException extends ExtensionConfigurationException {
+  private static final long serialVersionUID = 1L;
+
+  public ExtensionNotSupportedException(String message) {
+    super(ClientError.Code.CONFIGURATION_UNSUPPORTED, message);
+  }
+}

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtension.java
@@ -109,11 +109,7 @@ public class HmacSecretExtension extends Extension {
     boolean prf = extensions.has(PRF);
     boolean hmac = false;
     if (allowHmacSecret) {
-      Object hmacCreateSecret = extensions.get(HMAC_CREATE_SECRET);
-      if (hmacCreateSecret != null && !(hmacCreateSecret instanceof Boolean)) {
-        throw new IllegalArgumentException("hmacCreateSecret must be a boolean");
-      }
-      hmac = Boolean.TRUE.equals(hmacCreateSecret);
+      hmac = Boolean.TRUE.equals(asBoolean(extensions.get(HMAC_CREATE_SECRET), HMAC_CREATE_SECRET));
     }
 
     if (!prf && !hmac) {
@@ -471,39 +467,6 @@ public class HmacSecretExtension extends Extension {
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException("SHA-256 missing", e);
     }
-  }
-
-  /**
-   * Returns {@code value} as a {@code Map} (a dictionary extension member). Absent values are
-   * ignored ({@code null}); a wrong-typed value is malformed structure and is surfaced as an {@link
-   * IllegalArgumentException} (mapped to {@code BAD_REQUEST}).
-   */
-  @SuppressWarnings("unchecked")
-  @Nullable
-  private static Map<String, Object> asMap(@Nullable Object value, String field) {
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof Map)) {
-      throw new IllegalArgumentException(field + " must be an object");
-    }
-    return (Map<String, Object>) value;
-  }
-
-  /**
-   * Returns {@code value} as a {@code String} (a base64url BufferSource member). Absent values are
-   * ignored ({@code null}); a wrong-typed value is malformed structure and is surfaced as an {@link
-   * IllegalArgumentException} (mapped to {@code BAD_REQUEST}).
-   */
-  @Nullable
-  private static String asString(@Nullable Object value, String field) {
-    if (value == null) {
-      return null;
-    }
-    if (!(value instanceof String)) {
-      throw new IllegalArgumentException(field + " must be a string");
-    }
-    return (String) value;
   }
 
   private static class PrfInputs {

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
@@ -232,28 +232,19 @@ public class LargeBlobExtension extends Extension {
         return null;
       }
 
-      Object data = extensions.get(LARGE_BLOB);
-      if (data == null) {
+      Map<String, Object> map = asMap(extensions.get(LARGE_BLOB), LARGE_BLOB);
+      if (map == null) {
         return null; // not requested
       }
-      if (!(data instanceof Map)) {
-        throw new IllegalArgumentException("largeBlob must be an object");
-      }
-      Map<?, ?> map = (Map<?, ?>) data;
-      Object read = map.get(ACTION_READ);
-      Object write = map.get(ACTION_WRITE);
-      Object support = map.get(SUPPORT);
-      if (read != null && !(read instanceof Boolean)) {
-        throw new IllegalArgumentException("largeBlob.read must be a boolean");
-      }
-      if (write != null && !(write instanceof String)) {
-        throw new IllegalArgumentException("largeBlob.write must be a string");
-      }
+      String support = asString(map.get(SUPPORT), "largeBlob.support");
       if (support != null && !REQUIRED.equals(support) && !PREFERRED.equals(support)) {
         throw new IllegalArgumentException(
             "largeBlob.support must be \"required\" or \"preferred\"");
       }
-      return new Inputs((Boolean) read, (String) write, (String) support);
+      return new Inputs(
+          asBoolean(map.get(ACTION_READ), "largeBlob.read"),
+          asString(map.get(ACTION_WRITE), "largeBlob.write"),
+          support);
     }
   }
 }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/LargeBlobExtension.java
@@ -26,11 +26,13 @@ import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol;
 import com.yubico.yubikit.fido.webauthn.ClientExtensionResultProvider;
 import com.yubico.yubikit.fido.webauthn.Extensions;
 import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialCreationOptions;
+import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialDescriptor;
 import com.yubico.yubikit.fido.webauthn.PublicKeyCredentialRequestOptions;
 import com.yubico.yubikit.fido.webauthn.SerializationType;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -69,6 +71,48 @@ public class LargeBlobExtension extends Extension {
         && Boolean.TRUE.equals(ctap.getCachedInfo().getOptions().get(LARGE_BLOBS));
   }
 
+  @Override
+  public void validateCreateInputs(PublicKeyCredentialCreationOptions options) {
+    validateCreateInputs(Inputs.fromExtensions(options.getExtensions()));
+  }
+
+  private void validateCreateInputs(@Nullable Inputs inputs) {
+    // WebAuthn largeBlob client processing (registration): read/write are authentication-only;
+    // their presence here is a NotSupportedError. Device-independent; support:"required" needs the
+    // authenticator's info and is checked in makeCredential.
+    if (inputs != null && (inputs.read != null || inputs.write != null)) {
+      throw new ExtensionConfigurationException(
+          "largeBlob read/write is not valid during registration");
+    }
+  }
+
+  @Override
+  public void validateGetInputs(PublicKeyCredentialRequestOptions options) {
+    validateGetInputs(
+        Inputs.fromExtensions(options.getExtensions()), options.getAllowCredentials());
+  }
+
+  private void validateGetInputs(
+      @Nullable Inputs inputs, List<PublicKeyCredentialDescriptor> allowCredentials) {
+    // WebAuthn largeBlob client processing (authentication). Each condition is a NotSupportedError
+    // in the spec and depends only on the request (no authenticator info needed).
+    if (inputs == null) {
+      return;
+    }
+    if (inputs.support != null) {
+      throw new ExtensionConfigurationException(
+          "largeBlob support is not valid during authentication");
+    }
+    if (inputs.read != null && inputs.write != null) {
+      throw new ExtensionConfigurationException(
+          "largeBlob read and write must not both be present");
+    }
+    if (inputs.write != null && allowCredentials.size() != 1) {
+      throw new ExtensionConfigurationException(
+          "largeBlob write requires exactly one allowed credential");
+    }
+  }
+
   @Nullable
   @Override
   public RegistrationProcessor makeCredential(
@@ -76,15 +120,10 @@ public class LargeBlobExtension extends Extension {
       PublicKeyCredentialCreationOptions options,
       PinUvAuthProtocol pinUvAuthProtocol) {
     final Inputs inputs = Inputs.fromExtensions(options.getExtensions());
+    validateCreateInputs(inputs);
     if (inputs != null) {
-      // WebAuthn largeBlob client processing (registration): read/write are authentication-only;
-      // their presence here is a NotSupportedError.
-      if (inputs.read != null || inputs.write != null) {
-        throw new ExtensionConfigurationException(
-            "largeBlob read/write is not valid during registration");
-      }
       if (REQUIRED.equals(inputs.support) && !isSupported(ctap)) {
-        throw new ExtensionConfigurationException(
+        throw new ExtensionNotSupportedException(
             "Authenticator does not support large blob storage");
       }
       return new RegistrationProcessor(
@@ -107,28 +146,16 @@ public class LargeBlobExtension extends Extension {
       PinUvAuthProtocol pinUvAuthProtocol) {
 
     final Inputs inputs = Inputs.fromExtensions(options.getExtensions());
+    validateGetInputs(inputs, options.getAllowCredentials());
     if (inputs == null) {
       return null;
     }
-    // WebAuthn largeBlob client processing (authentication). Each condition below is a
-    // NotSupportedError in the spec.
-    if (inputs.support != null) {
-      throw new ExtensionConfigurationException(
-          "largeBlob support is not valid during authentication");
-    }
-    if (inputs.read != null && inputs.write != null) {
-      throw new ExtensionConfigurationException(
-          "largeBlob read and write must not both be present");
-    }
+    // Request shape already validated by validateGetInputs (support / read+write / write-count).
     if (Boolean.TRUE.equals(inputs.read)) {
       return new AuthenticationProcessor(
           (selected, pinToken) -> Collections.singletonMap(LARGE_BLOB_KEY, true),
           (assertionData, pinToken) -> read(assertionData, ctap));
     } else if (inputs.write != null) {
-      if (options.getAllowCredentials().size() != 1) {
-        throw new ExtensionConfigurationException(
-            "largeBlob write requires exactly one allowed credential");
-      }
       return new AuthenticationProcessor(
           (selected, pinToken) -> Collections.singletonMap(LARGE_BLOB_KEY, true),
           (assertionData, pinToken) ->

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/MinPinLengthExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/MinPinLengthExtension.java
@@ -58,15 +58,8 @@ public class MinPinLengthExtension extends Extension {
       return null;
     }
 
-    Object input = extensions.get(name);
-    if (input == null) {
-      return null;
-    }
-    if (!(input instanceof Boolean)) {
-      throw new IllegalArgumentException("minPinLength must be a boolean");
-    }
-    if (!(Boolean) input) {
-      return null;
+    if (!Boolean.TRUE.equals(asBoolean(extensions.get(name), "minPinLength"))) {
+      return null; // not requested, or explicitly false
     }
     return new RegistrationProcessor(pinToken -> Collections.singletonMap(name, true));
   }

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/SignExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/SignExtension.java
@@ -307,21 +307,17 @@ public class SignExtension extends Extension {
    * types, missing required keys, or invalid base64url) so the client reports it as a bad request
    * rather than silently dropping it.
    */
-  @SuppressWarnings("unchecked")
   @Nullable
   private static AuthenticationExtensionsSign parseSignInput(@Nullable Extensions extensions) {
     if (extensions == null) {
       return null;
     }
-    Object signInput = extensions.get(SIGN);
+    Map<String, Object> signInput = asMap(extensions.get(SIGN), "previewSign");
     if (signInput == null) {
       return null; // not requested
     }
-    if (!(signInput instanceof Map)) {
-      throw new IllegalArgumentException("previewSign must be an object");
-    }
     try {
-      return AuthenticationExtensionsSign.fromMap((Map<String, ?>) signInput);
+      return AuthenticationExtensionsSign.fromMap(signInput);
     } catch (RuntimeException e) {
       // fromMap uses unchecked casts / requireNonNull; surface any malformed structure as bad
       // input.

--- a/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtension.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/client/extensions/ThirdPartyPaymentExtension.java
@@ -99,22 +99,12 @@ public class ThirdPartyPaymentExtension extends Extension {
       return null;
     }
 
-    Object paymentValue = extensions.get(PAYMENT);
-    if (paymentValue == null) {
+    Map<String, Object> payment = asMap(extensions.get(PAYMENT), "payment");
+    if (payment == null) {
       return null;
-    }
-    if (!(paymentValue instanceof Map)) {
-      throw new IllegalArgumentException("payment must be an object");
     }
     // CTAP leaves the client input platform-defined; this SDK uses payment.isPayment as the flag.
-    Object isPayment = ((Map<?, ?>) paymentValue).get(IS_PAYMENT);
-    if (isPayment == null) {
-      return null;
-    }
-    if (!(isPayment instanceof Boolean)) {
-      throw new IllegalArgumentException("payment.isPayment must be a boolean");
-    }
-    if (!(Boolean) isPayment) {
+    if (!Boolean.TRUE.equals(asBoolean(payment.get(IS_PAYMENT), "payment.isPayment"))) {
       return null;
     }
     return Boolean.TRUE;

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionHardFailTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionHardFailTest.java
@@ -85,9 +85,10 @@ public class ExtensionHardFailTest {
     Map<String, Object> ext = new HashMap<>();
     ext.put(LargeBlobExtension.LARGE_BLOB, largeBlob);
 
-    ExtensionConfigurationException error =
+    // Capability the RP required is missing -> the ineligible subtype.
+    ExtensionNotSupportedException error =
         assertThrows(
-            ExtensionConfigurationException.class,
+            ExtensionNotSupportedException.class,
             () ->
                 new LargeBlobExtension()
                     .makeCredential(

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionHardFailTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/ExtensionHardFailTest.java
@@ -17,6 +17,7 @@
 package com.yubico.yubikit.fido.client.extensions;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -66,9 +67,10 @@ public class ExtensionHardFailTest {
     ext.put(CredProtectExtension.POLICY, CredProtectExtension.REQUIRED);
     ext.put(CredProtectExtension.ENFORCE, true);
 
-    ExtensionConfigurationException error =
+    // Capability the RP required is missing -> the ineligible subtype.
+    ExtensionNotSupportedException error =
         assertThrows(
-            ExtensionConfigurationException.class,
+            ExtensionNotSupportedException.class,
             () ->
                 new CredProtectExtension()
                     .makeCredential(
@@ -110,5 +112,7 @@ public class ExtensionHardFailTest {
                     .makeCredential(
                         sessionWithout(), optionsWith(ext), mock(PinUvAuthProtocol.class)));
     assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, error.getCode());
+    // A malformed request shape is the base type, not the ineligible subtype.
+    assertFalse(error instanceof ExtensionNotSupportedException);
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtensionTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/HmacSecretExtensionTest.java
@@ -125,6 +125,21 @@ public class HmacSecretExtensionTest {
   }
 
   @Test
+  public void prepareSaltsEvalByCredentialWithoutAllowListThrows() {
+    // WebAuthn prf (authentication): evalByCredential with an empty allowCredentials ->
+    // NotSupportedError, carrying PRF_EVAL_BY_CREDENTIAL_REQUIRES_ALLOWLIST.
+    Map<String, Object> prf =
+        Collections.singletonMap(
+            "evalByCredential",
+            Collections.singletonMap("AA", Collections.singletonMap("first", "AA")));
+    ExtensionConfigurationException e =
+        assertThrows(
+            ExtensionConfigurationException.class,
+            () -> extension.prepareSalts(null, null, prfInputs(prf)));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getCode());
+  }
+
+  @Test
   public void prepareSaltsIgnoresNullSecond() {
     // Regression: an RP sending prf.eval with "second": null (key present, null value) must not
     // crash the ceremony (previously an NPE from Base64.fromUrlSafeString(null)); the null second
@@ -174,6 +189,12 @@ public class HmacSecretExtensionTest {
   private static HmacSecretExtension.Inputs prfEval(Map<String, Object> eval) {
     Extensions extensions =
         Extensions.fromMap(Collections.singletonMap("prf", Collections.singletonMap("eval", eval)));
+    return Objects.requireNonNull(HmacSecretExtension.Inputs.fromExtensions(extensions));
+  }
+
+  /** Builds parsed extension {@link HmacSecretExtension.Inputs} for {@code prf: <prf>}. */
+  private static HmacSecretExtension.Inputs prfInputs(Map<String, Object> prf) {
+    Extensions extensions = Extensions.fromMap(Collections.singletonMap("prf", prf));
     return Objects.requireNonNull(HmacSecretExtension.Inputs.fromExtensions(extensions));
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/PrevalidationTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/client/extensions/PrevalidationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido.client.extensions;
+
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.creation;
+import static com.yubico.yubikit.fido.client.extensions.ExtensionTestHelper.request;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.yubico.yubikit.fido.client.ClientError;
+import com.yubico.yubikit.fido.client.Ctap2Client;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Device-free pre-validation via {@link Ctap2Client#validateExtensionInputs}: request-shape
+ * extension errors are raised from the request alone, with no {@link
+ * com.yubico.yubikit.fido.ctap.Ctap2Session}, so a client can fail a doomed request before
+ * connecting to a key. These are the same errors {@code makeCredential}/{@code getAssertion} raise
+ * (see {@link LargeBlobExtensionTest} / {@link ExtensionHardFailTest}); here we assert they surface
+ * from the default extension set without an authenticator.
+ */
+public class PrevalidationTest {
+
+  private static final String LARGE_BLOB = "largeBlob";
+
+  private static Map<String, ?> largeBlob(String key, Object value) {
+    return Collections.singletonMap(LARGE_BLOB, Collections.singletonMap(key, value));
+  }
+
+  @Test
+  public void writeWithoutExactlyOneCredentialIsRejected() throws Exception {
+    // largeBlob write with an empty allow list (size != 1) -> NotSupportedError, no device needed.
+    ClientError e =
+        assertThrows(
+            ClientError.class,
+            () -> Ctap2Client.validateExtensionInputs(request(largeBlob("write", "AQ")), null));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getErrorCode());
+    assertTrue(e.getCause() instanceof ExtensionConfigurationException);
+  }
+
+  @Test
+  public void supportDuringAuthenticationIsRejected() {
+    ClientError e =
+        assertThrows(
+            ClientError.class,
+            () ->
+                Ctap2Client.validateExtensionInputs(
+                    request(largeBlob("support", "preferred")), null));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getErrorCode());
+    assertTrue(e.getCause() instanceof ExtensionConfigurationException);
+  }
+
+  @Test
+  public void readAndWriteTogetherIsRejected() {
+    Map<String, Object> both = new HashMap<>();
+    both.put("read", true);
+    both.put("write", "AQ");
+    ClientError e =
+        assertThrows(
+            ClientError.class,
+            () ->
+                Ctap2Client.validateExtensionInputs(
+                    request(Collections.singletonMap(LARGE_BLOB, both)), null));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getErrorCode());
+    assertTrue(e.getCause() instanceof ExtensionConfigurationException);
+  }
+
+  @Test
+  public void readWriteDuringRegistrationIsRejected() {
+    ClientError e =
+        assertThrows(
+            ClientError.class,
+            () -> Ctap2Client.validateExtensionInputs(creation(largeBlob("read", true)), null));
+    assertEquals(ClientError.Code.CONFIGURATION_UNSUPPORTED, e.getErrorCode());
+    assertTrue(e.getCause() instanceof ExtensionConfigurationException);
+  }
+
+  @Test
+  public void validRequestPasses() throws Exception {
+    // read is a valid authentication request; an empty request has nothing to validate.
+    Ctap2Client.validateExtensionInputs(request(largeBlob("read", true)), null);
+    Ctap2Client.validateExtensionInputs(request(Collections.emptyMap()), null);
+    Ctap2Client.validateExtensionInputs(creation(Collections.emptyMap()), null);
+  }
+}


### PR DESCRIPTION
## Summary

Aligns FIDO client extension error handling with the WebAuthn spec: every extension hard-failure now surfaces as a typed exception carrying its spec `DOMException` name, requests can be pre-validated without a key, and the Android UI returns the real terminal error to the caller instead of a generic cancellation.

## Changes

- **Shared input coercion** — add `asBoolean`/`asString`/`asMap` helpers on `Extension` and adopt them across all extensions, dropping the duplicated per-extension coercion.
- **Typed hard failures** — add `ExtensionNotSupportedException` for a   capability the RP required but the authenticator lacks; carrier-wrap malformed input so the `ClientError` cause is always an `ExtensionConfigurationException`; add `getWebAuthnErrorName()` mapping each failure to `SyntaxError` / `NotSupportedError`.
- **Device-free pre-validation** — add Extension.validateCreateInputs`/
    `validateGetInputs` hooks and `Ctap2Client.validateExtensionInputs` so a caller can reject a doomed request before connecting to a key.
- **Terminal errors in the UI** — add `WebAuthnClientException` and   `Error.Terminal`; map extension-cause `ClientError`s to a dedicated unsupported-request error (or device-ineligible for a missing capability); a terminal error shows a single Close and rejects the page's promise with a `DOMException` of the correct name, forwarded through the activity result and JS bridge.

## Testing

- `./gradlew :fido:test :fido-android-ui:test` — all green, including new coverage for the terminal error path (`FidoClientImplTest`, `FidoMessageBridgeTest`) and extension mapping/pre-validation.
- Verified on-device: an unsupported `largeBlob` write rejects the page promise with `DOMException("NotSupportedError")` and offers a single Close.
- `FidoTests` pass