### PR TITLE
fix(testing): stop AllowList exiting the test process

### DIFF
--- a/testing-android/README.adoc
+++ b/testing-android/README.adoc
@@ -36,6 +36,8 @@ Example `allowed_serials.csv` content:
 
 The test framework will now only run on the YubiKeys specified in this file.
 
+If the file is missing, or the connected key is not listed, each test that needs a YubiKey fails with an assertion naming the reason and the run still produces a report. Tests that need no YubiKey are unaffected.
+
 === Running the tests
 1. Make sure that the YubiKey you are using is meant for testing. Don't proceed with the tests if unsure.
  Running the instrumented tests will: change PIN, PUK, management key and overwrite stored certificates in the PIV application

--- a/testing-android/src/main/java/com/yubico/yubikit/TestActivity.java
+++ b/testing-android/src/main/java/com/yubico/yubikit/TestActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 Yubico.
+ * Copyright (C) 2022-2026 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,10 @@ public class TestActivity extends AppCompatActivity {
 
   private static final Logger logger = LoggerFactory.getLogger(TestActivity.class);
 
-  private static final AllowList allowList = new AllowList(new AndroidAllowListProvider());
+  /** Built on first use, so launching the activity does not read allowed_serials.csv. */
+  private static final class AllowListHolder {
+    static final AllowList INSTANCE = new AllowList(new AndroidAllowListProvider());
+  }
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -138,7 +141,7 @@ public class TestActivity extends AppCompatActivity {
             ? ((UsbYubiKeyDevice) connectedDevice).getPid()
             : null;
 
-    allowList.verify(connectedDevice, pid);
+    AllowListHolder.INSTANCE.verify(connectedDevice, pid);
 
     runOnUiThread(
         () -> {

--- a/testing-desktop/README.adoc
+++ b/testing-desktop/README.adoc
@@ -28,6 +28,8 @@ Example `allowed_serials.csv` content:
 
 The test framework will now only run on the YubiKeys specified in this file.
 
+If the file is missing, or the connected key is not listed, each test that needs a YubiKey fails with an assertion naming the reason and the run still produces a report.
+
 === Device selection when multiple YubiKeys are connected
 
 When multiple YubiKeys are plugged in, the test framework requires you to specify which device to use.

--- a/testing/src/main/java/com/yubico/yubikit/AllowList.java
+++ b/testing/src/main/java/com/yubico/yubikit/AllowList.java
@@ -50,23 +50,25 @@ public class AllowList {
     String onNotAllowedErrorMessage(Integer serialNumber);
   }
 
+  // An empty list is not fatal here; only verify() needs the serials.
   public AllowList(AllowListProvider allowListProvider) {
     this.allowListProvider = allowListProvider;
     this.allowedSerials = allowListProvider.getList();
-    if (allowedSerials.isEmpty()) {
-      logger.error("{}", allowListProvider.onInvalidInputErrorMessage());
-      System.exit(-1);
-    }
   }
 
   // verify that the device is in the allow-list
   public void verify(YubiKeyDevice connectedDevice, @Nullable UsbPid pid) {
+    // Throw, never System.exit: an exit kills the process and the run emits no report.
+    if (allowedSerials.isEmpty()) {
+      String message = allowListProvider.onInvalidInputErrorMessage();
+      logger.error("{}", message);
+      throw new AssertionError(message);
+    }
+
     Integer serialNumber = getDeviceSerialNumber(connectedDevice, pid);
     if (pid != UsbPid.OTHER && !isDeviceAllowed(serialNumber)) {
       String message = allowListProvider.onNotAllowedErrorMessage(serialNumber);
       logger.error("{}", message);
-      // Throw rather than System.exit: an exit kills the process, so the run emits no report at
-      // all. Safe either way - verify() runs before any session is opened on the key.
       throw new AssertionError(message);
     }
   }

--- a/testing/src/test/java/com/yubico/yubikit/AllowListTest.java
+++ b/testing/src/test/java/com/yubico/yubikit/AllowListTest.java
@@ -23,6 +23,7 @@ import com.yubico.yubikit.core.Transport;
 import com.yubico.yubikit.core.UsbPid;
 import com.yubico.yubikit.core.YubiKeyConnection;
 import com.yubico.yubikit.core.YubiKeyDevice;
+import com.yubico.yubikit.core.smartcard.SmartCardConnection;
 import com.yubico.yubikit.core.util.Callback;
 import com.yubico.yubikit.core.util.Result;
 import java.io.IOException;
@@ -59,6 +60,60 @@ public class AllowListTest {
     @Override
     public String onNotAllowedErrorMessage(Integer serialNumber) {
       return "not allowed: " + serialNumber;
+    }
+  }
+
+  /**
+   * Answers "file not found" to every APDU, so no applet can be selected. That is how a FIDO-only
+   * Security Key presents over NFC, and it makes readInfo give up with an IllegalArgumentException,
+   * which AllowList maps to serial number 0.
+   */
+  private static class SerialLessNfcConnection implements SmartCardConnection {
+    @Override
+    public byte[] sendAndReceive(byte[] apdu) {
+      return new byte[] {0x6a, (byte) 0x82}; // SW_FILE_NOT_FOUND
+    }
+
+    @Override
+    public Transport getTransport() {
+      return Transport.NFC;
+    }
+
+    @Override
+    public boolean isExtendedLengthApduSupported() {
+      return false;
+    }
+
+    @Override
+    public byte[] getAtr() {
+      return new byte[0];
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  /** A key with no serial number, reachable only over NFC. */
+  private static class SerialLessDevice implements YubiKeyDevice {
+    @Override
+    public Transport getTransport() {
+      return Transport.NFC;
+    }
+
+    @Override
+    public boolean supportsConnection(Class<? extends YubiKeyConnection> connectionType) {
+      return connectionType.isAssignableFrom(SmartCardConnection.class);
+    }
+
+    @Override
+    public <T extends YubiKeyConnection> void requestConnection(
+        Class<T> connectionType, Callback<Result<T, IOException>> callback) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends YubiKeyConnection> T openConnection(Class<T> connectionType) {
+      return connectionType.cast(new SerialLessNfcConnection());
     }
   }
 
@@ -123,9 +178,28 @@ public class AllowListTest {
     assertEquals(NO_LIST, error.getMessage());
   }
 
-  /** An unreadable serial must fail closed, not be waved through. */
+  /**
+   * A key with no serial number resolves to 0, so 0 is what admits Security Keys. Distinct from a
+   * serial that could not be read at all, which resolves to null - see {@link
+   * #unreadableSerialIsRejected()}.
+   */
   @Test
-  public void unknownSerialIsRejected() {
+  public void serialLessKeyIsAllowedByZeroEntry() {
+    allowListOf(0).verify(new SerialLessDevice(), null);
+  }
+
+  @Test
+  public void serialLessKeyIsRejectedWithoutZeroEntry() {
+    AssertionError error =
+        assertThrows(
+            AssertionError.class, () -> allowListOf(1234567).verify(new SerialLessDevice(), null));
+
+    assertEquals("not allowed: 0", error.getMessage());
+  }
+
+  /** A serial that could not be read at all must fail closed, not be waved through. */
+  @Test
+  public void unreadableSerialIsRejected() {
     AssertionError error =
         assertThrows(
             AssertionError.class,

--- a/testing/src/test/java/com/yubico/yubikit/AllowListTest.java
+++ b/testing/src/test/java/com/yubico/yubikit/AllowListTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.yubico.yubikit.core.Transport;
+import com.yubico.yubikit.core.UsbPid;
+import com.yubico.yubikit.core.YubiKeyConnection;
+import com.yubico.yubikit.core.YubiKeyDevice;
+import com.yubico.yubikit.core.util.Callback;
+import com.yubico.yubikit.core.util.Result;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Covers the contract that decides whether a YubiKey may be used by the integration tests. A
+ * regression here either bricks a key that should have been rejected, or kills the test process.
+ */
+public class AllowListTest {
+
+  private static final String NO_LIST = "no allow list";
+
+  private static class FakeProvider implements AllowList.AllowListProvider {
+    private final List<Integer> serials;
+
+    FakeProvider(List<Integer> serials) {
+      this.serials = serials;
+    }
+
+    @Override
+    public List<Integer> getList() {
+      return serials;
+    }
+
+    @Override
+    public String onInvalidInputErrorMessage() {
+      return NO_LIST;
+    }
+
+    @Override
+    public String onNotAllowedErrorMessage(Integer serialNumber) {
+      return "not allowed: " + serialNumber;
+    }
+  }
+
+  /** Supports no connection type, so the serial number cannot be read and resolves to null. */
+  private static class UnreadableDevice implements YubiKeyDevice {
+    @Override
+    public Transport getTransport() {
+      return Transport.USB;
+    }
+
+    @Override
+    public boolean supportsConnection(Class<? extends YubiKeyConnection> connectionType) {
+      return false;
+    }
+
+    @Override
+    public <T extends YubiKeyConnection> void requestConnection(
+        Class<T> connectionType, Callback<Result<T, IOException>> callback) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends YubiKeyConnection> T openConnection(Class<T> connectionType) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static AllowList allowListOf(Integer... serials) {
+    return new AllowList(new FakeProvider(Arrays.asList(serials)));
+  }
+
+  private static AllowList emptyAllowList() {
+    return new AllowList(new FakeProvider(Collections.emptyList()));
+  }
+
+  /** The whole point of deferring the check: a missing file must not stop construction. */
+  @Test
+  public void constructionSucceedsWithNoSerials() {
+    emptyAllowList();
+  }
+
+  @Test
+  public void emptyListIsReportedAsMissingConfiguration() {
+    AssertionError error =
+        assertThrows(
+            AssertionError.class, () -> emptyAllowList().verify(new UnreadableDevice(), null));
+
+    assertEquals(NO_LIST, error.getMessage());
+  }
+
+  /**
+   * The serial check below deliberately skips UsbPid.OTHER, so the empty-list check has to be
+   * unconditional or a missing allow list would silently admit those devices.
+   */
+  @Test
+  public void emptyListIsRejectedEvenForOtherPid() {
+    AssertionError error =
+        assertThrows(
+            AssertionError.class,
+            () -> emptyAllowList().verify(new UnreadableDevice(), UsbPid.OTHER));
+
+    assertEquals(NO_LIST, error.getMessage());
+  }
+
+  /** An unreadable serial must fail closed, not be waved through. */
+  @Test
+  public void unknownSerialIsRejected() {
+    AssertionError error =
+        assertThrows(
+            AssertionError.class,
+            () -> allowListOf(1234567).verify(new UnreadableDevice(), UsbPid.YK4_OTP_FIDO_CCID));
+
+    assertEquals("not allowed: null", error.getMessage());
+  }
+
+  /** With a populated list, UsbPid.OTHER bypasses the serial check, as before. */
+  @Test
+  public void otherPidBypassesSerialCheckWhenListIsPopulated() {
+    allowListOf(1234567).verify(new UnreadableDevice(), UsbPid.OTHER);
+  }
+}


### PR DESCRIPTION
`TestActivity` held the `AllowList` in a `static final` field, so the list was read during class initialization. With no `allowed_serials.csv` the list came back empty and the constructor called `System.exit(-1)`, killing the process before `onCreate` ran: no report, reason only in logcat. A test needing no YubiKey died on a check that only matters once a YubiKey is present.

The empty-list check moves from the constructor into `verify()`, where the list is actually needed, and throws instead of exiting. It stays unconditional there on purpose: the serial check below deliberately skips `UsbPid.OTHER`, so folding the two together would let a missing allow list silently admit those devices. The `AllowList` is now built through a holder, so launching the activity no longer reads the file or touches the instrumentation registry.

`testing-desktop` has the same eager static; fixing the shared `AllowList` covers it.

Adds five JVM tests in a new `testing/src/test` source set, covering construction with no serials, both reject paths, and the `UsbPid.OTHER` bypass. Verified they have teeth: replacing the empty-list guard with `if (false)` fails exactly the two tests asserting it.

Both READMEs gain a line on what happens when the file is missing or the key is not listed — previously undocumented.

Verified on a Pixel 8 (Android 16) and a Nexus 4 (API 21). With `allowed_serials.csv` removed, a test that launches `TestActivity` now passes where it previously killed the run. With a real key connected, all three paths were exercised: missing file and unlisted serial each fail with an actionable assertion and a full report, and an allowed key passes through and the tests run.

Note: the unlisted-serial path could only be confirmed by temporarily raising `minSdk` to 24. At `minSdk 21` the serial read dies first on `AbstractMethodError` from `logger.atTrace()`, so over USB the allow list currently cannot reject a key at all — it crashes before deciding. That is tracked separately as the SLF4J fluent-API fix.