### PR TITLE
fix: bound TLV and CBOR parsing before allocating

### DIFF
--- a/core/src/main/java/com/yubico/yubikit/core/util/Tlv.java
+++ b/core/src/main/java/com/yubico/yubikit/core/util/Tlv.java
@@ -18,6 +18,7 @@ package com.yubico.yubikit.core.util;
 
 import java.io.ByteArrayOutputStream;
 import java.math.BigInteger;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Locale;
@@ -29,6 +30,12 @@ import org.jspecify.annotations.Nullable;
  * <p>This class handles BER-TLV encoded data with determinate length.
  */
 public class Tlv {
+  /** Maximum number of bytes in a tag, bounded by the int the tag is decoded into. */
+  private static final int MAX_TAG_BYTES = 4;
+
+  /** Maximum number of bytes in a long form length, bounded by the int it is decoded into. */
+  private static final int MAX_LENGTH_BYTES = 4;
+
   private final int tag;
   private final int length;
   private final byte[] bytes;
@@ -117,8 +124,15 @@ public class Tlv {
     int tag = buffer.get() & 0xFF;
     if ((tag & 0x1F) == 0x1F) { // Long form tag
       tag = (tag << 8) | (buffer.get() & 0xFF);
+      int tagBytes = 2;
       while ((tag & 0x80) == 0x80) {
+        // Without this the shift below silently overflows the int and misparses the tag.
+        if (tagBytes == MAX_TAG_BYTES) {
+          throw new IllegalArgumentException(
+              String.format(Locale.ROOT, "Tag exceeds %d bytes", MAX_TAG_BYTES));
+        }
         tag = (tag << 8) | (buffer.get() & 0xFF);
+        tagBytes++;
       }
     }
 
@@ -127,10 +141,26 @@ public class Tlv {
       throw new IllegalArgumentException("Indefinite length not supported");
     } else if (length > 0x80) {
       int lengthLn = length - 0x80;
+      // A long form length may declare up to 127 bytes; anything past 4 overflows the int below,
+      // which would silently wrap to a plausible looking (and wrong) length.
+      if (lengthLn > MAX_LENGTH_BYTES) {
+        throw new IllegalArgumentException(
+            String.format(Locale.ROOT, "Length exceeds %d bytes", MAX_LENGTH_BYTES));
+      }
       length = 0;
       for (int i = 0; i < lengthLn; i++) {
         length = (length << 8) | (buffer.get() & 0xff);
       }
+      if (length < 0) {
+        throw new IllegalArgumentException("Length exceeds Integer.MAX_VALUE");
+      }
+    }
+
+    // Check the declared length against what is actually available before allocating. Allocating
+    // first lets a malformed length of e.g. 0x7FFFFFFF raise an OutOfMemoryError, which is an
+    // Error rather than the BufferUnderflowException callers expect from a truncated response.
+    if (length > buffer.remaining()) {
+      throw new BufferUnderflowException();
     }
 
     byte[] value = new byte[length];

--- a/core/src/test/java/com/yubico/yubikit/core/util/TlvsTest.java
+++ b/core/src/test/java/com/yubico/yubikit/core/util/TlvsTest.java
@@ -16,6 +16,7 @@
 package com.yubico.yubikit.core.util;
 
 import com.yubico.yubikit.core.application.BadResponseException;
+import java.nio.BufferUnderflowException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -49,5 +50,64 @@ public class TlvsTest {
 
     byte[] value = Tlvs.unpackValue(0x7F49, new byte[] {0x7F, 0x49, 3, 1, 2, 3});
     Assert.assertArrayEquals(new byte[] {1, 2, 3}, value);
+  }
+
+  /**
+   * A declared length larger than the data actually present must report a truncated response rather
+   * than allocating first. Allocating first raises an OutOfMemoryError, which is an {@link Error}
+   * and so escapes callers that recover from BufferUnderflowException.
+   */
+  @Test(expected = BufferUnderflowException.class)
+  public void testOversizedLengthDoesNotAllocate() {
+    // Long form length of 0x7FFFFFFF in a six byte buffer.
+    Tlv.parse(new byte[] {0x01, (byte) 0x84, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+  }
+
+  @Test(expected = BufferUnderflowException.class)
+  public void testShortFormLengthPastEndOfBuffer() {
+    Tlv.parse(new byte[] {0x01, 0x10, 0x00});
+  }
+
+  /**
+   * Five length bytes overflow the int the length is accumulated into. Before this was rejected the
+   * value below wrapped to zero and parsed as an empty, valid looking Tlv.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testLengthWithTooManyBytes() {
+    Tlv.parse(new byte[] {0x01, (byte) 0x85, 0x01, 0x00, 0x00, 0x00, 0x00});
+  }
+
+  /** A length above Integer.MAX_VALUE previously reached {@code new byte[-1]}. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testLengthAboveIntegerMaxValue() {
+    Tlv.parse(new byte[] {0x01, (byte) 0x84, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF});
+  }
+
+  /** A long form tag whose continuation bit never clears would silently overflow the tag int. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testUnterminatedLongFormTag() {
+    Tlv.parse(new byte[] {0x1F, (byte) 0x81, (byte) 0x81, (byte) 0x81, (byte) 0x81, 0x00});
+  }
+
+  /** Four byte tags are still in range, so the bound cannot break real responses. */
+  @Test
+  public void testMaxLengthTagIsAccepted() {
+    Tlv tlv = Tlv.parse(new byte[] {0x1F, (byte) 0x81, (byte) 0x81, 0x01, 0x00});
+    Assert.assertEquals(0x1F818101, tlv.getTag());
+    Assert.assertEquals(0, tlv.getLength());
+  }
+
+  /** Four length bytes are the widest a valid length can be, and must still parse. */
+  @Test
+  public void testFourByteLengthIsAccepted() {
+    Tlv tlv = Tlv.parse(new byte[] {0x01, (byte) 0x84, 0x00, 0x00, 0x00, 0x03, 1, 2, 3});
+    Assert.assertEquals(3, tlv.getLength());
+    Assert.assertArrayEquals(new byte[] {1, 2, 3}, tlv.getValue());
+  }
+
+  /** Truncation partway through a sequence must not yield a silently short list. */
+  @Test(expected = BufferUnderflowException.class)
+  public void testTruncatedListEntry() {
+    Tlvs.decodeList(new byte[] {0x01, 0x01, (byte) 0xAA, 0x02, 0x04, 0x01, 0x02});
   }
 }

--- a/fido/src/main/java/com/yubico/yubikit/fido/Cbor.java
+++ b/fido/src/main/java/com/yubico/yubikit/fido/Cbor.java
@@ -19,6 +19,7 @@ package com.yubico.yubikit.fido;
 import com.yubico.yubikit.core.util.ZeroingByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -39,6 +40,12 @@ import org.jspecify.annotations.Nullable;
  * when encoding to send to a device, but any response will have ints for keys.
  */
 public class Cbor {
+  /**
+   * Maximum nesting depth of a decoded structure. CTAP2 structures nest only a few levels deep;
+   * this bound keeps a run of nested list or map headers from recursing into a StackOverflowError.
+   */
+  private static final int MAX_DEPTH = 32;
+
   /**
    * Encodes an object into canonical CBOR.
    *
@@ -115,8 +122,18 @@ public class Cbor {
    *
    * @param buf the ByteBuffer from where the Object should be decoded.
    * @return The decoded object.
+   * @throws IllegalArgumentException if the data is malformed, or nests deeper than {@link
+   *     #MAX_DEPTH}.
    */
   public static @Nullable Object decodeFrom(ByteBuffer buf) {
+    return decodeFrom(buf, 0);
+  }
+
+  private static @Nullable Object decodeFrom(ByteBuffer buf, int depth) {
+    if (depth > MAX_DEPTH) {
+      throw new IllegalArgumentException(
+          String.format(Locale.ROOT, "Nesting depth exceeds %d", MAX_DEPTH));
+    }
     int head = 0xff & buf.get();
     byte additionalInfo = (byte) (head & 0b11111);
     switch (head >> 5) {
@@ -129,9 +146,9 @@ public class Cbor {
       case 3:
         return loadString(additionalInfo, buf);
       case 4:
-        return loadList(additionalInfo, buf);
+        return loadList(additionalInfo, buf, depth);
       case 5:
-        return loadMap(additionalInfo, buf);
+        return loadMap(additionalInfo, buf, depth);
       case 7:
         return loadSimple(additionalInfo);
     }
@@ -253,7 +270,14 @@ public class Cbor {
   }
 
   private static byte[] loadBytes(byte additionalInfo, ByteBuffer buf) {
-    byte[] value = new byte[(int) loadInt(additionalInfo, buf)];
+    int length = loadInt(additionalInfo, buf);
+    // Check the declared length against what is actually available before allocating. Allocating
+    // first lets a length of e.g. 0x7FFFFFFF raise an OutOfMemoryError, which is an Error rather
+    // than the BufferUnderflowException callers expect from a truncated response.
+    if (length > buf.remaining()) {
+      throw new BufferUnderflowException();
+    }
+    byte[] value = new byte[length];
     buf.get(value);
     return value;
   }
@@ -262,18 +286,30 @@ public class Cbor {
     return new String(loadBytes(additionalInfo, buf), StandardCharsets.UTF_8);
   }
 
-  private static List<?> loadList(byte additionalInfo, ByteBuffer buf) {
+  /**
+   * Rejects an item count that the remaining bytes cannot possibly satisfy, since every item costs
+   * at least one byte. Without this the count is only bounded once decoding runs off the buffer.
+   */
+  private static int loadCount(byte additionalInfo, ByteBuffer buf) {
+    int count = loadInt(additionalInfo, buf);
+    if (count > buf.remaining()) {
+      throw new BufferUnderflowException();
+    }
+    return count;
+  }
+
+  private static List<?> loadList(byte additionalInfo, ByteBuffer buf, int depth) {
     List<@Nullable Object> list = new ArrayList<>();
-    for (int i = loadInt(additionalInfo, buf); i > 0; i--) {
-      list.add(decodeFrom(buf));
+    for (int i = loadCount(additionalInfo, buf); i > 0; i--) {
+      list.add(decodeFrom(buf, depth + 1));
     }
     return list;
   }
 
-  private static Map<?, ?> loadMap(byte additionalInfo, ByteBuffer buf) {
+  private static Map<?, ?> loadMap(byte additionalInfo, ByteBuffer buf, int depth) {
     Map<@Nullable Object, @Nullable Object> map = new HashMap<>();
-    for (int i = loadInt(additionalInfo, buf); i > 0; i--) {
-      map.put(decodeFrom(buf), decodeFrom(buf));
+    for (int i = loadCount(additionalInfo, buf); i > 0; i--) {
+      map.put(decodeFrom(buf, depth + 1), decodeFrom(buf, depth + 1));
     }
     return map;
   }

--- a/fido/src/test/java/com/yubico/yubikit/fido/CborTest.java
+++ b/fido/src/test/java/com/yubico/yubikit/fido/CborTest.java
@@ -19,6 +19,7 @@ package com.yubico.yubikit.fido;
 import static com.yubico.yubikit.fido.TestUtils.decodeHex;
 import static com.yubico.yubikit.fido.TestUtils.encodeHex;
 
+import java.nio.BufferUnderflowException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -231,6 +232,67 @@ public class CborTest {
     @Test(expected = IllegalArgumentException.class)
     public void testDecodeIntOutOfRange() {
       Cbor.decode(decodeHex("1a80000000"));
+    }
+  }
+
+  /**
+   * A malfunctioning or hostile authenticator can declare sizes far larger than the response it
+   * actually sent. Decoding must fail with an exception rather than an {@link Error}, which would
+   * escape the {@code catch (RuntimeException)} handlers callers use.
+   */
+  public static class MalformedInputTest {
+    /** Byte string declaring 0x7FFFFFFF bytes, in a 5 byte response. */
+    @Test(expected = BufferUnderflowException.class)
+    public void testOversizedByteString() {
+      Cbor.decode(decodeHex("5a7fffffff"));
+    }
+
+    /** Text string declaring 0x7FFFFFFF bytes, in a 5 byte response. */
+    @Test(expected = BufferUnderflowException.class)
+    public void testOversizedTextString() {
+      Cbor.decode(decodeHex("7a7fffffff"));
+    }
+
+    /** Byte string declaring one more byte than was sent. */
+    @Test(expected = BufferUnderflowException.class)
+    public void testTruncatedByteString() {
+      Cbor.decode(decodeHex("430102"));
+    }
+
+    /** Array declaring 0x7FFFFFFF elements, with none present. */
+    @Test(expected = BufferUnderflowException.class)
+    public void testOversizedListCount() {
+      Cbor.decode(decodeHex("9a7fffffff"));
+    }
+
+    /** Map declaring 0x7FFFFFFF entries, with none present. */
+    @Test(expected = BufferUnderflowException.class)
+    public void testOversizedMapCount() {
+      Cbor.decode(decodeHex("ba7fffffff"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExcessiveNestingIsRejected() {
+      Cbor.decode(nestedLists(33));
+    }
+
+    /** Nesting up to the limit must still decode, so the bound cannot break real responses. */
+    @Test
+    public void testNestingAtLimitIsAccepted() {
+      Object decoded = Cbor.decode(nestedLists(32));
+      for (int i = 0; i < 32; i++) {
+        Assert.assertTrue("Expected a list at depth " + i, decoded instanceof List);
+        decoded = ((List<?>) decoded).get(0);
+      }
+      Assert.assertEquals(0, decoded);
+    }
+
+    /** {@code depth} nested single element arrays wrapping the integer 0. */
+    private static byte[] nestedLists(int depth) {
+      byte[] data = new byte[depth + 1];
+      Arrays.fill(data, (byte) 0x81);
+      data[depth] = 0x00;
+      return data;
     }
   }
 


### PR DESCRIPTION
Both parsers allocated from an input-declared length before checking it against the bytes actually available, and CBOR recursed with no depth bound. A 6-byte TLV declaring length `0x7FFFFFFF` raised `OutOfMemoryError`, a 5-byte long-form length silently wrapped to 0 and parsed as a valid-looking empty `Tlv`, and nested CBOR arrays reached `StackOverflowError`.

Sizes are now checked against `remaining()` before allocating, long-form tag and length are capped at 4 bytes, and CBOR nesting is bounded at 32.

Source and binary compatible: `javap` shows the public surface of `Tlv` and `Cbor` unchanged, and valid input decodes byte-identically. Only malformed input changes, from `Error`s that escaped the SDK's `catch (RuntimeException)` handlers to `IllegalArgumentException` or `BufferUnderflowException`. `BufferUnderflowException` is deliberately kept for "declared length exceeds available" because `OpenPgpSession` catches that type as a firmware workaround.

## Testing

14 unit tests covering oversized, truncated, overflowing and deeply nested input, plus lower-edge tests pinning depth 32 and 4-byte tags/lengths as accepted so the bounds cannot be tightened silently.

Smoke suite on a Pixel 8 (API 36) over USB (25 pass / 4 skip / 0 fail) and NFC (20 / 9 / 0), covering PIV, OATH, OpenPGP, SCP03, SCP11b, CTAP1/CTAP2 across both PIN protocols, credential management and YubiOTP. `KeylessDeviceTests` also green on a Nexus 4 (API 21), Pixel 6 and Pixel 8.