### PR TITLE
fix(fido): decode COSE EC2 coordinates unsigned

### DIFF
--- a/fido/src/main/java/com/yubico/yubikit/fido/Cose.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/Cose.java
@@ -121,7 +121,11 @@ public class Cose {
         throw new IllegalArgumentException("Unknown COSE EC2 curve: " + crv);
     }
 
-    return new Ec(ellipticCurveValues, new BigInteger(x), new BigInteger(y)).toPublicKey();
+    // COSE EC2 coordinates are fixed-width unsigned big-endian integers (RFC 9053 7.1.1), so they
+    // must be read with the unsigned BigInteger constructor. The signed one makes any coordinate
+    // with the high bit set negative, and when the leading 0xFF is redundant the minimal two's
+    // complement form loses a byte, which the re-encoder then left-pads with 0x00.
+    return new Ec(ellipticCurveValues, new BigInteger(1, x), new BigInteger(1, y)).toPublicKey();
   }
 
   private static PublicKey importCoseRsaPublicKey(Map<Integer, ?> cosePublicKey)

--- a/fido/src/main/java/com/yubico/yubikit/fido/Cose.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/Cose.java
@@ -123,10 +123,8 @@ public class Cose {
         throw new IllegalArgumentException("Unknown COSE EC2 curve: " + crv);
     }
 
-    // COSE EC2 coordinates are fixed-width unsigned big-endian integers (RFC 9053 7.1.1), so they
-    // must be read with the unsigned BigInteger constructor. The signed one makes any coordinate
-    // with the high bit set negative, and when the leading 0xFF is redundant the minimal two's
-    // complement form loses a byte, which the re-encoder then left-pads with 0x00.
+    // Parse coordinates as unsigned big-endian integers (RFC 9053 7.1.1) to avoid sign-extension
+    // byte truncation.
     return new Ec(ellipticCurveValues, new BigInteger(1, x), new BigInteger(1, y)).toPublicKey();
   }
 

--- a/fido/src/test/java/com/yubico/yubikit/fido/CoseTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/CoseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,5 +192,38 @@ public class CoseTest {
     PublicKey publicKey = Cose.getPublicKey(EDDSA);
     Assert.assertNotNull(publicKey);
     Assert.assertEquals(EDDSA_PUB, encode(publicKey.getEncoded()));
+  }
+
+  /*
+   * Regression coverage for signed decoding of EC2 coordinates. The vectors and the round-trip
+   * assertion live in CoseTestVectors so that this test and the Android instrumented test in
+   * :testing-android share one source of truth; see that class for why these coordinates matter.
+   *
+   * The plain high-bit case (negative, but no truncation) is already covered by getPublicKeyES256,
+   * whose x starts 0xC1.
+   */
+
+  @Test
+  public void getPublicKeyES256TruncatingX()
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    CoseTestVectors.assertRoundTrip(CoseTestVectors.ES256_TRUNCATING_X);
+  }
+
+  @Test
+  public void getPublicKeyES256TruncatingY()
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    CoseTestVectors.assertRoundTrip(CoseTestVectors.ES256_TRUNCATING_Y);
+  }
+
+  @Test
+  public void getPublicKeyES384TruncatingX()
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    CoseTestVectors.assertRoundTrip(CoseTestVectors.ES384_TRUNCATING_X);
+  }
+
+  @Test
+  public void getPublicKeyES256LeadingFf()
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    CoseTestVectors.assertRoundTrip(CoseTestVectors.ES256_LEADING_FF);
   }
 }

--- a/fido/src/test/java/com/yubico/yubikit/fido/CoseTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/CoseTest.java
@@ -29,115 +29,15 @@ public class CoseTest {
 
   private static final Map<Integer, Object> EMPTY_COSE = new HashMap<>();
 
-  private static final Map<Integer, Object> RS256 = new HashMap<>();
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String RS256_PUB =
-      "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0KeO-wuDQK18v9WwN5hFe6G_1TM4Ra8alOFa8cyN9xfqaLK"
-          + "1TvYVQHZfOcVvgM5XztCEOPNcQ5AWMJmTOESwvjuHkj5ulGt2jCVJUWKxPX-KYq0UFlb5jr305D66p5vRKb7z"
-          + "BterpDJSOxwLKr7g9jVhgpM2mgVjrRnQPMUAfvt8q9QMUWy1eIgIxnABi9b28cZ6WBDi42LMYiHz8mfUWi_ga"
-          + "9TASAwTqYZmGFUr7Z71ZuPKxuOxsgTxUksqKEmJw8iWcCgTC6-O8sMe-aZ3gqcwDEk9kRKZQJKlxtyYuArn2z"
-          + "DKfaAHJ1A2wLwjtq8m_TsiOEdW3289Fe_F4gSA_wIDAQAB";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String RS256_N =
-      "0KeO-wuDQK18v9WwN5hFe6G_1TM4Ra8alOFa8cyN9xfqaLK1TvYVQHZfOcVvgM5XztCEOPNcQ5AWMJmTOESwvjuHkj5"
-          + "ulGt2jCVJUWKxPX-KYq0UFlb5jr305D66p5vRKb7zBterpDJSOxwLKr7g9jVhgpM2mgVjrRnQPMUAfvt8q9QM"
-          + "UWy1eIgIxnABi9b28cZ6WBDi42LMYiHz8mfUWi_ga9TASAwTqYZmGFUr7Z71ZuPKxuOxsgTxUksqKEmJw8iWc"
-          + "CgTC6-O8sMe-aZ3gqcwDEk9kRKZQJKlxtyYuArn2zDKfaAHJ1A2wLwjtq8m_TsiOEdW3289Fe_F4gSA_w";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String RS256_E = "AAEAAQ";
-
-  private static final Map<Integer, Object> ES256 = new HashMap<>();
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES256_PUB =
-      "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwYXQNcHYEQHhLWssYM3Wxh59Glcd27iQRAbH7g73zEfw3nbfNHww9Dd"
-          + "UZVXRCbWETV_QEQb3PiZAhIdamjpdfA";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES256_X = "wYXQNcHYEQHhLWssYM3Wxh59Glcd27iQRAbH7g73zEc";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES256_Y = "8N523zR8MPQ3VGVV0Qm1hE1f0BEG9z4mQISHWpo6XXw";
-
-  private static final Map<Integer, Object> ES384 = new HashMap<>();
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES384_PUB =
-      "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEetBCP2oYwt-gkaDtb4eRy_QwdcywdSYvTtzpXMNxwfby4npVyJJ1yktnFhg"
-          + "i9ftU1VpkK0DSb8XIv-k7cJiU5eT1m8YYu8nlV7hKCz5_YzDtsprXCaHMhv37XGiENkLp";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES384_X =
-      "etBCP2oYwt-gkaDtb4eRy_QwdcywdSYvTtzpXMNxwfby4npVyJJ1yktnFhgi9ftU";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES384_Y =
-      "1VpkK0DSb8XIv-k7cJiU5eT1m8YYu8nlV7hKCz5_YzDtsprXCaHMhv37XGiENkLp";
-
-  private static final Map<Integer, Object> ES512 = new HashMap<>();
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES512_PUB =
-      "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBt0sGA8_brqo0_oRLGGxxndU6NZAsPLE0Bi6IS6MCoNILVI6uonHWOTM"
-          + "sfM2hoD5AM2Jm1VM8tQwC41jGxzQD6Q4BBMI0mQapyTTeA5SpUnZDN7fnbkRHAU2BzOLTvzWA2y6R8f87ghp-"
-          + "2pRtn_mKEqjzJLjOW0-ECHjmMiLGH8Qww88";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES512_X =
-      "AbdLBgPP266qNP6ESxhscZ3VOjWQLDyxNAYuiEujAqDSC1SOrqJx1jkzLHzNoaA-QDNiZtVTPLUMAuNYxsc0A-kO";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES512_Y =
-      "AQTCNJkGqck03gOUqVJ2Qze3525ERwFNgczi0781gNsukfH_O4IaftqUbZ_5ihKo8yS4zltPhAh45jIixh_EMMPP";
-
-  private static final Map<Integer, Object> EDDSA = new HashMap<>();
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String EDDSA_PUB =
-      "MCowBQYDK2VwAyEA3wIKsJK63Ctb-nLkcwG8fJOp2vZxz8lmhv3BcFI-ves";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String EDDSA_RAW_KEY = "3wIKsJK63Ctb-nLkcwG8fJOp2vZxz8lmhv3BcFI-ves";
-
-  static {
-    RS256.put(1, 3); // kty
-    RS256.put(3, -257); // alg
-    RS256.put(-1, decode(RS256_N)); // n
-    RS256.put(-2, decode(RS256_E)); // e
-
-    ES256.put(1, 2); // kty
-    ES256.put(3, -7); // alg
-    ES256.put(-1, 1); // crv
-    ES256.put(-2, decode(ES256_X)); // x
-    ES256.put(-3, decode(ES256_Y)); // y
-
-    ES384.put(1, 2); // kty
-    ES384.put(3, -35); // alg
-    ES384.put(-1, 2); // crv
-    ES384.put(-2, decode(ES384_X)); // x
-    ES384.put(-3, decode(ES384_Y)); // y
-
-    ES512.put(1, 2); // kty
-    ES512.put(3, -36); // alg
-    ES512.put(-1, 3); // crv
-    ES512.put(-2, decode(ES512_X)); // x
-    ES512.put(-3, decode(ES512_Y)); // y
-
-    EDDSA.put(1, 1); // kty
-    EDDSA.put(3, -8); // alg
-    EDDSA.put(-1, 6); // crv
-    EDDSA.put(-2, decode(EDDSA_RAW_KEY)); // raw key
-  }
-
-  private static byte[] decode(String urlSafeBase64) {
-    return Base64.fromUrlSafeString(urlSafeBase64);
-  }
-
   private static String encode(byte[] data) {
     return Base64.toUrlSafeString(data);
+  }
+
+  private static void assertDecodesTo(Map<Integer, Object> coseKey, String expectedSpki)
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    PublicKey publicKey = Cose.getPublicKey(coseKey);
+    Assert.assertNotNull(publicKey);
+    Assert.assertEquals(expectedSpki, encode(publicKey.getEncoded()));
   }
 
   @Test(expected = NullPointerException.class)
