### PR TITLE
fix: replace SLF4J fluent API with guarded calls

### DIFF
--- a/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcSmartCardConnection.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/nfc/NfcSmartCardConnection.java
@@ -55,13 +55,13 @@ public class NfcSmartCardConnection implements SmartCardConnection {
 
   @Override
   public byte[] sendAndReceive(byte[] apdu) throws IOException {
-    logger.atTrace().setMessage("sent: {}").addArgument(() -> StringUtils.bytesToHex(apdu)).log();
+    if (logger.isTraceEnabled()) {
+      logger.trace("sent: {}", StringUtils.bytesToHex(apdu));
+    }
     byte[] received = card.transceive(apdu);
-    logger
-        .atTrace()
-        .setMessage("received: {}")
-        .addArgument(() -> StringUtils.bytesToHex(received))
-        .log();
+    if (logger.isTraceEnabled()) {
+      logger.trace("received: {}", StringUtils.bytesToHex(received));
+    }
     return received;
   }
 

--- a/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnection.java
+++ b/android/src/main/java/com/yubico/yubikit/android/transport/usb/connection/UsbSmartCardConnection.java
@@ -170,14 +170,12 @@ public class UsbSmartCardConnection extends UsbYubiKeyConnection implements Smar
           connection.bulkTransfer(
               endpointOut, bufferOut, bytesSent, bufferOut.length - bytesSent, TIMEOUT);
       if (bytesSentPackage > 0) {
-        final int sentOffset = bytesSent;
-        final int sentLength = bytesSentPackage;
-        logger
-            .atTrace()
-            .setMessage("{} bytes sent over ccid: {}")
-            .addArgument(bytesSentPackage)
-            .addArgument(() -> StringUtils.bytesToHex(bufferOut, sentOffset, sentLength))
-            .log();
+        if (logger.isTraceEnabled()) {
+          logger.trace(
+              "{} bytes sent over ccid: {}",
+              bytesSentPackage,
+              StringUtils.bytesToHex(bufferOut, bytesSent, bytesSentPackage));
+        }
         bytesSent += bytesSentPackage;
       } else if (bytesSentPackage < 0) {
         throw new IOException("Failed to send " + (bufferOut.length - bytesSent) + " bytes");
@@ -200,13 +198,10 @@ public class UsbSmartCardConnection extends UsbYubiKeyConnection implements Smar
     do {
       bytesRead = connection.bulkTransfer(endpointIn, bufferRead, bufferRead.length, TIMEOUT);
       if (bytesRead > 0) {
-        final int readLength = bytesRead;
-        logger
-            .atTrace()
-            .setMessage("{} bytes received: {}")
-            .addArgument(bytesRead)
-            .addArgument(() -> StringUtils.bytesToHex(bufferRead, 0, readLength))
-            .log();
+        if (logger.isTraceEnabled()) {
+          logger.trace(
+              "{} bytes received: {}", bytesRead, StringUtils.bytesToHex(bufferRead, 0, bytesRead));
+        }
 
         if (receivedExpectedPrefix) {
           stream.write(bufferRead, 0, bytesRead);

--- a/build-logic/src/main/kotlin/CheckNoFluentSlf4jTask.kt
+++ b/build-logic/src/main/kotlin/CheckNoFluentSlf4jTask.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Fails the build on any use of the SLF4J 2.x fluent logging API.
+ *
+ * See [FluentSlf4jDetector] for why the fluent API is banned and what to write instead.
+ */
+@CacheableTask
+abstract class CheckNoFluentSlf4jTask : DefaultTask() {
+
+    @get:InputFiles
+    @get:SkipWhenEmpty
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sources: ConfigurableFileCollection
+
+    /** Written on success so Gradle can skip the task when nothing changed. */
+    @get:OutputFile
+    abstract val report: RegularFileProperty
+
+    @TaskAction
+    fun check() {
+        val uses = FluentSlf4jDetector.scan(sources.files.sortedBy { it.path })
+        if (uses.isNotEmpty()) {
+            throw GradleException(FluentSlf4jDetector.describe(uses))
+        }
+        val output = report.get().asFile
+        output.parentFile.mkdirs()
+        output.writeText("Scanned ${sources.files.size} file(s), no fluent SLF4J calls found.\n")
+    }
+}

--- a/build-logic/src/main/kotlin/FluentSlf4jDetector.kt
+++ b/build-logic/src/main/kotlin/FluentSlf4jDetector.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File
+
+/** A single use of the SLF4J 2.x fluent logging API. */
+data class FluentSlf4jUse(val file: File, val line: Int, val text: String) {
+    override fun toString() = "${file.path}:$line: ${text.trim()}"
+}
+
+/**
+ * Finds uses of the SLF4J 2.x fluent logging API (`logger.atDebug()`, `atTrace()`, ...).
+ *
+ * Those calls are unusable in any code that D8 may desugar. `Logger.atDebug()` and friends are
+ * interface *default* methods, and logback-android's prebuilt `ch.qos.logback.classic.Logger`
+ * implements none of them. When the consuming app declares `minSdk < 24`, D8 emits the
+ * `org/slf4j/Logger$-CC` companion and leaves the call site as `invoke-interface`, but injects no
+ * forwarder into the prebuilt class - so dispatch lands on a bogus vtable slot. That surfaces as
+ * `AbstractMethodError` on a modern device and as a native SIGSEGV on API 21, which kills the
+ * process outright. The device's own API level is irrelevant; only the consumer's `minSdk` matters.
+ *
+ * The supported shape is an `isXEnabled()` guard around a plain call, which uses no default methods
+ * and additionally defers *eagerly* evaluated arguments - something `addArgument(Supplier)` cannot
+ * do:
+ * ```
+ * if (logger.isTraceEnabled()) {
+ *   logger.trace("sent: {}", StringUtils.bytesToHex(apdu));
+ * }
+ * ```
+ */
+object FluentSlf4jDetector {
+
+    /**
+     * Opt-out marker. A file containing this token anywhere is skipped entirely.
+     *
+     * Reserved for code whose purpose is to demonstrate the defect - `LoggingSmokeTests` has to
+     * call the fluent API to show that it still crashes. Production code must not use it; the
+     * remedy there is the guard, not a marker.
+     */
+    const val ALLOW_MARKER = "SLF4J-FLUENT-ALLOWED"
+
+    /** `.atTrace(`, `.atDebug(`, ... including `.atLevel(`, allowing whitespace before the paren. */
+    private val FLUENT_CALL = Regex("""\.at(Trace|Debug|Info|Warn|Error|Level)\s*\(""")
+
+    /**
+     * Line comments and Javadoc/block-comment bodies. Documenting the banned shape - as this
+     * detector's own KDoc does - must not trip the check.
+     */
+    private val COMMENT_LINE = Regex("""^\s*(//|/\*|\*)""")
+
+    fun scan(file: File): List<FluentSlf4jUse> {
+        val lines = file.readLines()
+        if (lines.any { it.contains(ALLOW_MARKER) }) {
+            return emptyList()
+        }
+        return lines.mapIndexedNotNull { index, line ->
+            if (COMMENT_LINE.containsMatchIn(line) || !FLUENT_CALL.containsMatchIn(line)) {
+                null
+            } else {
+                FluentSlf4jUse(file, index + 1, line)
+            }
+        }
+    }
+
+    fun scan(files: Iterable<File>): List<FluentSlf4jUse> = files.flatMap { scan(it) }
+
+    /** The failure message for [uses], which must not be empty. */
+    fun describe(uses: List<FluentSlf4jUse>): String =
+        buildString {
+            appendLine("Found ${uses.size} use(s) of the SLF4J fluent logging API:")
+            uses.forEach { appendLine("  $it") }
+            appendLine()
+            appendLine("The fluent API breaks whenever the consuming app declares minSdk < 24:")
+            appendLine("  AbstractMethodError on a modern device, native SIGSEGV on API 21.")
+            appendLine("Use an isXEnabled() guard around a plain call instead:")
+            appendLine("  if (logger.isTraceEnabled()) {")
+            appendLine("    logger.trace(\"sent: {}\", StringUtils.bytesToHex(apdu));")
+            appendLine("  }")
+        }
+}

--- a/build-logic/src/main/kotlin/yubikit-logging.gradle.kts
+++ b/build-logic/src/main/kotlin/yubikit-logging.gradle.kts
@@ -19,3 +19,16 @@ val libs: VersionCatalog = extensions.getByType<VersionCatalogsExtension>().name
 dependencies {
     add("api", libs.findLibrary("slf4j-api").get())
 }
+
+// slf4j-api is exposed on the `api` configuration above, so the fluent logging API is in reach of
+// every module this plugin touches. It cannot be used - see FluentSlf4jDetector - so guard against
+// it here, where the dependency is introduced.
+val checkNoFluentSlf4j =
+    tasks.register<CheckNoFluentSlf4jTask>("checkNoFluentSlf4j") {
+        group = "verification"
+        description = "Fails on uses of the SLF4J fluent logging API, which D8 cannot desugar."
+        sources.from(fileTree("src") { include("**/*.java", "**/*.kt") })
+        report.set(layout.buildDirectory.file("reports/logging/no-fluent-slf4j.txt"))
+    }
+
+tasks.matching { it.name == "check" }.configureEach { dependsOn(checkNoFluentSlf4j) }

--- a/build-logic/src/test/kotlin/FluentSlf4jDetectorTest.kt
+++ b/build-logic/src/test/kotlin/FluentSlf4jDetectorTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class FluentSlf4jDetectorTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun javaFile(name: String, body: String): File =
+        tmp.newFile(name).apply { writeText(body.trimIndent()) }
+
+    @Test
+    fun `flags each fluent level`() {
+        val file =
+            javaFile(
+                "Levels.java",
+                """
+                class Levels {
+                  void m() {
+                    logger.atTrace().log("a");
+                    logger.atDebug().log("b");
+                    logger.atInfo().log("c");
+                    logger.atWarn().log("d");
+                    logger.atError().log("e");
+                    logger.atLevel(Level.DEBUG).log("f");
+                  }
+                }
+                """,
+            )
+
+        val uses = FluentSlf4jDetector.scan(file)
+
+        assertEquals(6, uses.size)
+        assertEquals(listOf(3, 4, 5, 6, 7, 8), uses.map { it.line })
+    }
+
+    @Test
+    fun `flags a chain broken across lines`() {
+        val file =
+            javaFile(
+                "Chain.java",
+                """
+                class Chain {
+                  void m() {
+                    logger
+                        .atTrace()
+                        .setMessage("sent: {}")
+                        .addArgument(() -> hex(apdu))
+                        .log();
+                  }
+                }
+                """,
+            )
+
+        val uses = FluentSlf4jDetector.scan(file)
+
+        assertEquals(1, uses.size)
+        assertEquals(4, uses.single().line)
+    }
+
+    @Test
+    fun `allows the guarded plain call`() {
+        val file =
+            javaFile(
+                "Guarded.java",
+                """
+                class Guarded {
+                  void m() {
+                    if (logger.isTraceEnabled()) {
+                      logger.trace("sent: {}", hex(apdu));
+                    }
+                    logger.debug("alg: {}", alg);
+                  }
+                }
+                """,
+            )
+
+        assertEquals(emptyList<FluentSlf4jUse>(), FluentSlf4jDetector.scan(file))
+    }
+
+    @Test
+    fun `ignores comments that document the banned shape`() {
+        val file =
+            javaFile(
+                "Documented.java",
+                """
+                /**
+                 * Do not write logger.atDebug().log("x") here.
+                 * <p>Use the guard instead.
+                 */
+                class Documented {
+                  // logger.atTrace().log("old code");
+                  /* logger.atWarn().log("also old"); */
+                  void m() {}
+                }
+                """,
+            )
+
+        assertEquals(emptyList<FluentSlf4jUse>(), FluentSlf4jDetector.scan(file))
+    }
+
+    @Test
+    fun `does not flag unrelated methods starting with at`() {
+        val file =
+            javaFile(
+                "Unrelated.java",
+                """
+                class Unrelated {
+                  void m() {
+                    list.get(0).attach(x);
+                    buffer.atomicRead();
+                    logger.debug("at debug time: {}", x);
+                  }
+                }
+                """,
+            )
+
+        assertEquals(emptyList<FluentSlf4jUse>(), FluentSlf4jDetector.scan(file))
+    }
+
+    @Test
+    fun `honours the opt-out marker for a file that demonstrates the defect`() {
+        val file =
+            javaFile(
+                "Repro.java",
+                """
+                /** ${FluentSlf4jDetector.ALLOW_MARKER} - demonstrates the crash on purpose. */
+                class Repro {
+                  void m() {
+                    logger.atDebug().log("this must not be flagged");
+                  }
+                }
+                """,
+            )
+
+        assertEquals(emptyList<FluentSlf4jUse>(), FluentSlf4jDetector.scan(file))
+    }
+
+    @Test
+    fun `marker in one file does not exempt another`() {
+        val exempt =
+            javaFile(
+                "Exempt.java",
+                "/** ${FluentSlf4jDetector.ALLOW_MARKER} */ class E { void m() " +
+                    "{ logger.atDebug().log(\"e\"); } }",
+            )
+        val other = javaFile("Other.java", "class O { void m() { logger.atWarn().log(\"o\"); } }")
+
+        val uses = FluentSlf4jDetector.scan(listOf(exempt, other))
+
+        assertEquals(1, uses.size)
+        assertEquals(other, uses.single().file)
+    }
+
+    @Test
+    fun `scans multiple files and reports every use`() {
+        val a = javaFile("A.java", "class A { void m() { logger.atDebug().log(\"a\"); } }")
+        val b = javaFile("B.java", "class B { void m() { logger.trace(\"b\"); } }")
+
+        val uses = FluentSlf4jDetector.scan(listOf(a, b))
+
+        assertEquals(1, uses.size)
+        assertEquals(a, uses.single().file)
+    }
+
+    @Test
+    fun `describe names every offending site and the remedy`() {
+        val file = javaFile("C.java", "class C { void m() { logger.atDebug().log(\"c\"); } }")
+
+        val message = FluentSlf4jDetector.describe(FluentSlf4jDetector.scan(file))
+
+        assertTrue(message, message.contains("C.java:1"))
+        assertTrue(message, message.contains("isTraceEnabled"))
+        assertTrue(message, message.contains("minSdk < 24"))
+    }
+}

--- a/core/src/main/java/com/yubico/yubikit/core/fido/FidoProtocol.java
+++ b/core/src/main/java/com/yubico/yubikit/core/fido/FidoProtocol.java
@@ -102,12 +102,9 @@ public class FidoProtocol implements Closeable {
     do {
       toSend.get(buffer, packet.position(), Math.min(toSend.remaining(), packet.remaining()));
       connection.send(buffer);
-      logger
-          .atTrace()
-          .setMessage("{} bytes sent over fido: {}")
-          .addArgument(buffer.length)
-          .addArgument(() -> StringUtils.bytesToHex(buffer))
-          .log();
+      if (logger.isTraceEnabled()) {
+        logger.trace("{} bytes sent over fido: {}", buffer.length, StringUtils.bytesToHex(buffer));
+      }
       Arrays.fill(buffer, (byte) 0);
       packet.clear();
       packet.putInt(channelId).put((byte) (0x7f & seq++));
@@ -123,20 +120,16 @@ public class FidoProtocol implements Closeable {
         Arrays.fill(buffer, (byte) 0);
         packet.putInt(channelId).put(CTAPHID_CANCEL);
         connection.send(buffer);
-        logger
-            .atTrace()
-            .setMessage("Sent over fido: {}")
-            .addArgument(() -> StringUtils.bytesToHex(buffer))
-            .log();
+        if (logger.isTraceEnabled()) {
+          logger.trace("Sent over fido: {}", StringUtils.bytesToHex(buffer));
+        }
         packet.clear();
       }
 
       connection.receive(buffer);
-      logger
-          .atTrace()
-          .setMessage("Received over fido: {}")
-          .addArgument(() -> StringUtils.bytesToHex(buffer))
-          .log();
+      if (logger.isTraceEnabled()) {
+        logger.trace("Received over fido: {}", StringUtils.bytesToHex(buffer));
+      }
       int responseChannel = packet.getInt();
       if (responseChannel != channelId) {
         throw new IOException(

--- a/core/src/main/java/com/yubico/yubikit/core/otp/OtpProtocol.java
+++ b/core/src/main/java/com/yubico/yubikit/core/otp/OtpProtocol.java
@@ -127,21 +127,17 @@ public class OtpProtocol implements Closeable {
   private byte[] readFeatureReport() throws IOException {
     byte[] bufferRead = new byte[FEATURE_RPT_SIZE];
     connection.receive(bufferRead);
-    logger
-        .atTrace()
-        .setMessage("Read feature report: {}")
-        .addArgument(() -> StringUtils.bytesToHex(bufferRead))
-        .log();
+    if (logger.isTraceEnabled()) {
+      logger.trace("Read feature report: {}", StringUtils.bytesToHex(bufferRead));
+    }
     return bufferRead;
   }
 
   /* Write a single 8 byte feature report */
   private void writeFeatureReport(byte[] buffer) throws IOException {
-    logger
-        .atTrace()
-        .setMessage("Write feature report: {}")
-        .addArgument(() -> StringUtils.bytesToHex(buffer))
-        .log();
+    if (logger.isTraceEnabled()) {
+      logger.trace("Write feature report: {}", StringUtils.bytesToHex(buffer));
+    }
     connection.send(buffer);
   }
 
@@ -175,12 +171,12 @@ public class OtpProtocol implements Closeable {
 
   /* Packs and sends one 70 byte frame */
   private int sendFrame(byte slot, byte[] payload) throws IOException {
-    logger
-        .atTrace()
-        .setMessage("Sending payload over HID to slot {}: {}")
-        .addArgument(() -> String.format("0x%02x", 0xff & slot))
-        .addArgument(() -> StringUtils.bytesToHex(payload))
-        .log();
+    if (logger.isTraceEnabled()) {
+      logger.trace(
+          "Sending payload over HID to slot {}: {}",
+          String.format("0x%02x", 0xff & slot),
+          StringUtils.bytesToHex(payload));
+    }
 
     // Format Frame
     ByteBuffer buf =
@@ -227,12 +223,10 @@ public class OtpProtocol implements Closeable {
           // Transmission complete
           resetState();
           byte[] response = stream.toByteArray();
-          logger
-              .atTrace()
-              .setMessage("{} bytes read over HID: {}")
-              .addArgument(response.length)
-              .addArgument(() -> StringUtils.bytesToHex(response))
-              .log();
+          if (logger.isTraceEnabled()) {
+            logger.trace(
+                "{} bytes read over HID: {}", response.length, StringUtils.bytesToHex(response));
+          }
           return response;
         }
       } else if (statusByte == 0) { // Status response
@@ -247,11 +241,10 @@ public class OtpProtocol implements Closeable {
           // Note that when deleting the "last" slot so no slots are valid, the programming sequence
           // is set to 0.
           byte[] status = Arrays.copyOfRange(report, 1, 7); // Skip first and last bytes
-          logger
-              .atTrace()
-              .setMessage("HID programming sequence updated. New status: {}")
-              .addArgument(() -> StringUtils.bytesToHex(status))
-              .log();
+          if (logger.isTraceEnabled()) {
+            logger.trace(
+                "HID programming sequence updated. New status: {}", StringUtils.bytesToHex(status));
+          }
           return status;
         } else if (needsTouch) {
           throw new TimeoutException("Timed out waiting for touch");

--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/scp/ScpState.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/scp/ScpState.java
@@ -79,11 +79,9 @@ public class ScpState {
 
   public byte[] encrypt(byte[] data) {
     // Pad the data
-    logger
-        .atTrace()
-        .setMessage("Plaintext data: {}")
-        .addArgument(() -> StringUtils.bytesToHex(data))
-        .log();
+    if (logger.isTraceEnabled()) {
+      logger.trace("Plaintext data: {}", StringUtils.bytesToHex(data));
+    }
     int padLen = 16 - (data.length % 16);
     byte[] padded = Arrays.copyOf(data, data.length + padLen);
     padded[data.length] = (byte) 0x80;
@@ -128,12 +126,9 @@ public class ScpState {
       decrypted = cipher.doFinal(encrypted);
       for (int i = decrypted.length - 1; i > 0; i--) {
         if (decrypted[i] == (byte) 0x80) {
-          final byte[] result = decrypted;
-          logger
-              .atTrace()
-              .setMessage("Plaintext resp: {}")
-              .addArgument(() -> StringUtils.bytesToHex(result))
-              .log();
+          if (logger.isTraceEnabled()) {
+            logger.trace("Plaintext resp: {}", StringUtils.bytesToHex(decrypted));
+          }
           return Arrays.copyOf(decrypted, i);
         } else if (decrypted[i] != 0x00) {
           break;

--- a/core/src/main/java/com/yubico/yubikit/core/smartcard/scp/SecurityDomainSession.java
+++ b/core/src/main/java/com/yubico/yubikit/core/smartcard/scp/SecurityDomainSession.java
@@ -277,12 +277,9 @@ public class SecurityDomainSession extends ApplicationSession<SecurityDomainSess
    * @param ski the Subject Key Identifier to store
    */
   public void storeCaIssuer(KeyRef keyRef, byte[] ski) throws ApduException, IOException {
-    logger
-        .atDebug()
-        .setMessage("Storing CA issuer SKI for {}: {}")
-        .addArgument(keyRef)
-        .addArgument(() -> StringUtils.bytesToHex(ski))
-        .log();
+    if (logger.isDebugEnabled()) {
+      logger.debug("Storing CA issuer SKI for {}: {}", keyRef, StringUtils.bytesToHex(ski));
+    }
     byte klcc = 0;
     switch (keyRef.getKid()) {
       case ScpKid.SCP11a:

--- a/desktop/src/main/java/com/yubico/yubikit/desktop/pcsc/PcscSmartCardConnection.java
+++ b/desktop/src/main/java/com/yubico/yubikit/desktop/pcsc/PcscSmartCardConnection.java
@@ -75,24 +75,18 @@ public class PcscSmartCardConnection implements SmartCardConnection {
   @Override
   public byte[] sendAndReceive(byte[] apdu) throws IOException {
     try {
-      final byte[] sentApdu = apdu;
-      logger
-          .atTrace()
-          .setMessage("{} bytes sent over PCSC: {}")
-          .addArgument(sentApdu.length)
-          .addArgument(() -> StringUtils.bytesToHex(sentApdu))
-          .log();
+      if (logger.isTraceEnabled()) {
+        logger.trace("{} bytes sent over PCSC: {}", apdu.length, StringUtils.bytesToHex(apdu));
+      }
       if (apdu.length < 5) {
         // CardChannel.transmit requires at least 5 bytes.
         apdu = Arrays.copyOf(apdu, 5);
       }
       byte[] response = cardChannel.transmit(new CommandAPDU(apdu)).getBytes();
-      logger
-          .atTrace()
-          .setMessage("{} bytes received over PCSC: {}")
-          .addArgument(response.length)
-          .addArgument(() -> StringUtils.bytesToHex(response))
-          .log();
+      if (logger.isTraceEnabled()) {
+        logger.trace(
+            "{} bytes received over PCSC: {}", response.length, StringUtils.bytesToHex(response));
+      }
       return response;
     } catch (CardException e) {
       throw new IOException(e);

--- a/fido/src/main/java/com/yubico/yubikit/fido/Cose.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/Cose.java
@@ -66,11 +66,9 @@ public class Cose {
         throw new IllegalArgumentException("Unsupported key type: " + kty);
     }
 
-    logger
-        .atDebug()
-        .setMessage("publicKey: {}")
-        .addArgument(() -> Base64.toUrlSafeString(publicKey.getEncoded()))
-        .log();
+    if (logger.isDebugEnabled()) {
+      logger.debug("publicKey: {}", Base64.toUrlSafeString(publicKey.getEncoded()));
+    }
 
     return publicKey;
   }
@@ -88,7 +86,9 @@ public class Cose {
   private static PublicKey importCoseEd25519PublicKey(Map<Integer, ?> cosePublicKey)
       throws InvalidKeySpecException, NoSuchAlgorithmException {
     final byte[] rawKey = (byte[]) Objects.requireNonNull(cosePublicKey.get(-2));
-    logger.atDebug().setMessage("raw: {}").addArgument(() -> Base64.toUrlSafeString(rawKey)).log();
+    if (logger.isDebugEnabled()) {
+      logger.debug("raw: {}", Base64.toUrlSafeString(rawKey));
+    }
     return new Cv25519(EllipticCurveValues.Ed25519, rawKey).toPublicKey();
   }
 
@@ -99,8 +99,10 @@ public class Cose {
     final byte[] y = (byte[]) Objects.requireNonNull(cosePublicKey.get(-3));
 
     logger.debug("crv: {}", crv);
-    logger.atDebug().setMessage("x: {}").addArgument(() -> Base64.toUrlSafeString(x)).log();
-    logger.atDebug().setMessage("y: {}").addArgument(() -> Base64.toUrlSafeString(y)).log();
+    if (logger.isDebugEnabled()) {
+      logger.debug("x: {}", Base64.toUrlSafeString(x));
+      logger.debug("y: {}", Base64.toUrlSafeString(y));
+    }
 
     EllipticCurveValues ellipticCurveValues;
 
@@ -128,8 +130,10 @@ public class Cose {
       throws NoSuchAlgorithmException, InvalidKeySpecException {
     byte[] n = (byte[]) Objects.requireNonNull(cosePublicKey.get(-1));
     byte[] e = (byte[]) Objects.requireNonNull(cosePublicKey.get(-2));
-    logger.atDebug().setMessage("n: {}").addArgument(() -> Base64.toUrlSafeString(n)).log();
-    logger.atDebug().setMessage("e: {}").addArgument(() -> Base64.toUrlSafeString(e)).log();
+    if (logger.isDebugEnabled()) {
+      logger.debug("n: {}", Base64.toUrlSafeString(n));
+      logger.debug("e: {}", Base64.toUrlSafeString(e));
+    }
     return new Rsa(new BigInteger(1, n), new BigInteger(1, e)).toPublicKey();
   }
 }

--- a/fido/src/main/java/com/yubico/yubikit/fido/ctap/FingerprintBioEnrollment.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/ctap/FingerprintBioEnrollment.java
@@ -443,12 +443,9 @@ public class FingerprintBioEnrollment extends BioEnrollment {
    *     FriendlyName</a>
    */
   public void setName(byte[] templateId, String name) throws IOException, CommandException {
-    logger
-        .atDebug()
-        .setMessage("Changing name of template: {} {}")
-        .addArgument(() -> Base64.toUrlSafeString(templateId))
-        .addArgument(name)
-        .log();
+    if (logger.isDebugEnabled()) {
+      logger.debug("Changing name of template: {} {}", Base64.toUrlSafeString(templateId), name);
+    }
 
     Map<Integer, Object> parameters = new HashMap<>();
     parameters.put(PARAM_TEMPLATE_ID, templateId);
@@ -469,11 +466,9 @@ public class FingerprintBioEnrollment extends BioEnrollment {
    *     enrollment</a>
    */
   public void removeEnrollment(byte[] templateId) throws IOException, CommandException {
-    logger
-        .atDebug()
-        .setMessage("Deleting template: {}")
-        .addArgument(() -> Base64.toUrlSafeString(templateId))
-        .log();
+    if (logger.isDebugEnabled()) {
+      logger.debug("Deleting template: {}", Base64.toUrlSafeString(templateId));
+    }
 
     Map<Integer, Object> parameters = new HashMap<>();
     parameters.put(PARAM_TEMPLATE_ID, templateId);

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/GuardedLoggingCallSitesTest.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/GuardedLoggingCallSitesTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2026 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.yubikit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import android.util.Log;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.yubico.yubikit.core.internal.codec.Base64;
+import com.yubico.yubikit.fido.Cose;
+import java.security.PublicKey;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Drives SDK production code whose logging was converted from the SLF4J 2.x fluent API to {@code
+ * isXEnabled()}-guarded plain calls, and asserts it survives on the device under test.
+ *
+ * <p>{@code LoggingSmokeTests} covers the call <em>shapes</em> in isolation against a logger it
+ * creates itself. This covers the real thing: {@link Cose} is reachable without a YubiKey and holds
+ * six converted call sites spanning all three key types - {@code publicKey} in {@code
+ * getPublicKey}, {@code raw} for Ed25519, {@code x}/{@code y} for EC2 and {@code n}/{@code e} for
+ * RSA.
+ *
+ * <p>Before the conversion every one of those was {@code logger.atDebug()}, which on an APK built
+ * at {@code minSdk < 24} throws {@code AbstractMethodError} on a modern device and takes the whole
+ * instrumentation process down with a native SIGSEGV on API 21. {@code testing-android} builds at
+ * {@code minSdk 21}, and its {@code logback.xml} sets the root level to TRACE, so the guards do not
+ * short-circuit - the converted bodies really execute and really format their arguments. Reaching
+ * the end of a test method is therefore the assertion that matters; a regression here does not fail
+ * the test, it kills the process.
+ */
+@RunWith(AndroidJUnit4.class)
+public class GuardedLoggingCallSitesTest {
+
+  private static final String TAG = "GuardedLoggingCallSites";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String ES256_X = "wYXQNcHYEQHhLWssYM3Wxh59Glcd27iQRAbH7g73zEc";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String ES256_Y = "8N523zR8MPQ3VGVV0Qm1hE1f0BEG9z4mQISHWpo6XXw";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String RS256_N =
+      "0KeO-wuDQK18v9WwN5hFe6G_1TM4Ra8alOFa8cyN9xfqaLK1TvYVQHZfOcVvgM5XztCEOPNcQ5AWMJmTOESwvjuHkj5"
+          + "ulGt2jCVJUWKxPX-KYq0UFlb5jr305D66p5vRKb7zBterpDJSOxwLKr7g9jVhgpM2mgVjrRnQPMUAfvt8q9QM"
+          + "UWy1eIgIxnABi9b28cZ6WBDi42LMYiHz8mfUWi_ga9TASAwTqYZmGFUr7Z71ZuPKxuOxsgTxUksqKEmJw8iWc"
+          + "CgTC6-O8sMe-aZ3gqcwDEk9kRKZQJKlxtyYuArn2zDKfaAHJ1A2wLwjtq8m_TsiOEdW3289Fe_F4gSA_w";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String RS256_E = "AAEAAQ";
+
+  @SuppressWarnings("SpellCheckingInspection")
+  private static final String EDDSA_RAW_KEY = "3wIKsJK63Ctb-nLkcwG8fJOp2vZxz8lmhv3BcFI-ves";
+
+  private static Map<Integer, Object> es256() {
+    Map<Integer, Object> key = new HashMap<>();
+    key.put(1, 2); // kty
+    key.put(3, -7); // alg
+    key.put(-1, 1); // crv
+    key.put(-2, Base64.fromUrlSafeString(ES256_X));
+    key.put(-3, Base64.fromUrlSafeString(ES256_Y));
+    return key;
+  }
+
+  private static Map<Integer, Object> rs256() {
+    Map<Integer, Object> key = new HashMap<>();
+    key.put(1, 3); // kty
+    key.put(3, -257); // alg
+    key.put(-1, Base64.fromUrlSafeString(RS256_N));
+    key.put(-2, Base64.fromUrlSafeString(RS256_E));
+    return key;
+  }
+
+  private static Map<Integer, Object> eddsa() {
+    Map<Integer, Object> key = new HashMap<>();
+    key.put(1, 1); // kty
+    key.put(3, -8); // alg
+    key.put(-1, 6); // crv
+    key.put(-2, Base64.fromUrlSafeString(EDDSA_RAW_KEY));
+    return key;
+  }
+
+  /** Exercises the {@code x}/{@code y} sites plus the shared {@code publicKey} site. */
+  @Test
+  public void ec2CallSites() throws Exception {
+    PublicKey publicKey = Cose.getPublicKey(es256());
+
+    assertNotNull("EC2 key did not decode", publicKey);
+    assertEquals("EC", publicKey.getAlgorithm());
+    Log.i(TAG, "EC2 call sites OK: " + publicKey.getAlgorithm());
+  }
+
+  /** Exercises the {@code n}/{@code e} sites plus the shared {@code publicKey} site. */
+  @Test
+  public void rsaCallSites() throws Exception {
+    PublicKey publicKey = Cose.getPublicKey(rs256());
+
+    assertNotNull("RSA key did not decode", publicKey);
+    assertEquals("RSA", publicKey.getAlgorithm());
+    Log.i(TAG, "RSA call sites OK: " + publicKey.getAlgorithm());
+  }
+
+  /**
+   * Exercises the Ed25519 {@code raw} site.
+   *
+   * <p>Android had no Ed25519 provider until API 33, so {@code toPublicKey()} is expected to throw
+   * on an old device. That is irrelevant here: the converted log statement runs before it, so
+   * catching the provider failure and returning normally still proves the call site is safe. What
+   * would fail is the process dying before the catch.
+   */
+  @Test
+  public void ed25519CallSite() {
+    try {
+      PublicKey publicKey = Cose.getPublicKey(eddsa());
+      Log.i(TAG, "Ed25519 call site OK, key decoded: " + publicKey);
+    } catch (Exception e) {
+      Log.i(TAG, "Ed25519 call site OK, no provider on this device: " + e);
+    }
+  }
+
+  /** The plain, never-converted call in {@code getAlgorithm}, as a control. */
+  @Test
+  public void plainCallSiteControl() {
+    assertEquals(Integer.valueOf(-7), Cose.getAlgorithm(es256()));
+    assertEquals(Integer.valueOf(-257), Cose.getAlgorithm(rs256()));
+    Log.i(TAG, "plain control OK");
+  }
+}

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/KeylessDeviceTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/KeylessDeviceTests.java
@@ -31,5 +31,9 @@ import org.junit.runners.Suite;
  * reports zero tests and still passes, which is the silent success this harness exists to avoid.
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses({ThemeInflationTests.class})
+@Suite.SuiteClasses({
+  ThemeInflationTests.class,
+  LoggingSmokeTests.class,
+  GuardedLoggingCallSitesTest.class
+})
 public class KeylessDeviceTests {}

--- a/testing-android/src/androidTest/java/com/yubico/yubikit/LoggingSmokeTests.java
+++ b/testing-android/src/androidTest/java/com/yubico/yubikit/LoggingSmokeTests.java
@@ -39,6 +39,10 @@ import org.slf4j.spi.LoggingEventBuilder;
  *
  * <p><b>The fluent tests are opt-in and will kill the test process on API &lt; 24.</b> See {@link
  * #requireFluentApiOptIn()}.
+ *
+ * <p>SLF4J-FLUENT-ALLOWED - exempt from the checkNoFluentSlf4j build check. Calling the fluent API
+ * is the point of this file: it demonstrates that the calls still crash. Production code gets the
+ * isXEnabled() guard instead, never this marker.
  */
 @RunWith(AndroidJUnit4.class)
 public class LoggingSmokeTests {


### PR DESCRIPTION
`logger.atDebug()` and friends are interface default methods that logback-android does not implement. Wherever the consuming app declares `minSdk < 24`, D8 leaves the call site unresolvable: `AbstractMethodError` on a modern device, native `SIGSEGV` on API 21 that kills the process. The device's own API level is irrelevant — only the consumer's `minSdk` matters.

Converts all 25 call sites to `isXEnabled()`-guarded plain calls (core 11, fido 8, android 4, desktop 2). The guard uses no default methods and also defers eagerly evaluated arguments, which `addArgument(Supplier)` cannot.

Adds a `checkNoFluentSlf4j` task wired into `check` from the same convention plugin that puts `slf4j-api` on the `api` configuration, so new call sites cannot creep back. A file may opt out with an `SLF4J-FLUENT-ALLOWED` marker — used only by `LoggingSmokeTests`, whose purpose is to demonstrate the crash.

Verified on a Nexus 4 (API 21): `KeylessDeviceTests` reports 13 tests, 0 failures. The same APK still SIGSEGVs (fault addr `0x78`) when the opt-in fluent cases are enabled. API 22 and 23 emulators fail identically, so the whole 21–23 range is affected.