### PR TITLE
refactor(fido-android-ui): reuse isFormValid in the PIN submit guard

### DIFF
--- a/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/ui/screens/CreateChangePinScreen.kt
+++ b/fido-android-ui/src/main/kotlin/com/yubico/yubikit/fido/android/ui/internal/ui/screens/CreateChangePinScreen.kt
@@ -159,10 +159,19 @@ private fun CreateChangePinScreen(
             else -> stringResource(R.string.yk_fido_creating_pin_failed)
         }
 
+    val isFormValid by remember(forceChangePin, minPinLen) {
+        derivedStateOf {
+            val hasCurrentPin = !forceChangePin || currentPinState.text.isNotEmpty()
+            val newPin = newPinState.text.toString()
+            val repeatPin = repeatPinState.text.toString()
+            hasCurrentPin && isPinValid(newPin, repeatPin, minPinLen)
+        }
+    }
+
+    // Guarded by the same condition that enables the submit buttons, so that the keyboard
+    // Done action cannot trigger an action the buttons would have refused.
     val submit: () -> Unit = {
-        if ((!forceChangePin || currentPinState.text.isNotEmpty()) &&
-            isPinValid(newPinState.text.toString(), repeatPinState.text.toString(), minPinLen)
-        ) {
+        if (isFormValid) {
             onPinAction(
                 newPinState.text.toString().toCharArray(),
                 currentPinState.text.toString().toCharArray(),
@@ -174,15 +183,6 @@ private fun CreateChangePinScreen(
     // Ensures the submit button scrolls into view when the confirm-PIN field is focused,
     // so it is not hidden behind the software keyboard.
     val buttonRequester = remember { BringIntoViewRequester() }
-
-    val isFormValid by remember(forceChangePin, minPinLen) {
-        derivedStateOf {
-            val hasCurrentPin = !forceChangePin || currentPinState.text.isNotEmpty()
-            val newPin = newPinState.text.toString()
-            val repeatPin = repeatPinState.text.toString()
-            hasCurrentPin && isPinValid(newPin, repeatPin, minPinLen)
-        }
-    }
 
     LaunchedEffect(Unit) {
         if (forceChangePin && currentPin == null) {

--- a/fido-android-ui/src/test/kotlin/com/yubico/yubikit/fido/android/ui/screens/CreateChangePinScreenTest.kt
+++ b/fido-android-ui/src/test/kotlin/com/yubico/yubikit/fido/android/ui/screens/CreateChangePinScreenTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import com.yubico.yubikit.fido.android.ui.internal.FidoClientService
 import com.yubico.yubikit.fido.android.ui.internal.ui.Error
@@ -29,6 +30,7 @@ import com.yubico.yubikit.fido.android.ui.internal.ui.screens.DEFAULT_MIN_PIN_LE
 import com.yubico.yubikit.fido.android.ui.internal.ui.screens.ForceChangePinScreen
 import com.yubico.yubikit.fido.android.ui.internal.ui.theme.FidoAndroidTheme
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -122,6 +124,42 @@ class CreatePinScreenTest {
         composeTestRule
             .onNodeWithTag("create_pin_button")
             .performClick()
+
+        assertEquals("123456", createdPin)
+    }
+
+    @Test
+    fun `keyboard action does not submit when PINs do not match`() {
+        var invoked = false
+        setCreatePinContent(onCreatePin = { invoked = true })
+
+        composeTestRule
+            .onNodeWithTag("new_pin_input")
+            .performTextInput("123456")
+        composeTestRule
+            .onNodeWithTag("repeat_pin_input")
+            .performTextInput("654321")
+        composeTestRule
+            .onNodeWithTag("repeat_pin_input")
+            .performImeAction()
+
+        assertFalse(invoked)
+    }
+
+    @Test
+    fun `keyboard action submits when PINs are valid`() {
+        var createdPin = ""
+        setCreatePinContent(onCreatePin = { createdPin = String(it) })
+
+        composeTestRule
+            .onNodeWithTag("new_pin_input")
+            .performTextInput("123456")
+        composeTestRule
+            .onNodeWithTag("repeat_pin_input")
+            .performTextInput("123456")
+        composeTestRule
+            .onNodeWithTag("repeat_pin_input")
+            .performImeAction()
 
         assertEquals("123456", createdPin)
     }
@@ -278,5 +316,20 @@ class ForceChangePinScreenTest {
 
         assertEquals("current", capturedCurrentPin)
         assertEquals("123456", capturedNewPin)
+    }
+
+    @Test
+    fun `keyboard action does not submit when current PIN is empty`() {
+        var invoked = false
+        setForceChangePinContent(onChangePin = { _, _ -> invoked = true })
+
+        composeTestRule.onNodeWithTag("new_pin_input")
+            .performTextInput("123456")
+        composeTestRule.onNodeWithTag("repeat_pin_input")
+            .performTextInput("123456")
+        composeTestRule.onNodeWithTag("repeat_pin_input")
+            .performImeAction()
+
+        assertFalse(invoked)
     }
 }


### PR DESCRIPTION
## What

The `submit` lambda in `CreateChangePinScreen` recomputed `(!forceChangePin || currentPin.isNotEmpty()) && isPinValid(...)` — the exact predicate already held by the `isFormValid` `derivedStateOf` declared a few lines below it. This moves the derived state above `submit` and has `submit` read it, so the four `enabled =` call sites and the keyboard Done handler all share one source.

## Why

The two copies were identical, so there is no behavioural change today. The point is that they could drift: `enabled` gates the buttons while the confirm-PIN field's `ImeAction.Done` routes straight to `submit`, so a change to one predicate and not the other reintroduces an enabled-vs-action mismatch where the keyboard can trigger what the buttons refuse.

## Tests

The IME path had no coverage. Three tests added: Done with mismatched new PINs, Done with a valid form, and Done with an empty current PIN in the force-change layout. Stubbing the guard to `if (true)` fails the two negative tests, so they exercise the real condition rather than asserting on themselves.

## Verification

`./gradlew spotlessCheck test` clean repo-wide; `:fido-android-ui:check` clean, including main's new `checkNoFluentSlf4j` gate.

Also verified on a Pixel 8 with a real key configured via `ykman fido access force-change`. The force-change screen is reached before any PIN prompt, so Current PIN starts empty — the exact state the guard covers. The logcat state trace shows one transition out of `ForcePinChangeError` across three submit attempts, and it is the one that reached `PinChanged`; the empty-current-PIN and mismatched-PIN attempts produced no state change.