### PR TITLE
fix(fido): make InfoData.getFirmwareVersion public

### DIFF
--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/Ctap2Session.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/Ctap2Session.java
@@ -971,7 +971,8 @@ public class Ctap2Session extends Ctap1Session {
      *
      * @return the firmware version
      */
-    @Nullable Integer getFirmwareVersion() {
+    @Nullable
+    public Integer getFirmwareVersion() {
       return firmwareVersion;
     }
 


### PR DESCRIPTION
## Summary

`Ctap2Session.InfoData.getFirmwareVersion()` was accidentally
package-private while every sibling accessor in `InfoData` is `public`.
This made the firmware version returned by the `authenticatorGetInfo`
command unreadable to SDK consumers. This adds the missing `public`
modifier so it matches the rest of the `getInfo` result API.

Widening visibility is source- and binary-compatible, so no existing
callers break.

## API visibility audit

A colleague flagged this getter. I swept all seven main-source modules
(`fido`, `core`, `oath`, `piv`, `openpgp`, `management`, `yubiotp`) for
the same class of bug — accessors missing `public` while their siblings
are public, with special attention to the `@Nullable`-getter-without-
`public` pattern that hid this one. No other accidental cases were
found; the remaining package-private accessors are intentionally
internal.

## Testing

- `./gradlew :fido:spotlessCheck` — clean
- `./gradlew :fido:test` — passed
- Android CI — green