@@ -147,51 +47,36 @@ public class CoseTest {
 
   @Test
   public void getAlgorithm() {
-    Assert.assertEquals(Integer.valueOf(-257), Cose.getAlgorithm(RS256));
-    Assert.assertEquals(Integer.valueOf(-7), Cose.getAlgorithm(ES256));
-    Assert.assertEquals(Integer.valueOf(-35), Cose.getAlgorithm(ES384));
-    Assert.assertEquals(Integer.valueOf(-36), Cose.getAlgorithm(ES512));
-    Assert.assertEquals(Integer.valueOf(-8), Cose.getAlgorithm(EDDSA));
+    Assert.assertEquals(Integer.valueOf(-257), Cose.getAlgorithm(CoseTestVectors.rs256()));
+    Assert.assertEquals(Integer.valueOf(-7), Cose.getAlgorithm(CoseTestVectors.es256()));
+    Assert.assertEquals(Integer.valueOf(-35), Cose.getAlgorithm(CoseTestVectors.es384()));
+    Assert.assertEquals(Integer.valueOf(-36), Cose.getAlgorithm(CoseTestVectors.es512()));
+    Assert.assertEquals(Integer.valueOf(-8), Cose.getAlgorithm(CoseTestVectors.eddsa()));
   }
 
   @Test
-  public void getPublicKeyRS256()
-      throws InvalidKeySpecException, NoSuchAlgorithmException, NullPointerException {
-    PublicKey publicKey = Cose.getPublicKey(RS256);
-    Assert.assertNotNull(publicKey);
-    Assert.assertEquals(RS256_PUB, encode(publicKey.getEncoded()));
+  public void getPublicKeyRS256() throws InvalidKeySpecException, NoSuchAlgorithmException {
+    assertDecodesTo(CoseTestVectors.rs256(), CoseTestVectors.RS256_SPKI);
   }
 
   @Test
-  public void getPublicKeyES256()
-      throws InvalidKeySpecException, NoSuchAlgorithmException, NullPointerException {
-    PublicKey publicKey = Cose.getPublicKey(ES256);
-    Assert.assertNotNull(publicKey);
-    Assert.assertEquals(ES256_PUB, encode(publicKey.getEncoded()));
+  public void getPublicKeyES256() throws InvalidKeySpecException, NoSuchAlgorithmException {
+    assertDecodesTo(CoseTestVectors.es256(), CoseTestVectors.ES256_SPKI);
   }
 
   @Test
-  public void getPublicKeyES384()
-      throws InvalidKeySpecException, NoSuchAlgorithmException, NullPointerException {
-    PublicKey publicKey = Cose.getPublicKey(ES384);
-    Assert.assertNotNull(publicKey);
-    Assert.assertEquals(ES384_PUB, encode(publicKey.getEncoded()));
+  public void getPublicKeyES384() throws InvalidKeySpecException, NoSuchAlgorithmException {
+    assertDecodesTo(CoseTestVectors.es384(), CoseTestVectors.ES384_SPKI);
   }
 
   @Test
-  public void getPublicKeyES512()
-      throws InvalidKeySpecException, NoSuchAlgorithmException, NullPointerException {
-    PublicKey publicKey = Cose.getPublicKey(ES512);
-    Assert.assertNotNull(publicKey);
-    Assert.assertEquals(ES512_PUB, encode(publicKey.getEncoded()));
+  public void getPublicKeyES512() throws InvalidKeySpecException, NoSuchAlgorithmException {
+    assertDecodesTo(CoseTestVectors.es512(), CoseTestVectors.ES512_SPKI);
   }
 
   @Test
-  public void getPublicKeyEDDSA()
-      throws InvalidKeySpecException, NoSuchAlgorithmException, NullPointerException {
-    PublicKey publicKey = Cose.getPublicKey(EDDSA);
-    Assert.assertNotNull(publicKey);
-    Assert.assertEquals(EDDSA_PUB, encode(publicKey.getEncoded()));
+  public void getPublicKeyEDDSA() throws InvalidKeySpecException, NoSuchAlgorithmException {
+    assertDecodesTo(CoseTestVectors.eddsa(), CoseTestVectors.EDDSA_SPKI);
   }
 
   /*

--- a/fido/src/test/java/com/yubico/yubikit/fido/CoseTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/CoseTest.java
@@ -79,15 +79,7 @@ public class CoseTest {
     assertDecodesTo(CoseTestVectors.eddsa(), CoseTestVectors.EDDSA_SPKI);
   }
 
-  /*
-   * Regression coverage for signed decoding of EC2 coordinates. The vectors and the round-trip
-   * assertion live in CoseTestVectors so that this test and the Android instrumented test in
-   * :testing-android share one source of truth; see that class for why these coordinates matter.
-   *
-   * The plain high-bit case (negative, but no truncation) is already covered by getPublicKeyES256,
-   * whose x starts 0xC1.
-   */
-
+  // Regression coverage for signed EC2 coordinate decoding (shared in CoseTestVectors).
   @Test
   public void getPublicKeyES256TruncatingX()
       throws InvalidKeySpecException, NoSuchAlgorithmException {

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/GuardedLoggingCallSitesTest.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/GuardedLoggingCallSitesTest.java
@@ -21,11 +21,9 @@ import static org.junit.Assert.assertNotNull;
 
 import android.util.Log;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import com.yubico.yubikit.core.internal.codec.Base64;
 import com.yubico.yubikit.fido.Cose;
+import com.yubico.yubikit.fido.CoseTestVectors;
 import java.security.PublicKey;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,57 +50,10 @@ public class GuardedLoggingCallSitesTest {
 
   private static final String TAG = "GuardedLoggingCallSites";
 
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES256_X = "wYXQNcHYEQHhLWssYM3Wxh59Glcd27iQRAbH7g73zEc";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String ES256_Y = "8N523zR8MPQ3VGVV0Qm1hE1f0BEG9z4mQISHWpo6XXw";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String RS256_N =
-      "0KeO-wuDQK18v9WwN5hFe6G_1TM4Ra8alOFa8cyN9xfqaLK1TvYVQHZfOcVvgM5XztCEOPNcQ5AWMJmTOESwvjuHkj5"
-          + "ulGt2jCVJUWKxPX-KYq0UFlb5jr305D66p5vRKb7zBterpDJSOxwLKr7g9jVhgpM2mgVjrRnQPMUAfvt8q9QM"
-          + "UWy1eIgIxnABi9b28cZ6WBDi42LMYiHz8mfUWi_ga9TASAwTqYZmGFUr7Z71ZuPKxuOxsgTxUksqKEmJw8iWc"
-          + "CgTC6-O8sMe-aZ3gqcwDEk9kRKZQJKlxtyYuArn2zDKfaAHJ1A2wLwjtq8m_TsiOEdW3289Fe_F4gSA_w";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String RS256_E = "AAEAAQ";
-
-  @SuppressWarnings("SpellCheckingInspection")
-  private static final String EDDSA_RAW_KEY = "3wIKsJK63Ctb-nLkcwG8fJOp2vZxz8lmhv3BcFI-ves";
-
-  private static Map<Integer, Object> es256() {
-    Map<Integer, Object> key = new HashMap<>();
-    key.put(1, 2); // kty
-    key.put(3, -7); // alg
-    key.put(-1, 1); // crv
-    key.put(-2, Base64.fromUrlSafeString(ES256_X));
-    key.put(-3, Base64.fromUrlSafeString(ES256_Y));
-    return key;
-  }
-
-  private static Map<Integer, Object> rs256() {
-    Map<Integer, Object> key = new HashMap<>();
-    key.put(1, 3); // kty
-    key.put(3, -257); // alg
-    key.put(-1, Base64.fromUrlSafeString(RS256_N));
-    key.put(-2, Base64.fromUrlSafeString(RS256_E));
-    return key;
-  }
-
-  private static Map<Integer, Object> eddsa() {
-    Map<Integer, Object> key = new HashMap<>();
-    key.put(1, 1); // kty
-    key.put(3, -8); // alg
-    key.put(-1, 6); // crv
-    key.put(-2, Base64.fromUrlSafeString(EDDSA_RAW_KEY));
-    return key;
-  }
-
   /** Exercises the {@code x}/{@code y} sites plus the shared {@code publicKey} site. */
   @Test
   public void ec2CallSites() throws Exception {
-    PublicKey publicKey = Cose.getPublicKey(es256());
+    PublicKey publicKey = Cose.getPublicKey(CoseTestVectors.es256());
 
     assertNotNull("EC2 key did not decode", publicKey);
     assertEquals("EC", publicKey.getAlgorithm());
@@ -112,7 +63,7 @@ public class GuardedLoggingCallSitesTest {
   /** Exercises the {@code n}/{@code e} sites plus the shared {@code publicKey} site. */
   @Test
   public void rsaCallSites() throws Exception {
-    PublicKey publicKey = Cose.getPublicKey(rs256());
+    PublicKey publicKey = Cose.getPublicKey(CoseTestVectors.rs256());
 
     assertNotNull("RSA key did not decode", publicKey);
     assertEquals("RSA", publicKey.getAlgorithm());
@@ -130,7 +81,7 @@ public class GuardedLoggingCallSitesTest {
   @Test
   public void ed25519CallSite() {
     try {
-      PublicKey publicKey = Cose.getPublicKey(eddsa());
+      PublicKey publicKey = Cose.getPublicKey(CoseTestVectors.eddsa());
       Log.i(TAG, "Ed25519 call site OK, key decoded: " + publicKey);
     } catch (Exception e) {
       Log.i(TAG, "Ed25519 call site OK, no provider on this device: " + e);
@@ -140,8 +91,8 @@ public class GuardedLoggingCallSitesTest {
   /** The plain, never-converted call in {@code getAlgorithm}, as a control. */
   @Test
   public void plainCallSiteControl() {
-    assertEquals(Integer.valueOf(-7), Cose.getAlgorithm(es256()));
-    assertEquals(Integer.valueOf(-257), Cose.getAlgorithm(rs256()));
+    assertEquals(Integer.valueOf(-7), Cose.getAlgorithm(CoseTestVectors.es256()));
+    assertEquals(Integer.valueOf(-257), Cose.getAlgorithm(CoseTestVectors.rs256()));
     Log.i(TAG, "plain control OK");
   }
 }

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/KeylessDeviceTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/KeylessDeviceTests.java
@@ -16,6 +16,7 @@
 
 package com.yubico.yubikit;
 
+import com.yubico.yubikit.fido.CoseInstrumentedTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -34,6 +35,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
   ThemeInflationTests.class,
   LoggingSmokeTests.class,
-  GuardedLoggingCallSitesTest.class
+  GuardedLoggingCallSitesTest.class,
+  CoseInstrumentedTest.class
 })
 public class KeylessDeviceTests {}

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/fido/CoseInstrumentedTest.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/fido/CoseInstrumentedTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit.fido;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Device-side counterpart to {@code CoseTest} in the fido module, sharing its vectors via {@link
+ * CoseTestVectors}.
+ *
+ * <p>The JVM unit test exercises {@link Cose#getPublicKey} against the JDK's SunEC provider. This
+ * one runs the same vectors against whatever {@code KeyFactory.getInstance("EC")} resolves to on a
+ * real device (Conscrypt / BoringSSL), which is the provider that actually decodes credential
+ * public keys in production. The two disagree on an off-curve point: SunEC accepts it and returns a
+ * silently wrong key, Conscrypt throws {@link InvalidKeySpecException}. Both are failures and
+ * {@link CoseTestVectors#assertRoundTrip} catches either.
+ *
+ * <p>Needs no YubiKey, so it is deliberately not a member of any of the hardware test suites. Run
+ * it with:
+ *
+ * <pre>
+ * ./gradlew :testing-android:connectedDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=\
+ * com.yubico.yubikit.fido.CoseInstrumentedTest
+ * </pre>
+ */
+@RunWith(AndroidJUnit4.class)
+public class CoseInstrumentedTest {
+
+  @Test
+  public void getPublicKeyES256TruncatingX()
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    CoseTestVectors.assertRoundTrip(CoseTestVectors.ES256_TRUNCATING_X);
+  }
+
+  @Test
+  public void getPublicKeyES256TruncatingY()
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    CoseTestVectors.assertRoundTrip(CoseTestVectors.ES256_TRUNCATING_Y);
+  }
+
+  @Test
+  public void getPublicKeyES384TruncatingX()
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    CoseTestVectors.assertRoundTrip(CoseTestVectors.ES384_TRUNCATING_X);
+  }
+
+  @Test
+  public void getPublicKeyES256LeadingFf()
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    CoseTestVectors.assertRoundTrip(CoseTestVectors.ES256_LEADING_FF);
+  }
+}

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/fido/CoseInstrumentedTest.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/fido/CoseInstrumentedTest.java
@@ -33,13 +33,13 @@ import org.junit.runner.RunWith;
  * silently wrong key, Conscrypt throws {@link InvalidKeySpecException}. Both are failures and
  * {@link CoseTestVectors#assertRoundTrip} catches either.
  *
- * <p>Needs no YubiKey, so it is deliberately not a member of any of the hardware test suites. Run
- * it with:
+ * <p>Needs no YubiKey, so it belongs to {@code KeylessDeviceTests} rather than {@code DeviceTests}
+ * and runs unattended:
  *
  * <pre>
  * ./gradlew :testing-android:connectedDebugAndroidTest \
  *     -Pandroid.testInstrumentationRunnerArguments.class=\
- * com.yubico.yubikit.fido.CoseInstrumentedTest
+ * com.yubico.yubikit.KeylessDeviceTests
  * </pre>
  */
 @RunWith(AndroidJUnit4.class)

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/fido/CoseInstrumentedTest.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/fido/CoseInstrumentedTest.java
@@ -23,24 +23,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Device-side counterpart to {@code CoseTest} in the fido module, sharing its vectors via {@link
- * CoseTestVectors}.
- *
- * <p>The JVM unit test exercises {@link Cose#getPublicKey} against the JDK's SunEC provider. This
- * one runs the same vectors against whatever {@code KeyFactory.getInstance("EC")} resolves to on a
- * real device (Conscrypt / BoringSSL), which is the provider that actually decodes credential
- * public keys in production. The two disagree on an off-curve point: SunEC accepts it and returns a
- * silently wrong key, Conscrypt throws {@link InvalidKeySpecException}. Both are failures and
- * {@link CoseTestVectors#assertRoundTrip} catches either.
- *
- * <p>Needs no YubiKey, so it belongs to {@code KeylessDeviceTests} rather than {@code DeviceTests}
- * and runs unattended:
- *
- * <pre>
- * ./gradlew :testing-android:connectedDebugAndroidTest \
- *     -Pandroid.testInstrumentationRunnerArguments.class=\
- * com.yubico.yubikit.KeylessDeviceTests
- * </pre>
+ * Runs COSE test vectors against the device's native provider (Conscrypt/BoringSSL) to catch
+ * provider-specific off-curve point handling.
  */
 @RunWith(AndroidJUnit4.class)
 public class CoseInstrumentedTest {

--- a/testing/src/main/java/com/yubico/yubikit/fido/CoseTestVectors.java
+++ b/testing/src/main/java/com/yubico/yubikit/fido/CoseTestVectors.java
@@ -28,7 +28,20 @@ import java.util.Map;
 import org.junit.Assert;
 
 /**
- * Shared COSE EC2 test vectors covering signed decoding of key coordinates.
+ * Shared COSE test vectors.
+ *
+ * <p>Two groups, serving different purposes.
+ *
+ * <p><b>Standard keys</b> — {@link #es256()}, {@link #es384()}, {@link #es512()}, {@link #rs256()}
+ * and {@link #eddsa()}, one well-formed key per supported algorithm, each paired with an {@code
+ * *_SPKI} constant. For callers that just need a valid COSE key of a given type. Their coordinates
+ * stay in url-safe base64, the form they have always been in.
+ *
+ * <p><b>Regression vectors</b> — the {@code *_TRUNCATING_*} and {@link #ES256_LEADING_FF} {@link
+ * Vector}s below, which exist to pin one specific decoding defect and carry hex coordinates so the
+ * byte pattern under test stays readable.
+ *
+ * <h2>The defect the regression vectors cover</h2>
  *
  * <p>COSE encodes x and y as fixed-width unsigned big-endian integers (RFC 9053 7.1.1). Reading one
  * with the signed {@code BigInteger(byte[])} constructor makes any coordinate with the high bit set
@@ -56,6 +69,122 @@ public final class CoseTestVectors {
 
   private CoseTestVectors() {}
 
+  // ---------------------------------------------------------------------------------------------
+  // Standard keys — one well-formed key per algorithm, with the SPKI a correct decoder produces.
+  // ---------------------------------------------------------------------------------------------
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String ES256_X = "wYXQNcHYEQHhLWssYM3Wxh59Glcd27iQRAbH7g73zEc";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String ES256_Y = "8N523zR8MPQ3VGVV0Qm1hE1f0BEG9z4mQISHWpo6XXw";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  public static final String ES256_SPKI =
+      "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwYXQNcHYEQHhLWssYM3Wxh59Glcd27iQRAbH7g73zEfw3nbfNHww9Dd"
+          + "UZVXRCbWETV_QEQb3PiZAhIdamjpdfA";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String ES384_X =
+      "etBCP2oYwt-gkaDtb4eRy_QwdcywdSYvTtzpXMNxwfby4npVyJJ1yktnFhgi9ftU";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String ES384_Y =
+      "1VpkK0DSb8XIv-k7cJiU5eT1m8YYu8nlV7hKCz5_YzDtsprXCaHMhv37XGiENkLp";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  public static final String ES384_SPKI =
+      "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEetBCP2oYwt-gkaDtb4eRy_QwdcywdSYvTtzpXMNxwfby4npVyJJ1yktnFhg"
+          + "i9ftU1VpkK0DSb8XIv-k7cJiU5eT1m8YYu8nlV7hKCz5_YzDtsprXCaHMhv37XGiENkLp";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String ES512_X =
+      "AbdLBgPP266qNP6ESxhscZ3VOjWQLDyxNAYuiEujAqDSC1SOrqJx1jkzLHzNoaA-QDNiZtVTPLUMAuNYxsc0A-kO";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String ES512_Y =
+      "AQTCNJkGqck03gOUqVJ2Qze3525ERwFNgczi0781gNsukfH_O4IaftqUbZ_5ihKo8yS4zltPhAh45jIixh_EMMPP";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  public static final String ES512_SPKI =
+      "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBt0sGA8_brqo0_oRLGGxxndU6NZAsPLE0Bi6IS6MCoNILVI6uonHWOTM"
+          + "sfM2hoD5AM2Jm1VM8tQwC41jGxzQD6Q4BBMI0mQapyTTeA5SpUnZDN7fnbkRHAU2BzOLTvzWA2y6R8f87ghp-"
+          + "2pRtn_mKEqjzJLjOW0-ECHjmMiLGH8Qww88";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String RS256_N =
+      "0KeO-wuDQK18v9WwN5hFe6G_1TM4Ra8alOFa8cyN9xfqaLK1TvYVQHZfOcVvgM5XztCEOPNcQ5AWMJmTOESwvjuHkj5"
+          + "ulGt2jCVJUWKxPX-KYq0UFlb5jr305D66p5vRKb7zBterpDJSOxwLKr7g9jVhgpM2mgVjrRnQPMUAfvt8q9QM"
+          + "UWy1eIgIxnABi9b28cZ6WBDi42LMYiHz8mfUWi_ga9TASAwTqYZmGFUr7Z71ZuPKxuOxsgTxUksqKEmJw8iWc"
+          + "CgTC6-O8sMe-aZ3gqcwDEk9kRKZQJKlxtyYuArn2zDKfaAHJ1A2wLwjtq8m_TsiOEdW3289Fe_F4gSA_w";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String RS256_E = "AAEAAQ";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  public static final String RS256_SPKI =
+      "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0KeO-wuDQK18v9WwN5hFe6G_1TM4Ra8alOFa8cyN9xfqaLK"
+          + "1TvYVQHZfOcVvgM5XztCEOPNcQ5AWMJmTOESwvjuHkj5ulGt2jCVJUWKxPX-KYq0UFlb5jr305D66p5vRKb7z"
+          + "BterpDJSOxwLKr7g9jVhgpM2mgVjrRnQPMUAfvt8q9QMUWy1eIgIxnABi9b28cZ6WBDi42LMYiHz8mfUWi_ga"
+          + "9TASAwTqYZmGFUr7Z71ZuPKxuOxsgTxUksqKEmJw8iWcCgTC6-O8sMe-aZ3gqcwDEk9kRKZQJKlxtyYuArn2z"
+          + "DKfaAHJ1A2wLwjtq8m_TsiOEdW3289Fe_F4gSA_wIDAQAB";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String EDDSA_RAW_KEY = "3wIKsJK63Ctb-nLkcwG8fJOp2vZxz8lmhv3BcFI-ves";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  public static final String EDDSA_SPKI =
+      "MCowBQYDK2VwAyEA3wIKsJK63Ctb-nLkcwG8fJOp2vZxz8lmhv3BcFI-ves";
+
+  /** ES256 (SECP256R1) key. A fresh map each call, so callers may mutate it freely. */
+  public static Map<Integer, Object> es256() {
+    return ec2Key(-7, 1, Base64.fromUrlSafeString(ES256_X), Base64.fromUrlSafeString(ES256_Y));
+  }
+
+  /** ES384 (SECP384R1) key. */
+  public static Map<Integer, Object> es384() {
+    return ec2Key(-35, 2, Base64.fromUrlSafeString(ES384_X), Base64.fromUrlSafeString(ES384_Y));
+  }
+
+  /** ES512 (SECP521R1) key. */
+  public static Map<Integer, Object> es512() {
+    return ec2Key(-36, 3, Base64.fromUrlSafeString(ES512_X), Base64.fromUrlSafeString(ES512_Y));
+  }
+
+  /** RS256 key. */
+  public static Map<Integer, Object> rs256() {
+    Map<Integer, Object> cose = new HashMap<>();
+    cose.put(1, 3); // kty: RSA
+    cose.put(3, -257); // alg
+    cose.put(-1, Base64.fromUrlSafeString(RS256_N)); // n
+    cose.put(-2, Base64.fromUrlSafeString(RS256_E)); // e
+    return cose;
+  }
+
+  /** EdDSA (Ed25519) key. */
+  public static Map<Integer, Object> eddsa() {
+    Map<Integer, Object> cose = new HashMap<>();
+    cose.put(1, 1); // kty: OKP
+    cose.put(3, -8); // alg
+    cose.put(-1, 6); // crv: Ed25519
+    cose.put(-2, Base64.fromUrlSafeString(EDDSA_RAW_KEY)); // raw key
+    return cose;
+  }
+
+  private static Map<Integer, Object> ec2Key(int algorithm, int curve, byte[] x, byte[] y) {
+    Map<Integer, Object> cose = new HashMap<>();
+    cose.put(1, 2); // kty: EC2
+    cose.put(3, algorithm); // alg
+    cose.put(-1, curve); // crv
+    cose.put(-2, x); // x
+    cose.put(-3, y); // y
+    return cose;
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Regression vectors — see the class comment.
+  // ---------------------------------------------------------------------------------------------
+
   /** A COSE EC2 public key and the SPKI encoding a correct decoder must produce for it. */
   public static final class Vector {
     private final int algorithm;
@@ -74,13 +203,7 @@ public final class CoseTestVectors {
 
     /** The COSE key as {@link Cose#getPublicKey} expects it. */
     public Map<Integer, Object> toCoseKey() {
-      Map<Integer, Object> cose = new HashMap<>();
-      cose.put(1, 2); // kty: EC2
-      cose.put(3, algorithm); // alg
-      cose.put(-1, curve); // crv
-      cose.put(-2, Codec.fromHex(x)); // x
-      cose.put(-3, Codec.fromHex(y)); // y
-      return cose;
+      return ec2Key(algorithm, curve, Codec.fromHex(x), Codec.fromHex(y));
     }
 
     public BigInteger affineX() {

--- a/testing/src/main/java/com/yubico/yubikit/fido/CoseTestVectors.java
+++ b/testing/src/main/java/com/yubico/yubikit/fido/CoseTestVectors.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yubico.yubikit.fido;
+
+import com.yubico.yubikit.Codec;
+import com.yubico.yubikit.core.internal.codec.Base64;
+import java.math.BigInteger;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECPoint;
+import java.security.spec.InvalidKeySpecException;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+
+/**
+ * Shared COSE EC2 test vectors covering signed decoding of key coordinates.
+ *
+ * <p>COSE encodes x and y as fixed-width unsigned big-endian integers (RFC 9053 7.1.1). Reading one
+ * with the signed {@code BigInteger(byte[])} constructor makes any coordinate with the high bit set
+ * negative. That alone is usually harmless, because the minimal two's complement form of such a
+ * value is still the same width and re-encodes to the original bytes. It stops being harmless when
+ * the leading 0xFF is redundant, i.e. when the second byte also has its high bit set: the minimal
+ * form is then one byte shorter, and {@code ByteUtils.intToLength} left-pads it with 0x00, turning
+ * the leading 0xFF into 0x00 and producing a different key.
+ *
+ * <p>That is P(first byte == 0xFF) * P(second byte &gt;= 0x80) = 1/512 per coordinate, so roughly
+ * one EC credential in 256. SECP521R1 cannot be affected: its 66-byte coordinates always begin 0x00
+ * or 0x01.
+ *
+ * <p>These vectors live here so the JVM unit test and the Android instrumented test assert on one
+ * source of truth. They are worth running against more than one provider: an incorrect coordinate
+ * yields a point that is not on the curve, and providers disagree on whether that is fatal. SunEC
+ * accepts it and hands back a silently wrong key; Conscrypt rejects it with an {@link
+ * InvalidKeySpecException}.
+ *
+ * <p>Every vector is a small multiple of its curve generator, so it is a genuine point on the curve
+ * and a conforming decoder must round-trip it exactly. Coordinates are hex rather than base64 so
+ * that the leading byte pattern under test stays readable.
+ */
+public final class CoseTestVectors {
+
+  private CoseTestVectors() {}
+
+  /** A COSE EC2 public key and the SPKI encoding a correct decoder must produce for it. */
+  public static final class Vector {
+    private final int algorithm;
+    private final int curve;
+    private final String x;
+    private final String y;
+    private final String spki;
+
+    Vector(int algorithm, int curve, String x, String y, String spki) {
+      this.algorithm = algorithm;
+      this.curve = curve;
+      this.x = x;
+      this.y = y;
+      this.spki = spki;
+    }
+
+    /** The COSE key as {@link Cose#getPublicKey} expects it. */
+    public Map<Integer, Object> toCoseKey() {
+      Map<Integer, Object> cose = new HashMap<>();
+      cose.put(1, 2); // kty: EC2
+      cose.put(3, algorithm); // alg
+      cose.put(-1, curve); // crv
+      cose.put(-2, Codec.fromHex(x)); // x
+      cose.put(-3, Codec.fromHex(y)); // y
+      return cose;
+    }
+
+    public BigInteger affineX() {
+      return new BigInteger(1, Codec.fromHex(x));
+    }
+
+    public BigInteger affineY() {
+      return new BigInteger(1, Codec.fromHex(y));
+    }
+
+    /** Independently computed X.509 SubjectPublicKeyInfo, url-safe base64. */
+    public String expectedSpki() {
+      return spki;
+    }
+  }
+
+  /** SECP256R1, x begins 0xFF 0x9F: the leading byte is redundant and gets truncated away. */
+  public static final Vector ES256_TRUNCATING_X =
+      new Vector(
+          -7,
+          1,
+          "ff9f4aa102ef0ff733e9f8c4e5e6df114596d6c94ad81ac237b0ef9ef004ee81",
+          "238b7bfb3be7c9be1af55766343a0c7022fe93b9bf9a44d2a694cef7900dbfce",
+          "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE_59KoQLvD_cz6fjE5ebfEUWW1slK2BrCN7DvnvAE7oEji3v7O-fJ"
+              + "vhr1V2Y0OgxwIv6Tub-aRNKmlM73kA2_zg");
+
+  /** SECP256R1, y begins 0xFF 0xA0: x and y are decoded separately, so both need covering. */
+  public static final Vector ES256_TRUNCATING_Y =
+      new Vector(
+          -7,
+          1,
+          "edc4254f9e0612569c4be857c7d09a60cd4555e867909c76471cb2ed420cd819",
+          "ffa06b06845c31ec9b81bc4ca122ed16b083f7e9d263bc475e864937171cecfe",
+          "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7cQlT54GElacS-hXx9CaYM1FVehnkJx2Rxyy7UIM2Bn_oGsGhFwx"
+              + "7JuBvEyhIu0WsIP36dJjvEdehkk3Fxzs_g");
+
+  /**
+   * SECP384R1, x begins 0xFF 0xCF: shows the defect and the fix are independent of coordinate
+   * width. A P-384 y case would add no new path, being the same curve as this vector and the same
+   * coordinate role as {@link #ES256_TRUNCATING_Y}.
+   */
+  public static final Vector ES384_TRUNCATING_X =
+      new Vector(
+          -35,
+          2,
+          "ffcfb755a5e51c0eabb58a20633be121e273410334f3a2dba0d5e47e9c30a726"
+              + "05750cd9ccf23442fe6c04394b7767a8",
+          "535005ec1a4ed4c12eac1318ca9a5e9b35d7620c1705b4321aa01c4d11375281"
+              + "4d190b8462a0742f3e312418af13d52e",
+          "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE_8-3VaXlHA6rtYogYzvhIeJzQQM086LboNXkfpwwpyYFdQzZzPI0Qv5s"
+              + "BDlLd2eoU1AF7BpO1MEurBMYyppemzXXYgwXBbQyGqAcTRE3UoFNGQuEYqB0Lz4xJBivE9Uu");
+
+  /**
+   * Boundary case. SECP256R1 with x beginning 0xFF 0x22: the leading 0xFF is <em>not</em>
+   * redundant, so the minimal form keeps its width and this decodes correctly even under signed
+   * decoding. It is here so that a fix for the vectors above cannot regress it by stripping or
+   * padding unconditionally.
+   */
+  public static final Vector ES256_LEADING_FF =
+      new Vector(
+          -7,
+          1,
+          "ff229b98c9e2fbdc6b5b80a7aa28f671d6ffc7444f069bb1c9f4c3a13b0610f9",
+          "e6593b7734faaa4aa0db2934b3df4a91bfb3f221c986b4add02665720b321023",
+          "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE_yKbmMni-9xrW4Cnqij2cdb_x0RPBpuxyfTDoTsGEPnmWTt3NPqq"
+              + "SqDbKTSz30qRv7PyIcmGtK3QJmVyCzIQIw");
+
+  /**
+   * Asserts that {@link Cose#getPublicKey} round-trips the vector's coordinates exactly: the affine
+   * coordinates of the returned key must equal the unsigned values that went in, and the SPKI
+   * encoding must match the independently computed expectation.
+   *
+   * <p>Asserting on the affine coordinates as well as the encoding matters, because a provider that
+   * accepts an off-curve point fails silently rather than throwing.
+   */
+  public static void assertRoundTrip(Vector vector)
+      throws InvalidKeySpecException, NoSuchAlgorithmException {
+    PublicKey publicKey = Cose.getPublicKey(vector.toCoseKey());
+    Assert.assertNotNull(publicKey);
+    ECPoint point = ((ECPublicKey) publicKey).getW();
+    Assert.assertEquals("affine x", vector.affineX(), point.getAffineX());
+    Assert.assertEquals("affine y", vector.affineY(), point.getAffineY());
+    Assert.assertEquals(vector.expectedSpki(), Base64.toUrlSafeString(publicKey.getEncoded()));
+  }
+}

--- a/testing/src/main/java/com/yubico/yubikit/fido/CoseTestVectors.java
+++ b/testing/src/main/java/com/yubico/yubikit/fido/CoseTestVectors.java
@@ -28,100 +28,50 @@ import java.util.Map;
 import org.junit.Assert;
 
 /**
- * Shared COSE test vectors.
- *
- * <p>Two groups, serving different purposes.
- *
- * <p><b>Standard keys</b> — {@link #es256()}, {@link #es384()}, {@link #es512()}, {@link #rs256()}
- * and {@link #eddsa()}, one well-formed key per supported algorithm, each paired with an {@code
- * *_SPKI} constant. For callers that just need a valid COSE key of a given type. Their coordinates
- * stay in url-safe base64, the form they have always been in.
- *
- * <p><b>Regression vectors</b> — the {@code *_TRUNCATING_*} and {@link #ES256_LEADING_FF} {@link
- * Vector}s below, which exist to pin one specific decoding defect and carry hex coordinates so the
- * byte pattern under test stays readable.
- *
- * <h2>The defect the regression vectors cover</h2>
- *
- * <p>COSE encodes x and y as fixed-width unsigned big-endian integers (RFC 9053 7.1.1). Reading one
- * with the signed {@code BigInteger(byte[])} constructor makes any coordinate with the high bit set
- * negative. That alone is usually harmless, because the minimal two's complement form of such a
- * value is still the same width and re-encodes to the original bytes. It stops being harmless when
- * the leading 0xFF is redundant, i.e. when the second byte also has its high bit set: the minimal
- * form is then one byte shorter, and {@code ByteUtils.intToLength} left-pads it with 0x00, turning
- * the leading 0xFF into 0x00 and producing a different key.
- *
- * <p>That is P(first byte == 0xFF) * P(second byte &gt;= 0x80) = 1/512 per coordinate, so roughly
- * one EC credential in 256. SECP521R1 cannot be affected: its 66-byte coordinates always begin 0x00
- * or 0x01.
- *
- * <p>These vectors live here so the JVM unit test and the Android instrumented test assert on one
- * source of truth. They are worth running against more than one provider: an incorrect coordinate
- * yields a point that is not on the curve, and providers disagree on whether that is fatal. SunEC
- * accepts it and hands back a silently wrong key; Conscrypt rejects it with an {@link
- * InvalidKeySpecException}.
- *
- * <p>Every vector is a small multiple of its curve generator, so it is a genuine point on the curve
- * and a conforming decoder must round-trip it exactly. Coordinates are hex rather than base64 so
- * that the leading byte pattern under test stays readable.
+ * Shared COSE test vectors. Exercises standard key parsing across algorithms and tests unsigned
+ * decoding edge cases where leading 0xFF bytes trigger truncation.
  */
 public final class CoseTestVectors {
 
   private CoseTestVectors() {}
 
-  // ---------------------------------------------------------------------------------------------
-  // Standard keys — one well-formed key per algorithm, with the SPKI a correct decoder produces.
-  // ---------------------------------------------------------------------------------------------
-
-  @SuppressWarnings("SpellCheckingInspection")
   private static final String ES256_X = "wYXQNcHYEQHhLWssYM3Wxh59Glcd27iQRAbH7g73zEc";
 
-  @SuppressWarnings("SpellCheckingInspection")
   private static final String ES256_Y = "8N523zR8MPQ3VGVV0Qm1hE1f0BEG9z4mQISHWpo6XXw";
 
-  @SuppressWarnings("SpellCheckingInspection")
   public static final String ES256_SPKI =
       "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwYXQNcHYEQHhLWssYM3Wxh59Glcd27iQRAbH7g73zEfw3nbfNHww9Dd"
           + "UZVXRCbWETV_QEQb3PiZAhIdamjpdfA";
 
-  @SuppressWarnings("SpellCheckingInspection")
   private static final String ES384_X =
       "etBCP2oYwt-gkaDtb4eRy_QwdcywdSYvTtzpXMNxwfby4npVyJJ1yktnFhgi9ftU";
 
-  @SuppressWarnings("SpellCheckingInspection")
   private static final String ES384_Y =
       "1VpkK0DSb8XIv-k7cJiU5eT1m8YYu8nlV7hKCz5_YzDtsprXCaHMhv37XGiENkLp";
 
-  @SuppressWarnings("SpellCheckingInspection")
   public static final String ES384_SPKI =
       "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEetBCP2oYwt-gkaDtb4eRy_QwdcywdSYvTtzpXMNxwfby4npVyJJ1yktnFhg"
           + "i9ftU1VpkK0DSb8XIv-k7cJiU5eT1m8YYu8nlV7hKCz5_YzDtsprXCaHMhv37XGiENkLp";
 
-  @SuppressWarnings("SpellCheckingInspection")
   private static final String ES512_X =
       "AbdLBgPP266qNP6ESxhscZ3VOjWQLDyxNAYuiEujAqDSC1SOrqJx1jkzLHzNoaA-QDNiZtVTPLUMAuNYxsc0A-kO";
 
-  @SuppressWarnings("SpellCheckingInspection")
   private static final String ES512_Y =
       "AQTCNJkGqck03gOUqVJ2Qze3525ERwFNgczi0781gNsukfH_O4IaftqUbZ_5ihKo8yS4zltPhAh45jIixh_EMMPP";
 
-  @SuppressWarnings("SpellCheckingInspection")
   public static final String ES512_SPKI =
       "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBt0sGA8_brqo0_oRLGGxxndU6NZAsPLE0Bi6IS6MCoNILVI6uonHWOTM"
           + "sfM2hoD5AM2Jm1VM8tQwC41jGxzQD6Q4BBMI0mQapyTTeA5SpUnZDN7fnbkRHAU2BzOLTvzWA2y6R8f87ghp-"
           + "2pRtn_mKEqjzJLjOW0-ECHjmMiLGH8Qww88";
 
-  @SuppressWarnings("SpellCheckingInspection")
   private static final String RS256_N =
       "0KeO-wuDQK18v9WwN5hFe6G_1TM4Ra8alOFa8cyN9xfqaLK1TvYVQHZfOcVvgM5XztCEOPNcQ5AWMJmTOESwvjuHkj5"
           + "ulGt2jCVJUWKxPX-KYq0UFlb5jr305D66p5vRKb7zBterpDJSOxwLKr7g9jVhgpM2mgVjrRnQPMUAfvt8q9QM"
           + "UWy1eIgIxnABi9b28cZ6WBDi42LMYiHz8mfUWi_ga9TASAwTqYZmGFUr7Z71ZuPKxuOxsgTxUksqKEmJw8iWc"
           + "CgTC6-O8sMe-aZ3gqcwDEk9kRKZQJKlxtyYuArn2zDKfaAHJ1A2wLwjtq8m_TsiOEdW3289Fe_F4gSA_w";
 
-  @SuppressWarnings("SpellCheckingInspection")
   private static final String RS256_E = "AAEAAQ";
 
-  @SuppressWarnings("SpellCheckingInspection")
   public static final String RS256_SPKI =
       "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0KeO-wuDQK18v9WwN5hFe6G_1TM4Ra8alOFa8cyN9xfqaLK"
           + "1TvYVQHZfOcVvgM5XztCEOPNcQ5AWMJmTOESwvjuHkj5ulGt2jCVJUWKxPX-KYq0UFlb5jr305D66p5vRKb7z"
@@ -129,29 +79,23 @@ public final class CoseTestVectors {
           + "9TASAwTqYZmGFUr7Z71ZuPKxuOxsgTxUksqKEmJw8iWcCgTC6-O8sMe-aZ3gqcwDEk9kRKZQJKlxtyYuArn2z"
           + "DKfaAHJ1A2wLwjtq8m_TsiOEdW3289Fe_F4gSA_wIDAQAB";
 
-  @SuppressWarnings("SpellCheckingInspection")
   private static final String EDDSA_RAW_KEY = "3wIKsJK63Ctb-nLkcwG8fJOp2vZxz8lmhv3BcFI-ves";
 
-  @SuppressWarnings("SpellCheckingInspection")
   public static final String EDDSA_SPKI =
       "MCowBQYDK2VwAyEA3wIKsJK63Ctb-nLkcwG8fJOp2vZxz8lmhv3BcFI-ves";
 
-  /** ES256 (SECP256R1) key. A fresh map each call, so callers may mutate it freely. */
   public static Map<Integer, Object> es256() {
     return ec2Key(-7, 1, Base64.fromUrlSafeString(ES256_X), Base64.fromUrlSafeString(ES256_Y));
   }
 
-  /** ES384 (SECP384R1) key. */
   public static Map<Integer, Object> es384() {
     return ec2Key(-35, 2, Base64.fromUrlSafeString(ES384_X), Base64.fromUrlSafeString(ES384_Y));
   }
 
-  /** ES512 (SECP521R1) key. */
   public static Map<Integer, Object> es512() {
     return ec2Key(-36, 3, Base64.fromUrlSafeString(ES512_X), Base64.fromUrlSafeString(ES512_Y));
   }
 
-  /** RS256 key. */
   public static Map<Integer, Object> rs256() {
     Map<Integer, Object> cose = new HashMap<>();
     cose.put(1, 3); // kty: RSA
@@ -161,7 +105,6 @@ public final class CoseTestVectors {
     return cose;
   }
 
-  /** EdDSA (Ed25519) key. */
   public static Map<Integer, Object> eddsa() {
     Map<Integer, Object> cose = new HashMap<>();
     cose.put(1, 1); // kty: OKP
@@ -181,11 +124,6 @@ public final class CoseTestVectors {
     return cose;
   }
 
-  // ---------------------------------------------------------------------------------------------
-  // Regression vectors — see the class comment.
-  // ---------------------------------------------------------------------------------------------
-
-  /** A COSE EC2 public key and the SPKI encoding a correct decoder must produce for it. */
   public static final class Vector {
     private final int algorithm;
     private final int curve;
@@ -220,7 +158,7 @@ public final class CoseTestVectors {
     }
   }
 
-  /** SECP256R1, x begins 0xFF 0x9F: the leading byte is redundant and gets truncated away. */
+  // SECP256R1 vector with redundant leading 0xFF in x
   public static final Vector ES256_TRUNCATING_X =
       new Vector(
           -7,
@@ -230,7 +168,7 @@ public final class CoseTestVectors {
           "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE_59KoQLvD_cz6fjE5ebfEUWW1slK2BrCN7DvnvAE7oEji3v7O-fJ"
               + "vhr1V2Y0OgxwIv6Tub-aRNKmlM73kA2_zg");
 
-  /** SECP256R1, y begins 0xFF 0xA0: x and y are decoded separately, so both need covering. */
+  // SECP256R1 vector with redundant leading 0xFF in y
   public static final Vector ES256_TRUNCATING_Y =
       new Vector(
           -7,
@@ -240,11 +178,7 @@ public final class CoseTestVectors {
           "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7cQlT54GElacS-hXx9CaYM1FVehnkJx2Rxyy7UIM2Bn_oGsGhFwx"
               + "7JuBvEyhIu0WsIP36dJjvEdehkk3Fxzs_g");
 
-  /**
-   * SECP384R1, x begins 0xFF 0xCF: shows the defect and the fix are independent of coordinate
-   * width. A P-384 y case would add no new path, being the same curve as this vector and the same
-   * coordinate role as {@link #ES256_TRUNCATING_Y}.
-   */
+  // SECP384R1 vector verifying multi-width coordinate truncation
   public static final Vector ES384_TRUNCATING_X =
       new Vector(
           -35,
@@ -256,12 +190,7 @@ public final class CoseTestVectors {
           "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE_8-3VaXlHA6rtYogYzvhIeJzQQM086LboNXkfpwwpyYFdQzZzPI0Qv5s"
               + "BDlLd2eoU1AF7BpO1MEurBMYyppemzXXYgwXBbQyGqAcTRE3UoFNGQuEYqB0Lz4xJBivE9Uu");
 
-  /**
-   * Boundary case. SECP256R1 with x beginning 0xFF 0x22: the leading 0xFF is <em>not</em>
-   * redundant, so the minimal form keeps its width and this decodes correctly even under signed
-   * decoding. It is here so that a fix for the vectors above cannot regress it by stripping or
-   * padding unconditionally.
-   */
+  // Boundary check: non-redundant leading 0xFF that must not be stripped
   public static final Vector ES256_LEADING_FF =
       new Vector(
           -7,
@@ -272,12 +201,8 @@ public final class CoseTestVectors {
               + "SqDbKTSz30qRv7PyIcmGtK3QJmVyCzIQIw");
 
   /**
-   * Asserts that {@link Cose#getPublicKey} round-trips the vector's coordinates exactly: the affine
-   * coordinates of the returned key must equal the unsigned values that went in, and the SPKI
-   * encoding must match the independently computed expectation.
-   *
-   * <p>Asserting on the affine coordinates as well as the encoding matters, because a provider that
-   * accepts an off-curve point fails silently rather than throwing.
+   * Asserts that affine coordinates and SPKI encodings round-trip cleanly without silent provider
+   * failures.
    */
   public static void assertRoundTrip(Vector vector)
       throws InvalidKeySpecException, NoSuchAlgorithmException {


### PR DESCRIPTION
`Cose.getPublicKey` read the EC2 `x`/`y` coordinates with the signed `BigInteger(byte[])` constructor, but COSE encodes them as fixed-width *unsigned* big-endian integers (RFC 9053 7.1.1). When a coordinate starts `0xFF` and the next byte has its high bit set, the minimal two's complement form is a byte shorter and `ByteUtils.intToLength` left-pads `0x00` over it — a different key, for roughly 1 EC credential in 256.

Fix is one line: `new BigInteger(1, x)`, matching what the rest of the SDK already does.

The resulting point is off the curve, and providers disagree on how bad that is — SunEC returns a silently wrong key, Conscrypt throws. Tests assert affine `x`/`y` *and* the SPKI so both modes fail loudly. Vectors live in `CoseTestVectors`, shared by the JVM test and a new `CoseInstrumentedTest`; the second commit moves the pre-existing standard keys there too, de-duplicating `GuardedLoggingCallSitesTest`.

Verified failing-before / passing-after on the JVM and on three devices spanning API 21 to 37 — a Nexus 4 (Android 5.0.1), a Pixel 8 (Android 16) and a Pixel 6 (Android 17). SECP521R1 is unaffected — its 66-byte coordinates always begin `0x00`/`0x01`.
