### PR TITLE
test: make silent test-run failures visible

### DIFF
--- a/testing-android/README.adoc
+++ b/testing-android/README.adoc
@@ -3,7 +3,7 @@
 This module contains tests for execution on a physical device and with YubiKey connected via USB or NFC. The test runs need a presence of someone who can tap the key when needed and therefore are these tests suitable only for local execution.
 
 === Recommended setup
-1. A physical Android device running API 19+
+1. A physical Android device running API 21+
 2. YubiKey
 3. (optional) OTG cable for connecting a YubiKey
 ** modern devices with USB-C connector will work with USB-C YubiKeys directly

--- a/testing-android/src/main/java/com/yubico/yubikit/framework/YkInstrumentedTests.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/framework/YkInstrumentedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Yubico.
+ * Copyright (C) 2022-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,17 +24,37 @@ import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyDevice;
 import org.jspecify.annotations.Nullable;
 import org.junit.After;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class YkInstrumentedTests {
+
+  private static final Logger logger = LoggerFactory.getLogger(YkInstrumentedTests.class);
 
   private @Nullable TestActivity activity;
   protected @Nullable YubiKeyDevice device = null;
   protected @Nullable UsbPid usbPid = null;
 
   @Rule public final TestName name = new TestName();
+
+  /**
+   * Logs why a test was skipped; AGP reports an assumption failure as a bare {@code <skipped/>}
+   * with no message, so a whole suite skipping reads like a suite that ran.
+   */
+  @Rule
+  public final TestWatcher skipReasonLogger =
+      new TestWatcher() {
+        @Override
+        protected void skipped(AssumptionViolatedException e, Description description) {
+          logger.error("SKIPPED {}: {}", description.getMethodName(), e.getMessage());
+        }
+      };
 
   @Rule
   public final ActivityScenarioRule<TestActivity> scenarioRule =

--- a/testing/src/main/java/com/yubico/yubikit/AllowList.java
+++ b/testing/src/main/java/com/yubico/yubikit/AllowList.java
@@ -63,8 +63,11 @@ public class AllowList {
   public void verify(YubiKeyDevice connectedDevice, @Nullable UsbPid pid) {
     Integer serialNumber = getDeviceSerialNumber(connectedDevice, pid);
     if (pid != UsbPid.OTHER && !isDeviceAllowed(serialNumber)) {
-      logger.error("{}", allowListProvider.onNotAllowedErrorMessage(serialNumber));
-      System.exit(-1);
+      String message = allowListProvider.onNotAllowedErrorMessage(serialNumber);
+      logger.error("{}", message);
+      // Throw rather than System.exit: an exit kills the process, so the run emits no report at
+      // all. Safe either way - verify() runs before any session is opened on the key.
+      throw new AssertionError(message);
     }
   }
 


### PR DESCRIPTION
A test run that fails silently is indistinguishable from one that passed. Two ways that happened, both found while getting the instrumented tests running on low API levels.

`AllowList.verify()` called `System.exit` when a non-allow-listed key was tapped. That kills the instrumentation process, so the run emits no XML report at all and the reason survives only in logcat. It now throws `AssertionError`, which the report records as a normal failure carrying the message. Safe either way, because `verify()` runs before any session is opened on the key.

`YkInstrumentedTests` gains a `TestWatcher` rule that logs why a test was skipped. AGP writes an assumption failure to the XML report as a bare `<skipped/>` with no message, so a whole suite skipping reads like a suite that ran. This is what made "everything SKIPPED because a Security Key was tapped" so hard to spot.

Also corrects `API 19+` to `API 21+` in the README; the 19 was already wrong.

The `System.exit` path was hit again independently while verifying unrelated work on a Nexus 4: a test that needs no YubiKey died mid-run with no report, and the cause was only recoverable from logcat. This change turns that into a readable failure.