### PR TITLE
fix(testing): unblock API 21 instrumented tests

### DIFF
--- a/testing-android/README.adoc
+++ b/testing-android/README.adoc
@@ -49,3 +49,11 @@ If the file is missing, or the connected key is not listed, each test that needs
 It is also possible to run the tests from commandline by executing following command after the device is connected through adb:
 
   ./gradlew testing-android:connectedAndroidTest
+
+=== Tests that need no YubiKey
+A few instrumented tests exercise the harness itself rather than a key, and are collected in the `KeylessDeviceTests` suite. They need an Android device but no YubiKey and no `allowed_serials.csv`, so they run unattended:
+
+  ./gradlew testing-android:connectedAndroidTest \
+    -Pandroid.testInstrumentationRunnerArguments.class=com.yubico.yubikit.KeylessDeviceTests
+
+The suite is deliberately separate from `DeviceTests`, whose members all block waiting for a key. Add a test to it only if it needs no YubiKey.

--- a/testing-android/build.gradle.kts
+++ b/testing-android/build.gradle.kts
@@ -54,20 +54,27 @@ android {
 }
 
 dependencies {
+    // The SDK modules under test.
     api(project(":android"))
     api(project(":fido"))
     api(project(":piv"))
     api(project(":testing"))
 
+    // Backports the java.* APIs logback-android needs at minSdk 21; required by
+    // isCoreLibraryDesugaringEnabled above.
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
+    // Theme parent, and TestActivity extends AppCompatActivity. Deliberately not
+    // Material: its FocusRingDrawable aborts dex2oat on ART 5.0, so the test APK
+    // will not install on API 21.
+    implementation(libs.androidx.appcompat)
+
+    // Instrumentation harness: AndroidJUnit4, ActivityScenario, the test runner.
     implementation(libs.androidx.junit)
     implementation(libs.androidx.test.core)
-    implementation(libs.androidx.test.rules)
     implementation(libs.androidx.test.runner)
 
-    implementation(libs.material)
-
+    // SLF4J binding. The SDK modules expose slf4j-api only, so tests pick one.
     implementation(libs.logback.android)
 }
 

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/KeylessDeviceTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/KeylessDeviceTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Instrumented tests that need no YubiKey, and so can run unattended.
+ *
+ * <p>Kept out of {@link DeviceTests} on purpose. Every member of that suite blocks in {@code
+ * TestActivity.awaitSession} waiting for a key, so mixing these in would tie them to a hardware run
+ * - and an early attempt to do so wedged the hardware tests that followed. Running them on every
+ * push is a job for CI, which needs no key and cannot forget.
+ *
+ * <p>Add a test here only if it needs no YubiKey. Keep the suite non-empty: a suite with no classes
+ * reports zero tests and still passes, which is the silent success this harness exists to avoid.
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({ThemeInflationTests.class})
+public class KeylessDeviceTests {}

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/ThemeInflationTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/ThemeInflationTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.util.TypedValue;
+import androidx.core.content.ContextCompat;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.yubico.yubikit.testing.R;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Launches {@link TestActivity} and asserts its layout and theme resolve, without needing a
+ * YubiKey. Guards the switch from Theme.MaterialComponents to Theme.AppCompat: an attribute that
+ * stops resolving surfaces only at runtime, and every other instrumented test blocks waiting for a
+ * key before it would ever notice.
+ *
+ * <p>Deliberately does not require the RESUMED state. Inflation and theme resolution both complete
+ * in {@code onCreate}, while RESUMED is unreachable on a locked or dozing device - the normal
+ * condition for an unattended run with the phone left sitting on a key.
+ */
+@RunWith(AndroidJUnit4.class)
+public class ThemeInflationTests {
+
+  @Test
+  public void activityInflatesUnderAppCompatTheme() {
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            assertNotNull("statusText did not inflate", activity.findViewById(R.id.statusText));
+            assertNotNull("progressBar did not inflate", activity.findViewById(R.id.progressBar));
+            assertNotNull("bottomText did not inflate", activity.findViewById(R.id.bottomText));
+          });
+    }
+  }
+
+  @Test
+  public void themeSuppliesYubicoColors() {
+    try (ActivityScenario<TestActivity> scenario = ActivityScenario.launch(TestActivity.class)) {
+      scenario.onActivity(
+          activity -> {
+            assertEquals(
+                "colorPrimary is not yubico_green",
+                ContextCompat.getColor(activity, R.color.yubico_green),
+                resolveThemeColor(activity, androidx.appcompat.R.attr.colorPrimary));
+            assertEquals(
+                "colorAccent is not accent",
+                ContextCompat.getColor(activity, R.color.accent),
+                resolveThemeColor(activity, androidx.appcompat.R.attr.colorAccent));
+          });
+    }
+  }
+
+  private static int resolveThemeColor(TestActivity activity, int attr) {
+    TypedValue value = new TypedValue();
+    assertTrue(
+        "theme attribute "
+            + activity.getResources().getResourceEntryName(attr)
+            + " does not resolve",
+        activity.getTheme().resolveAttribute(attr, value, true));
+    return value.data;
+  }
+}

--- a/testing-android/src/main/res/values/themes.xml
+++ b/testing-android/src/main/res/values/themes.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="YubiKitTesterTheme" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <!--
+        AppCompat rather than MaterialComponents on purpose. The harness layout uses only
+        framework widgets and TextAppearance.AppCompat styles, so Material bought nothing - but
+        its FocusRingDrawable aborts dex2oat on ART 5.0 (compiler_driver.cc:1181 "Check failed:
+        !method->IsAbstract()"), so the test APK could not be installed on API 21 at all.
+    -->
+    <style name="YubiKitTesterTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <item name="colorPrimary">@color/yubico_green</item>
-        <item name="colorPrimaryVariant">@color/yubico_green_dark</item>
-        <item name="colorOnPrimary">@android:color/white</item>
-        <item name="colorSecondary">@color/accent</item>
-        <item name="colorSecondaryVariant">@color/accent</item>
-        <item name="colorOnSecondary">@android:color/white</item>
-        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
+        <item name="colorPrimaryDark">@color/yubico_green_dark</item>
+        <item name="colorAccent">@color/accent</item>
+        <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryDark</item>
     </style>
 </resources>


### PR DESCRIPTION
The androidTest APK could not be installed on API 21 at all: `dex2oat` aborted on Material Components' `FocusRingDrawable`, which ART 5.0 cannot compile, giving `INSTALL_FAILED_DEXOPT`.

Material was used only for the theme parent, so drop it for AppCompat and reparent `YubiKitTesterTheme`. `ThemeInflationTests` guards the swap.

Adds `KeylessDeviceTests` for instrumented tests needing no YubiKey. Kept out of `DeviceTests`, whose members all block waiting for a key — merging the two wedged the hardware run. Non-empty on purpose: a zero-class suite reports no tests and still passes.

Also drops `androidx.test.rules` (imported nowhere) and comments the remaining dependencies. README documents the new suite.

Verified with `allowed_serials.csv` absent on a Nexus 4 (API 21), emulators at API 22 and 23, and a Pixel 8 (Android 16).